### PR TITLE
chore(Stories): put linkedStoryGroup and hasPlayground consistenly

### DIFF
--- a/stories/3rdPartyIntegrations.stories.js
+++ b/stories/3rdPartyIntegrations.stories.js
@@ -7,7 +7,7 @@ import Rheostat from 'rheostat';
 const stories = storiesOf('Integration With Other Libraries', module);
 
 stories.add('Airbnb Rheostat', () => (
-  <WrapWithHits>
+  <WrapWithHits linkedStoryGroup="3rdPartyIntegrations">
     <ConnectedRange attributeName="price" />
   </WrapWithHits>
 ));

--- a/stories/ClearAll.stories.js
+++ b/stories/ClearAll.stories.js
@@ -8,32 +8,31 @@ const stories = storiesOf('ClearAll', module);
 
 stories.addDecorator(withKnobs);
 
-stories.add('with refinements to clear', () => (
-  <WrapWithHits linkedStoryGroup="ClearAll">
-    <div>
-      <ClearAll />
-      <div style={{ display: 'none' }}>
-        <RefinementList
-          attributeName="category"
-          defaultRefinement={['Dining']}
-        />
+stories
+  .add('with refinements to clear', () => (
+    <WrapWithHits linkedStoryGroup="ClearAll">
+      <div>
+        <ClearAll />
+        <div style={{ display: 'none' }}>
+          <RefinementList
+            attributeName="category"
+            defaultRefinement={['Dining']}
+          />
+        </div>
       </div>
-    </div>
-  </WrapWithHits>
-));
-
-stories.add('nothing to clear', () => (
-  <WrapWithHits linkedStoryGroup="ClearAll">
-    <ClearAll />
-  </WrapWithHits>
-));
-
-stories.add('clear all refinements and the query', () => (
-  <WrapWithHits linkedStoryGroup="ClearAll">
-    <ClearAll
-      clearsQuery
-      translations={{ reset: 'Clear refinements and query' }}
-    />
-    <RefinementList attributeName="category" defaultRefinement={['Dining']} />
-  </WrapWithHits>
-));
+    </WrapWithHits>
+  ))
+  .add('nothing to clear', () => (
+    <WrapWithHits linkedStoryGroup="ClearAll">
+      <ClearAll />
+    </WrapWithHits>
+  ))
+  .add('clear all refinements and the query', () => (
+    <WrapWithHits linkedStoryGroup="ClearAll">
+      <ClearAll
+        clearsQuery
+        translations={{ reset: 'Clear refinements and query' }}
+      />
+      <RefinementList attributeName="category" defaultRefinement={['Dining']} />
+    </WrapWithHits>
+  ));

--- a/stories/Conditional.stories.js
+++ b/stories/Conditional.stories.js
@@ -22,7 +22,7 @@ stories
       return <div>{content}</div>;
     });
     return (
-      <WrapWithHits>
+      <WrapWithHits linkedStoryGroup="Conditional">
         <Content />
       </WrapWithHits>
     );
@@ -40,7 +40,7 @@ stories
       return <div>{content}</div>;
     });
     return (
-      <WrapWithHits>
+      <WrapWithHits linkedStoryGroup="Conditional">
         <Content />
       </WrapWithHits>
     );

--- a/stories/Configure.stories.js
+++ b/stories/Configure.stories.js
@@ -12,13 +12,15 @@ class ConfigureExample extends React.Component {
     super();
     this.state = { hitsPerPage: 3 };
   }
+
   onClick() {
     const hitsPerPage = this.state.hitsPerPage === 3 ? 1 : 3;
     this.setState({ hitsPerPage });
   }
