### PR TITLE
Add `currentRefinement` doc to `connectToggle`

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectToggle.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.js
@@ -51,6 +51,7 @@ function cleanUp(props, searchState, context) {
  * @propType {boolean} [defaultChecked=false] - Default searchState of the widget. Should the toggle be checked by default?
  * @providedPropType {function} refine - a function to toggle a refinement
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
+ * @providedPropType {boolean} currentRefinement - the refinement currently applied
  */
 export default createConnector({
   displayName: 'AlgoliaToggle',


### PR DESCRIPTION
**Summary**

I noticed that `connectToggle` provides `currentRefinement` to the wrapped component, but this is not present in the documentation. This PR adds documentation for this prop.