### PR TITLE
fix(InstantSearch): dont fire request/onsearchStateChange when unmounting

### DIFF
--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -50,8 +50,8 @@ class InstantSearch extends Component {
     super(props);
 
     this.isControlled = Boolean(props.searchState);
-
     const initialState = this.isControlled ? props.searchState : {};
+    this.isUnmounting = false;
 
     this.aisManager = createInstantSearchManager({
       indexName: props.indexName,
@@ -71,6 +71,11 @@ class InstantSearch extends Component {
     if (this.isControlled) {
       this.aisManager.onExternalStateUpdate(nextProps.searchState);
     }
+  }
+
+  componentWillUnmount() {
+    this.isUnmounting = true;
+    this.aisManager.skipSearch();
   }
 
   getChildContext() {
@@ -115,7 +120,7 @@ class InstantSearch extends Component {
   }
 
   onSearchStateChange(searchState) {
-    if (this.props.onSearchStateChange) {
+    if (this.props.onSearchStateChange && !this.isUnmounting) {
       this.props.onSearchStateChange(searchState);
     }
   }

--- a/packages/react-instantsearch/src/core/InstantSearch.test.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.test.js
@@ -206,6 +206,31 @@ describe('InstantSearch', () => {
     expect(context.ais.widgetsManager).toBe(ism.widgetsManager);
   });
 
+  it('onSearchStateChange should not be called and search should be skipped if the widget is unmounting', () => {
+    const ism = {
+      skipSearch: jest.fn(),
+    };
+    createInstantSearchManager.mockImplementation(() => ism);
+    const onSearchStateChangeMock = jest.fn();
+    const wrapper = mount(
+      <InstantSearch
+        {...DEFAULT_PROPS}
+        onSearchStateChange={onSearchStateChangeMock}
+      >
+        <div />
+      </InstantSearch>
+    );
+    const {
+      ais: { onSearchStateChange },
+    } = wrapper.instance().getChildContext();
+
+    wrapper.unmount();
+    onSearchStateChange({});
+
+    expect(onSearchStateChangeMock.mock.calls.length).toBe(0);
+    expect(ism.skipSearch.mock.calls.length).toBe(1);
+  });
+
   describe('createHrefForState', () => {
     it('passes through to createURL when it is defined', () => {
       const widgetsIds = [];

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -111,6 +111,7 @@ export default function createConnector(connectorDesc) {
           if (isWidget) {
             // Since props might have changed, we need to re-run getSearchParameters
             // and getMetadata with the new props.
+
             this.context.ais.widgetsManager.update();
             if (connectorDesc.transitionState) {
               this.context.ais.onSearchStateChange(
@@ -129,7 +130,7 @@ export default function createConnector(connectorDesc) {
       componentWillUnmount() {
         this.unsubscribe();
         if (isWidget) {
-          this.unregisterWidget();
+          this.unregisterWidget(); //will schedule an update
           if (hasCleanUp) {
             const newState = connectorDesc.cleanUp.call(
               this,
@@ -140,8 +141,7 @@ export default function createConnector(connectorDesc) {
               ...this.context.ais.store.getState(),
               widgets: newState,
             });
-
-            this.context.ais.onInternalStateUpdate(removeEmptyKey(newState));
+            this.context.ais.onSearchStateChange(removeEmptyKey(newState));
           }
         }
       }

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -479,7 +479,7 @@ describe('createConnector', () => {
       })(() => null);
       const unregister = jest.fn();
       const setState = jest.fn();
-      const onInternalStateUpdate = jest.fn();
+      const onSearchStateChange = jest.fn();
       it('unregisters itself on unmount', () => {
         const wrapper = mount(<Connected />, {
           context: {
@@ -492,23 +492,23 @@ describe('createConnector', () => {
               widgetsManager: {
                 registerWidget: () => unregister,
               },
-              onInternalStateUpdate,
+              onSearchStateChange,
             },
           },
         });
         expect(unregister.mock.calls.length).toBe(0);
         expect(setState.mock.calls.length).toBe(0);
-        expect(onInternalStateUpdate.mock.calls.length).toBe(0);
+        expect(onSearchStateChange.mock.calls.length).toBe(0);
 
         wrapper.unmount();
 
         expect(unregister.mock.calls.length).toBe(1);
         expect(setState.mock.calls.length).toBe(1);
-        expect(onInternalStateUpdate.mock.calls.length).toBe(1);
+        expect(onSearchStateChange.mock.calls.length).toBe(1);
         expect(setState.mock.calls[0][0]).toEqual({
           widgets: { another: { state: 'state' } },
         });
-        expect(onInternalStateUpdate.mock.calls[0][0]).toEqual({
+        expect(onSearchStateChange.mock.calls[0][0]).toEqual({
           another: { state: 'state' },
         });
       });
@@ -524,13 +524,13 @@ describe('createConnector', () => {
               widgetsManager: {
                 registerWidget: () => unregister,
               },
-              onInternalStateUpdate,
+              onSearchStateChange,
             },
           },
         });
         wrapper.unmount();
 
-        expect(onInternalStateUpdate.mock.calls[0][0]).toEqual({
+        expect(onSearchStateChange.mock.calls[0][0]).toEqual({
           another: { state: 'state' },
         });
       });

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
@@ -175,6 +175,27 @@ describe('createInstantSearchManager', () => {
         expect(client1.search).toHaveBeenCalledTimes(1);
       });
     });
+    it('should not be called when the search is skipped', () => {
+      const client0 = makeClient(defaultResponse);
+      expect(client0.search).toHaveBeenCalledTimes(0);
+      const ism = createInstantSearchManager({
+        indexName: 'index',
+        initialState: {},
+        searchParameters: {},
+        algoliaClient: client0,
+      });
+
+      ism.skipSearch();
+
+      ism.widgetsManager.registerWidget({
+        getMetadata: () => {},
+        transitionState: () => {},
+      });
+
+      return Promise.resolve().then(() => {
+        expect(client0.search).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
See algolia/instantsearch.js#2061

Also fix issue with SPA => you want to move to another URL, but because of the unmount, onSearchStateChange is called and then you go back.