+
   render() {
     return (
-      <WrapWithHits>
+      <WrapWithHits linkedStoryGroup="Configure">
         <Configure hitsPerPage={this.state.hitsPerPage} />
         <button onClick={this.onClick.bind(this)}>Toggle HitsPerPage</button>
       </WrapWithHits>

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -40,7 +40,7 @@ stories
     </WrapWithHits>
   ))
   .add('with panel', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="CurrentRefinements">
       <Panel title="Current Refinements">
         <CurrentRefinements />
         <div style={{ display: 'none' }}>
@@ -53,7 +53,7 @@ stories
     </WrapWithHits>
   ))
   .add('with panel but no refinement', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="CurrentRefinements">
       <Panel title="Current Refinements">
         <CurrentRefinements />
       </Panel>

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -26,7 +26,7 @@ stories
     </WrapWithHits>
   ))
   .add('with default selected item', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
       <HierarchicalMenu
         attributes={['category', 'sub_category', 'sub_sub_category']}
         defaultRefinement="Eating"
@@ -34,7 +34,7 @@ stories
     </WrapWithHits>
   ))
   .add('with show more', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
       <HierarchicalMenu
         attributes={['category', 'sub_category', 'sub_sub_category']}
         limitMin={2}
@@ -44,7 +44,7 @@ stories
     </WrapWithHits>
   ))
   .add('with panel', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
       <Panel title="Category">
         <HierarchicalMenu
           attributes={['category', 'sub_category', 'sub_sub_category']}
@@ -53,7 +53,11 @@ stories
     </WrapWithHits>
   ))
   .add('with panel but no refinement', () => (
-    <WrapWithHits searchBox={false}>
+    <WrapWithHits
+      searchBox={false}
+      hasPlayground={true}
+      linkedStoryGroup="HierarchicalMenu"
+    >
       <Panel title="Category">
         <HierarchicalMenu
           attributes={['category', 'sub_category', 'sub_sub_category']}
@@ -65,7 +69,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="HierarchicalMenu">
       <HierarchicalMenu
         attributes={['category', 'sub_category', 'sub_sub_category']}
         defaultRefinement={text('defaultSelectedItem', 'Bathroom')}

--- a/stories/Hits.stories.js
+++ b/stories/Hits.stories.js
@@ -15,7 +15,7 @@ stories.add('default', () => (
 ));
 
 stories.add('with custom rendering', () => (
-  <WrapWithHits>
+  <WrapWithHits linkedStoryGroup="Hits">
     <Hits hitComponent={Product} />
   </WrapWithHits>
 ));

--- a/stories/HitsPerPage.stories.js
+++ b/stories/HitsPerPage.stories.js
@@ -10,7 +10,7 @@ stories.addDecorator(withKnobs);
 
 stories
   .add('default', () => (
-    <WrapWithHits linkedStoryGroup="HitsPerPage">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
       <HitsPerPage
         defaultRefinement={4}
         items={[
@@ -23,28 +23,15 @@ stories
     </WrapWithHits>
   ))
   .add('without label', () => (
-    <WrapWithHits linkedStoryGroup="HitsPerPage">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
       <HitsPerPage
         defaultRefinement={4}
         items={[{ value: 2 }, { value: 4 }, { value: 6 }, { value: 8 }]}
       />
     </WrapWithHits>
   ))
-  .add('playground', () => (
-    <WrapWithHits>
-      <HitsPerPage
-        defaultRefinement={number('default hits per page', 4)}
-        items={[
-          { value: 2, label: '2 hits per page' },
-          { value: 4, label: '4 hits per page' },
-          { value: 6, label: '6 hits per page' },
-          { value: 8, label: '8 hits per page' },
-        ]}
-      />
-    </WrapWithHits>
-  ))
   .add('inside a panel', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
       <Panel title="Hits to display">
         <HitsPerPage
           defaultRefinement={number('default hits per page', 4)}
@@ -56,5 +43,18 @@ stories
           ]}
         />
       </Panel>
+    </WrapWithHits>
+  ))
+  .add('playground', () => (
+    <WrapWithHits linkedStoryGroup="HitsPerPage">
+      <HitsPerPage
+        defaultRefinement={number('default hits per page', 4)}
+        items={[
+          { value: 2, label: '2 hits per page' },
+          { value: 4, label: '4 hits per page' },
+          { value: 6, label: '6 hits per page' },
+          { value: 8, label: '8 hits per page' },
+        ]}
+      />
     </WrapWithHits>
   ));

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -21,12 +21,12 @@ stories
     </WrapWithHits>
   ))
   .add('with default selected item', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
       <Menu attributeName="category" defaultRefinement="Eating" />
     </WrapWithHits>
   ))
   .add('with show more', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
       <Menu
         attributeName="category"
         limitMin={2}
@@ -36,7 +36,7 @@ stories
     </WrapWithHits>
   ))
   .add('with search inside items', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
       <Menu
         attributeName="category"
         withSearchBox
@@ -50,7 +50,7 @@ stories
     </WrapWithHits>
   ))
   .add('with the sort strategy changed', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
       <Menu
         attributeName="category"
         transformItems={items =>
@@ -59,14 +59,18 @@ stories
     </WrapWithHits>
   ))
   .add('with panel', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
       <Panel title="Category">
         <Menu attributeName="category" />
       </Panel>
     </WrapWithHits>
   ))
   .add('with panel but no available refinement', () => (
-    <WrapWithHits searchBox={false}>
+    <WrapWithHits
+      searchBox={false}
+      hasPlayground={true}
+      linkedStoryGroup="Menu"
+    >
       <Panel title="Category">
         <Menu attributeName="category" />
         <div style={{ display: 'none' }}>
@@ -76,7 +80,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="Menu">
       <Menu
         attributeName="category"
         defaultRefinement={text('defaultSelectedItem', 'Bathroom')}

--- a/stories/MultiRange.stories.js
+++ b/stories/MultiRange.stories.js
@@ -27,7 +27,7 @@ stories
     </WrapWithHits>
   ))
   .add('with a default range selected', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="MultiRange">
       <MultiRange
         attributeName="price"
         items={[
@@ -41,7 +41,7 @@ stories
     </WrapWithHits>
   ))
   .add('with some non selectable ranges', () => (
-    <WrapWithHits searchBox={false}>
+    <WrapWithHits searchBox={false} linkedStoryGroup="MultiRange">
       <MultiRange
         attributeName="price"
         items={[
@@ -54,7 +54,7 @@ stories
     </WrapWithHits>
   ))
   .add('with panel', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="MultiRange">
       <Panel title="Price">
         <MultiRange
           attributeName="price"
@@ -69,7 +69,7 @@ stories
     </WrapWithHits>
   ))
   .add('with panel but no available refinements', () => (
-    <WrapWithHits searchBox={false}>
+    <WrapWithHits searchBox={false} linkedStoryGroup="MultiRange">
       <Panel title="Price">
         <Configure filters="price>200000" />
         <MultiRange

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -19,7 +19,7 @@ stories
     </WrapWithHits>
   ))
   .add('with all props', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
       <Pagination
         showFirst={true}
         showLast={true}
@@ -30,8 +30,29 @@ stories
       />
     </WrapWithHits>
   ))
+  .add('with panel', () => (
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
+      <Panel title="Pages">
+        <Pagination />
+      </Panel>
+    </WrapWithHits>
+  ))
+  .add('with panel but no refinement', () => (
+    <WrapWithHits
+      searchBox={false}
+      hasPlayground={true}
+      linkedStoryGroup="Pagination"
+    >
+      <Panel title="Pages">
+        <Pagination />
+        <div style={{ display: 'none' }}>
+          <SearchBox defaultRefinement="ds" />
+        </div>
+      </Panel>
+    </WrapWithHits>
+  ))
   .add('playground', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="Pagination">
       <Pagination
         showFirst={boolean('show First', true)}
         showLast={boolean('show Last', true)}
@@ -40,22 +61,5 @@ stories
         pagesPadding={number('pages Padding', 2)}
         maxPages={number('max Pages', 3)}
       />
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits>
-      <Panel title="Pages">
-        <Pagination />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with panel but no refinement', () => (
-    <WrapWithHits searchBox={false}>
-      <Panel title="Pages">
-        <Pagination />
-        <div style={{ display: 'none' }}>
-          <SearchBox defaultRefinement="ds" />
-        </div>
-      </Panel>
     </WrapWithHits>
   ));

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -14,13 +14,12 @@ stories.addDecorator(withKnobs);
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput">
       <RangeInput attributeName="price" />
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits>
-
+    <WrapWithHits linkedStoryGroup="RangeInput">
       <RangeInput
         attributeName="price"
         min={number('max', 0)}
