### PR TITLE
fix(InstantSearch): dont fire request/onsearchStateChange when unmounting

### DIFF
--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -50,8 +50,8 @@ class InstantSearch extends Component {
     super(props);
 
     this.isControlled = Boolean(props.searchState);
-
     const initialState = this.isControlled ? props.searchState : {};
+    this.isUnmounting = false;
 
     this.aisManager = createInstantSearchManager({
       indexName: props.indexName,
@@ -59,6 +59,8 @@ class InstantSearch extends Component {
       algoliaClient: props.algoliaClient,
       initialState,
     });
+
+    this.isUnmounting = false;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -71,6 +73,10 @@ class InstantSearch extends Component {
     if (this.isControlled) {
       this.aisManager.onExternalStateUpdate(nextProps.searchState);
     }
+  }
+
+  componentWillUnmount() {
+    this.isUnmounting = true;
   }
 
   getChildContext() {
@@ -105,12 +111,14 @@ class InstantSearch extends Component {
   }
 
   onWidgetsInternalStateUpdate(searchState) {
-    searchState = this.aisManager.transitionState(searchState);
+    if (!this.isUnmounting) {
+      searchState = this.aisManager.transitionState(searchState);
 
-    this.onSearchStateChange(searchState);
+      this.onSearchStateChange(searchState);
 
-    if (!this.isControlled) {
-      this.aisManager.onExternalStateUpdate(searchState);
+      if (!this.isControlled) {
+        this.aisManager.onExternalStateUpdate(searchState);
+      }
     }
   }
 

--- a/packages/react-instantsearch/src/core/InstantSearch.test.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.test.js
@@ -206,6 +206,33 @@ describe('InstantSearch', () => {
     expect(context.ais.widgetsManager).toBe(ism.widgetsManager);
   });
 
+  it('onSearchStateChange and update should not be called if the widget is unmounting', () => {
+    const ism = {
+      transitionState: jest.fn(),
+      onExternalStateUpdate: jest.fn(),
+    };
+    createInstantSearchManager.mockImplementation(() => ism);
+    const onSearchStateChange = jest.fn();
+    const wrapper = mount(
+      <InstantSearch
+        {...DEFAULT_PROPS}
+        onSearchStateChange={onSearchStateChange}
+      >
+        <div />
+      </InstantSearch>
+    );
+    const {
+      ais: { onInternalStateUpdate },
+    } = wrapper.instance().getChildContext();
+
+    wrapper.unmount();
+    onInternalStateUpdate({});
+
+    expect(ism.onExternalStateUpdate.mock.calls.length).toBe(0);
+    expect(ism.onExternalStateUpdate.mock.calls.length).toBe(0);
+    expect(ism.onExternalStateUpdate.mock.calls.length).toBe(0);
+  });
+
   describe('createHrefForState', () => {
     it('passes through to createURL when it is defined', () => {
       const widgetsIds = [];


### PR DESCRIPTION
See algolia/instantsearch.js#2061

Also fix issue with SPA => you want to move to another URL, but because of the unmount, onSearchStateChange is called and then you go back.