### PR TITLE
chore: remove jest notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "node": "^6.x.x || ^7.x.x"
   },
   "jest": {
-    "notify": true
+    "notify": false
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
See: facebook/jest#3177

On OSX and watch mode, if a test is failing, the terminal-notifier process stays open.