@@ -33,14 +32,14 @@ stories
     </WrapWithHits>
   ))
   .add('with panel', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="RangeInput">
       <Panel title="Price">
         <RangeInput attributeName="price" />
       </Panel>
     </WrapWithHits>
   ))
   .add('with panel but no refinement', () => (
-    <WrapWithHits searchBox={false}>
+    <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput">
       <Panel title="Price">
         <RangeInput attributeName="price" />
         <div style={{ display: 'none' }}>

--- a/stories/RangeSlider.stories.js
+++ b/stories/RangeSlider.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import { withKnobs, object, number } from '@kadira/storybook-addon-knobs';
 import { WrapWithHits } from './util';
-import Range from './3rdPartiesIntegration.stories';
+import Range from './3rdPartyIntegrations.stories';
 const stories = storiesOf('RangeSlider', module);
 
 stories.addDecorator(withKnobs);
@@ -10,25 +10,21 @@ stories.addDecorator(withKnobs);
 stories
   .add('default', () => (
     <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
-
       <Range attributeName="price" />
     </WrapWithHits>
   ))
   .add('providing default value', () => (
-    <WrapWithHits>
-
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
       <Range attributeName="price" defaultRefinement={{ min: 50, max: 200 }} />
     </WrapWithHits>
   ))
   .add('custom min/max bounds', () => (
-    <WrapWithHits>
-
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
       <Range attributeName="price" min={30} max={100} />
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits>
-
+    <WrapWithHits linkedStoryGroup="RangeSlider">
       <Range
         attributeName="price"
         defaultRefinement={object('default value', { min: 150, max: 200 })}

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -22,16 +22,15 @@ stories
   .add('default', () => (
     <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
       <RefinementList attributeName="category" />
-
     </WrapWithHits>
   ))
   .add('with selected item', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
       <RefinementList attributeName="category" defaultRefinement={['Dining']} />
     </WrapWithHits>
   ))
   .add('with show more', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
       <RefinementList
         attributeName="category"
         limitMin={2}
@@ -41,12 +40,12 @@ stories
     </WrapWithHits>
   ))
   .add('with search inside items', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
       <RefinementList attributeName="category" withSearchBox />
     </WrapWithHits>
   ))
   .add('with the sort strategy changed', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
       <RefinementList
         attributeName="category"
         transformItems={items =>
@@ -55,14 +54,18 @@ stories
     </WrapWithHits>
   ))
   .add('with panel', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
       <Panel title="Category">
         <RefinementList attributeName="category" />
       </Panel>
     </WrapWithHits>
   ))
   .add('with panel but no refinement', () => (
-    <WrapWithHits searchBox={false}>
+    <WrapWithHits
+      searchBox={false}
+      linkedStoryGroup="RefinementList"
+      hasPlayground={true}
+    >
       <Panel title="Category">
         <RefinementList attributeName="category" />
         <div style={{ display: 'none' }}>
@@ -72,7 +75,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="RefinementList">
       <RefinementList
         attributeName="category"
         defaultRefinement={array('defaultSelectedItem', [

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -46,7 +46,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits searchBox={false}>
+    <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox">
       <SearchBox
         focusShortcuts={['s']}
         searchAsYouType={true}
@@ -109,7 +109,7 @@ class SearchBoxContainer extends Component {
       <WrapWithHits
         searchBox={false}
         hasPlayground={true}
-        linkedStoryGroup="searchBox"
+        linkedStoryGroup="SearchBox"
       >
         <div
           style={{

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -10,7 +10,7 @@ stories.addDecorator(withKnobs);
 
 stories
   .add('default', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="SortBy">
       <SortBy
         items={[
           { value: 'ikea', label: 'Featured' },
@@ -22,7 +22,7 @@ stories
     </WrapWithHits>
   ))
   .add('without label', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="SortBy">
       <SortBy
         items={[
           { value: 'ikea' },

--- a/stories/StarRating.stories.js
+++ b/stories/StarRating.stories.js
@@ -20,14 +20,14 @@ stories
     </WrapWithHits>
   ))
   .add('with panel', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
       <Panel title="Ratings">
         <StarRating attributeName="rating" max={6} min={1} />
       </Panel>
     </WrapWithHits>
   ))
   .add('with some unavailable refinements', () => (
-    <WrapWithHits>
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
       <Configure filters="rating>=4" />
       <Panel title="Ratings">
         <StarRating attributeName="rating" max={6} min={1} />
@@ -35,7 +35,11 @@ stories
     </WrapWithHits>
   ))
   .add('with panel but no refinement', () => (
-    <WrapWithHits searchBox={false}>
+    <WrapWithHits
+      searchBox={false}
+      hasPlayground={true}
+      linkedStoryGroup="StarRating"
+    >
       <Panel title="Ratings">
         <StarRating attributeName="rating" max={6} min={1} />
         <div style={{ display: 'none' }}>
@@ -51,7 +55,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits>
+    <WrapWithHits linkedStoryGroup="StarRating">
       <StarRating
         attributeName="rating"
         max={number('max', 6)}


### PR DESCRIPTION
**Summary**

Not all of the Stories were laid out consistently with regard to `linkedStoryGroup` and `hasPlayground`

**Result**

1. reordered all stories to have playground last
2. add `hasPlayground` wherever relevant
3. add `linkedStoryGroup` to all of them
  - a better solution would be to add this somehow to the `storiesOf`, but I didn't find a hook for this kind of behaviour.
4. use `stories.add().add()` instead of `stories.add();stories.add()` everywhere
