### PR TITLE
fix(MultiIndex): revert breaking change if no multiple index

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
@@ -6,6 +6,7 @@ import {
   getIndex,
   refineValue,
   getCurrentRefinementValue,
+  getResults,
 } from '../core/indexUtils';
 
 export const getId = props => props.attributes[0];
@@ -171,12 +172,11 @@ export default createConnector({
   getProvidedProps(props, searchState, searchResults) {
     const { showMore, limitMin, limitMax } = props;
     const id = getId(props);
-    const { results } = searchResults;
     const index = getIndex(this.context);
+    const results = getResults(searchResults, this.context);
 
     const isFacetPresent = Boolean(results) &&
-      Boolean(results[index]) &&
-      Boolean(results[index].getFacetByName(id));
+      Boolean(results.getFacetByName(id));
 
     if (!isFacetPresent) {
       return {
@@ -191,7 +191,7 @@ export default createConnector({
     }
 
     const limit = showMore ? limitMax : limitMin;
-    const value = results[index].getFacetValues(id, { sortBy });
+    const value = results.getFacetValues(id, { sortBy });
     const items = value.data
       ? transformValue(value.data, limit, props, searchState, this.context)
       : [];

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -19,13 +19,11 @@ describe('connectHierarchicalMenu', () => {
 
     it('provides the correct props to the component', () => {
       const results = {
-        index: {
-          getFacetValues: jest.fn(),
-          getFacetByName: () => true,
-        },
+        getFacetValues: jest.fn(),
+        getFacetByName: () => true,
       };
 
-      results.index.getFacetValues.mockImplementationOnce(() => ({}));
+      results.getFacetValues.mockImplementationOnce(() => ({}));
       props = getProvidedProps(
         { attributes: ['ok'] },
         { hierarchicalMenu: { ok: 'wat' } },
@@ -44,8 +42,8 @@ describe('connectHierarchicalMenu', () => {
         items: [],
       });
 
-      results.index.getFacetValues.mockClear();
-      results.index.getFacetValues.mockImplementation(() => ({
+      results.getFacetValues.mockClear();
+      results.getFacetValues.mockImplementation(() => ({
         data: [
           {
             name: 'wat',

--- a/packages/react-instantsearch/src/connectors/connectHits.js
+++ b/packages/react-instantsearch/src/connectors/connectHits.js
@@ -1,5 +1,5 @@
 import createConnector from '../core/createConnector';
-import { getIndex } from '../core/indexUtils';
+import { getIndex, getResults } from '../core/indexUtils';
 
 /**
  * connectHits connector provides the logic to create connected
@@ -18,9 +18,8 @@ export default createConnector({
 
   getProvidedProps(props, searchState, searchResults) {
     const index = getIndex(this.context);
-    const hits = searchResults.results && searchResults.results[index]
-      ? searchResults.results[index].hits
-      : [];
+    const results = getResults(searchResults, this.context);
+    const hits = results ? results.hits : [];
 
     return { hits };
   },

--- a/packages/react-instantsearch/src/connectors/connectHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHits.test.js
@@ -12,13 +12,13 @@ describe('connectHits', () => {
     it('provides the current hits to the component', () => {
       const hits = [{}];
       const props = getProvidedProps(null, null, {
-        results: { index: { hits } },
+        results: { hits },
       });
       expect(props).toEqual({ hits });
     });
 
     it("doesn't render when no hits are available", () => {
-      const props = getProvidedProps(null, null, { results: { index: null } });
+      const props = getProvidedProps(null, null, { results: null });
       expect(props).toEqual({ hits: [] });
     });
 

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -3,6 +3,7 @@ import {
   getIndex,
   getCurrentRefinementValue,
   refineValue,
+  getResults,
 } from '../core/indexUtils';
 
 function getId() {
@@ -42,7 +43,9 @@ export default createConnector({
 
   getProvidedProps(props, searchState, searchResults) {
     const index = getIndex(this.context);
-    if (!searchResults.results || !searchResults.results[index]) {
+    const results = getResults(searchResults, this.context);
+
+    if (!results) {
       this._allResults = [];
       return {
         hits: this._allResults,
@@ -50,7 +53,7 @@ export default createConnector({
       };
     }
 
-    const { hits, page, nbPages, hitsPerPage } = searchResults.results[index];
+    const { hits, page, nbPages, hitsPerPage } = results;
 
     if (page === 0) {
       this._allResults = hits;

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -11,7 +11,7 @@ describe('connectInfiniteHits', () => {
     it('provides the current hits to the component', () => {
       const hits = [{}];
       const props = getProvidedProps(null, null, {
-        results: { index: { hits, page: 0, hitsPerPage: 2, nbPages: 3 } },
+        results: { hits, page: 0, hitsPerPage: 2, nbPages: 3 },
       });
       expect(props).toEqual({ hits, hasMore: true });
     });
@@ -20,13 +20,16 @@ describe('connectInfiniteHits', () => {
       const hits = [{}, {}];
       const hits2 = [{}, {}];
       const res1 = getProvidedProps(null, null, {
-        results: { index: { hits, page: 0, hitsPerPage: 2, nbPages: 3 } },
+        results: { hits, page: 0, hitsPerPage: 2, nbPages: 3 },
       });
       expect(res1.hits).toEqual(hits);
       expect(res1.hasMore).toBe(true);
       const res2 = getProvidedProps(null, null, {
         results: {
-          index: { hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3 },
+          hits: hits2,
+          page: 1,
+          hitsPerPage: 2,
+          nbPages: 3,
         },
       });
       expect(res2.hits).toEqual([...hits, ...hits2]);
@@ -42,12 +45,10 @@ describe('connectInfiniteHits', () => {
         allHits = [...allHits, ...hits];
         const res = getProvidedProps(null, null, {
           results: {
-            index: {
-              hits,
-              page,
-              hitsPerPage: hits.length,
-              nbPages,
-            },
+            hits,
+            page,
+            hitsPerPage: hits.length,
+            nbPages,
           },
         });
         expect(res.hits).toEqual(allHits);
@@ -59,12 +60,10 @@ describe('connectInfiniteHits', () => {
       allHits = [...allHits, ...hits];
       const res = getProvidedProps(null, null, {
         results: {
-          index: {
-            hits,
-            page: nbPages - 1,
-            hitsPerPage: hits.length,
-            nbPages,
-          },
+          hits,
+          page: nbPages - 1,
+          hitsPerPage: hits.length,
+          nbPages,
         },
       });
       expect(res.hits.length).toEqual(nbPages * 2);
@@ -77,16 +76,22 @@ describe('connectInfiniteHits', () => {
       const hits2 = [{}, {}];
       const hits3 = [{}];
       getProvidedProps(null, null, {
-        results: { index: { hits, page: 0, hitsPerPage: 2, nbPages: 3 } },
+        results: { hits, page: 0, hitsPerPage: 2, nbPages: 3 },
       });
       getProvidedProps(null, null, {
         results: {
-          index: { hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3 },
+          hits: hits2,
+          page: 1,
+          hitsPerPage: 2,
+          nbPages: 3,
         },
       });
       const props = getProvidedProps(null, null, {
         results: {
-          index: { hits: hits3, page: 2, hitsPerPage: 2, nbPages: 3 },
+          hits: hits3,
+          page: 2,
+          hitsPerPage: 2,
+          nbPages: 3,
         },
       });
       expect(props.hits).toEqual([...hits, ...hits2, ...hits3]);

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -7,6 +7,7 @@ import {
   getIndex,
   refineValue,
   getCurrentRefinementValue,
+  getResults,
 } from '../core/indexUtils';
 
 const namespace = 'menu';
@@ -96,14 +97,13 @@ export default createConnector({
     meta,
     searchForFacetValuesResults
   ) {
-    const { results } = searchResults;
     const { attributeName, showMore, limitMin, limitMax } = props;
     const limit = showMore ? limitMax : limitMin;
     const index = getIndex(this.context);
+    const results = getResults(searchResults, this.context);
 
     const canRefine = Boolean(results) &&
-      Boolean(results[index]) &&
-      Boolean(results[index].getFacetByName(attributeName));
+      Boolean(results.getFacetByName(attributeName));
 
     const isFromSearch = Boolean(
       searchForFacetValuesResults &&
@@ -148,7 +148,7 @@ export default createConnector({
           count: v.count,
           isRefined: v.isRefined,
         }))
-      : results[index].getFacetValues(attributeName, { sortBy }).map(v => ({
+      : results.getFacetValues(attributeName, { sortBy }).map(v => ({
           label: v.name,
           value: getValue(v.name, props, searchState, this.context),
           count: v.count,

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -22,10 +22,8 @@ describe('connectMenu', () => {
 
     it('provides the correct props to the component', () => {
       const results = {
-        index: {
-          getFacetValues: jest.fn(() => []),
-          getFacetByName: () => true,
-        },
+        getFacetValues: jest.fn(() => []),
+        getFacetByName: () => true,
       };
 
       props = getProvidedProps({ attributeName: 'ok' }, {}, {});
@@ -85,8 +83,8 @@ describe('connectMenu', () => {
         searchForItems: undefined,
       });
 
-      results.index.getFacetValues.mockClear();
-      results.index.getFacetValues.mockImplementation(() => [
+      results.getFacetValues.mockClear();
+      results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
           isRefined: true,
@@ -210,12 +208,10 @@ describe('connectMenu', () => {
 
     it('if an item is equal to the currentRefinement, its value should be an empty string', () => {
       const results = {
-        index: {
-          getFacetValues: jest.fn(() => []),
-          getFacetByName: () => true,
-        },
+        getFacetValues: jest.fn(() => []),
+        getFacetByName: () => true,
       };
-      results.index.getFacetValues.mockImplementation(() => [
+      results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
           isRefined: true,
@@ -385,13 +381,11 @@ describe('connectMenu', () => {
 
     it('when search for facets values is activated order the item by isRefined first', () => {
       const results = {
-        index: {
-          getFacetValues: jest.fn(() => []),
-          getFacetByName: () => true,
-        },
+        getFacetValues: jest.fn(() => []),
+        getFacetByName: () => true,
       };
-      results.index.getFacetValues.mockClear();
-      results.index.getFacetValues.mockImplementation(() => [
+      results.getFacetValues.mockClear();
+      results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
           isRefined: false,

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.js
@@ -5,6 +5,7 @@ import {
   getIndex,
   refineValue,
   getCurrentRefinementValue,
+  getResults,
 } from '../core/indexUtils';
 
 import createConnector from '../core/createConnector';
@@ -125,21 +126,22 @@ export default createConnector({
       this.context
     );
     const index = getIndex(this.context);
+    const results = getResults(searchResults, this.context);
+
     const items = props.items.map(item => {
       const value = stringifyItem(item);
       return {
         label: item.label,
         value,
         isRefined: value === currentRefinement,
-        noRefinement: searchResults.results && searchResults.results[index]
-          ? itemHasRefinement(getId(props), searchResults.results[index], value)
+        noRefinement: results
+          ? itemHasRefinement(getId(props), results, value)
           : false,
       };
     });
 
-    const stats = has(searchResults, `results.${index}`) &&
-      searchResults.results[index].getFacetByName(attributeName)
-      ? searchResults.results[index].getFacetStats(attributeName)
+    const stats = results && results.getFacetByName(attributeName)
+      ? results.getFacetStats(attributeName)
       : null;
     const refinedItem = find(items, item => item.isRefined === true);
     if (!items.some(item => item.value === '')) {

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
@@ -18,10 +18,8 @@ describe('connectMultiRange', () => {
     const cleanUp = connect.cleanUp.bind(context);
 
     const results = {
-      index: {
-        getFacetStats: () => ({ min: 0, max: 300 }),
-        getFacetByName: () => true,
-      },
+      getFacetStats: () => ({ min: 0, max: 300 }),
+      getFacetByName: () => true,
     };
 
     it('provides the correct props to the component', () => {

--- a/packages/react-instantsearch/src/connectors/connectPagination.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.js
@@ -3,6 +3,7 @@ import {
   getIndex,
   refineValue,
   getCurrentRefinementValue,
+  getResults,
 } from '../core/indexUtils';
 
 import createConnector from '../core/createConnector';
@@ -57,11 +58,13 @@ export default createConnector({
 
   getProvidedProps(props, searchState, searchResults) {
     const index = getIndex(this.context);
-    if (!searchResults.results || !searchResults.results[index]) {
+    const results = getResults(searchResults, this.context);
+
+    if (!results) {
       return null;
     }
 
-    const nbPages = searchResults.results[index].nbPages;
+    const nbPages = results.nbPages;
     return {
       nbPages,
       currentRefinement: getCurrentRefinement(props, searchState, this.context),

--- a/packages/react-instantsearch/src/connectors/connectPagination.test.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.test.js
@@ -18,22 +18,14 @@ describe('connectPagination', () => {
     const cleanUp = connect.cleanUp.bind(context);
 
     it('provides the correct props to the component', () => {
-      props = getProvidedProps(
-        {},
-        {},
-        { results: { index: { nbPages: 666 } } }
-      );
+      props = getProvidedProps({}, {}, { results: { nbPages: 666 } });
       expect(props).toEqual({
         currentRefinement: 1,
         nbPages: 666,
         canRefine: true,
       });
 
-      props = getProvidedProps(
-        {},
-        { page: 5 },
-        { results: { index: { nbPages: 666 } } }
-      );
+      props = getProvidedProps({}, { page: 5 }, { results: { nbPages: 666 } });
       expect(props).toEqual({
         currentRefinement: 5,
         nbPages: 666,
@@ -43,7 +35,7 @@ describe('connectPagination', () => {
       props = getProvidedProps(
         {},
         { page: '5' },
-        { results: { index: { nbPages: 666 } } }
+        { results: { nbPages: 666 } }
       );
       expect(props).toEqual({
         currentRefinement: 5,
@@ -51,11 +43,7 @@ describe('connectPagination', () => {
         canRefine: true,
       });
 
-      props = getProvidedProps(
-        {},
-        { page: '1' },
-        { results: { index: { nbPages: 1 } } }
-      );
+      props = getProvidedProps({}, { page: '1' }, { results: { nbPages: 1 } });
       expect(props).toEqual({
         currentRefinement: 1,
         nbPages: 1,

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -4,6 +4,7 @@ import {
   getIndex,
   refineValue,
   getCurrentRefinementValue,
+  getResults,
 } from '../core/indexUtils';
 
 import createConnector from '../core/createConnector';
@@ -88,16 +89,17 @@ export default createConnector({
     const hasMax = typeof max !== 'undefined';
 
     const index = getIndex(this.context);
+    const results = getResults(searchResults, this.context);
 
     if (!hasMin || !hasMax) {
-      if (!searchResults.results || !searchResults.results[index]) {
+      if (!results) {
         return {
           canRefine: false,
         };
       }
 
-      const stats = searchResults.results[index].getFacetByName(attributeName)
-        ? searchResults.results[index].getFacetStats(attributeName)
+      const stats = results.getFacetByName(attributeName)
+        ? results.getFacetStats(attributeName)
         : null;
       if (!stats) {
         return {
@@ -113,12 +115,10 @@ export default createConnector({
       }
     }
 
-    const count = searchResults.results && searchResults.results[index]
-      ? searchResults.results[index].getFacetValues(attributeName).map(v => ({
+    const count = results ? results.getFacetValues(attributeName).map(v => ({
           value: v.name,
           count: v.count,
-        }))
-      : [];
+        })) : [];
 
     const {
       min: valueMin = min,

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -32,14 +32,12 @@ describe('connectRange', () => {
       });
 
       const results = {
-        index: {
-          getFacetStats: () => ({ min: 5, max: 10 }),
-          getFacetValues: () => [
-            { name: '5', count: 10 },
-            { name: '2', count: 20 },
-          ],
-          getFacetByName: () => true,
-        },
+        getFacetStats: () => ({ min: 5, max: 10 }),
+        getFacetValues: () => [
+          { name: '5', count: 10 },
+          { name: '2', count: 20 },
+        ],
+        getFacetByName: () => true,
       };
       props = getProvidedProps({ attributeName: 'ok' }, {}, { results });
       expect(props).toEqual({

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -4,6 +4,7 @@ import {
   getIndex,
   refineValue,
   getCurrentRefinementValue,
+  getResults,
 } from '../core/indexUtils';
 
 import createConnector from '../core/createConnector';
@@ -116,14 +117,13 @@ export default createConnector({
     metadata,
     searchForFacetValuesResults
   ) {
-    const { results } = searchResults;
     const { attributeName, showMore, limitMin, limitMax } = props;
     const limit = showMore ? limitMax : limitMin;
     const index = getIndex(this.context);
+    const results = getResults(searchResults, this.context);
 
     const canRefine = Boolean(results) &&
-      Boolean(results[index]) &&
-      Boolean(results[index].getFacetByName(attributeName));
+      Boolean(results.getFacetByName(attributeName));
 
     const isFromSearch = Boolean(
       searchForFacetValuesResults &&
@@ -168,7 +168,7 @@ export default createConnector({
           count: v.count,
           isRefined: v.isRefined,
         }))
-      : results[index].getFacetValues(attributeName, { sortBy }).map(v => ({
+      : results.getFacetValues(attributeName, { sortBy }).map(v => ({
           label: v.name,
           value: getValue(v.name, props, searchState, this.context),
           count: v.count,

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -21,10 +21,8 @@ describe('connectRefinementList', () => {
     const cleanUp = connect.cleanUp.bind(context);
 
     const results = {
-      index: {
-        getFacetValues: jest.fn(() => []),
-        getFacetByName: () => true,
-      },
+      getFacetValues: jest.fn(() => []),
+      getFacetByName: () => true,
     };
 
     it('provides the correct props to the component', () => {
@@ -95,8 +93,8 @@ describe('connectRefinementList', () => {
         withSearchBox: true,
       });
 
-      results.index.getFacetValues.mockClear();
-      results.index.getFacetValues.mockImplementation(() => [
+      results.getFacetValues.mockClear();
+      results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
           isRefined: true,

--- a/packages/react-instantsearch/src/connectors/connectStats.js
+++ b/packages/react-instantsearch/src/connectors/connectStats.js
@@ -1,5 +1,5 @@
 import createConnector from '../core/createConnector';
-import { getIndex } from '../core/indexUtils';
+import { getIndex, getResults } from '../core/indexUtils';
 
 /**
  * connectStats connector provides the logic to build a widget that will
@@ -14,12 +14,14 @@ export default createConnector({
 
   getProvidedProps(props, searchState, searchResults) {
     const index = getIndex(this.context);
-    if (!searchResults.results || !searchResults.results[index]) {
+    const results = getResults(searchResults, this.context);
+
+    if (!results) {
       return null;
     }
     return {
-      nbHits: searchResults.results[index].nbHits,
-      processingTimeMS: searchResults.results[index].processingTimeMS,
+      nbHits: results.nbHits,
+      processingTimeMS: results.processingTimeMS,
     };
   },
 });

--- a/packages/react-instantsearch/src/connectors/connectStats.test.js
+++ b/packages/react-instantsearch/src/connectors/connectStats.test.js
@@ -13,7 +13,7 @@ describe('connectStats', () => {
       expect(props).toBe(null);
 
       props = getProvidedProps(null, null, {
-        results: { index: { nbHits: 666, processingTimeMS: 1 } },
+        results: { nbHits: 666, processingTimeMS: 1 },
       });
       expect(props).toEqual({ nbHits: 666, processingTimeMS: 1 });
     });

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -3,7 +3,7 @@ import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import createWidgetsManager from './createWidgetsManager';
 import createStore from './createStore';
 import highlightTags from './highlightTags.js';
-import { omit } from 'lodash';
+import { omit, isEmpty } from 'lodash';
 
 /**
  * Creates a new instance of the InstantSearchManager which controls the widgets and
@@ -130,8 +130,12 @@ export default function createInstantSearchManager(
 
   function handleSearchSuccess(content) {
     const state = store.getState();
-    const results = state.results ? state.results : [];
-    results[indexMapping[content.index]] = content;
+    let results = state.results ? state.results : [];
+    if (!isEmpty(derivedHelpers)) {
+      results[indexMapping[content.index]] = content;
+    } else {
+      results = content;
+    }
 
     const nextState = omit(
       {

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
@@ -12,7 +12,7 @@ jest.mock('algoliasearch-helper/src/algoliasearch.helper.js', () => {
     'algoliasearch-helper/src/algoliasearch.helper.js'
   );
   Helper.prototype._dispatchAlgoliaResponse = function(state) {
-    this.emit('result', { count: count++, index: 'index' }, state);
+    this.emit('result', { count: count++ }, state);
   };
   Helper.prototype.searchForFacetValues = () =>
     Promise.resolve({ facetHits: 'results' });
@@ -49,11 +49,7 @@ describe('createInstantSearchManager', () => {
         });
 
         ism.widgetsManager.registerWidget({
-          getSearchParameters: params => {
-            params.setQuery('search');
-            params.setIndex('index');
-            return params;
-          },
+          getSearchParameters: params => params.setQuery('search'),
         });
 
         expect(ism.store.getState().results).toBe(null);
@@ -62,7 +58,7 @@ describe('createInstantSearchManager', () => {
           jest.runAllTimers();
 
           const store = ism.store.getState();
-          expect(store.results.index).toEqual({ count: 0, index: 'index' });
+          expect(store.results).toEqual({ count: 0 });
           expect(store.error).toBe(null);
 
           ism.widgetsManager.update();
@@ -71,7 +67,7 @@ describe('createInstantSearchManager', () => {
             jest.runAllTimers();
 
             const store1 = ism.store.getState();
-            expect(store.results.index).toEqual({ count: 1, index: 'index' });
+            expect(store1.results).toEqual({ count: 1 });
             expect(store1.error).toBe(null);
           });
         });
@@ -82,7 +78,7 @@ describe('createInstantSearchManager', () => {
         const ism = createInstantSearchManager({
           indexName: 'index',
           initialState: {},
-          searchParameters: { index: 'index' },
+          searchParameters: {},
           algoliaClient: client,
         });
 
@@ -93,7 +89,7 @@ describe('createInstantSearchManager', () => {
         jest.runAllTimers();
 
         const store = ism.store.getState();
-        expect(store.results.index).toEqual({ count: 2, index: 'index' });
+        expect(store.results).toEqual({ count: 2 });
         expect(store.error).toBe(null);
       });
     });
@@ -102,7 +98,7 @@ describe('createInstantSearchManager', () => {
         const ism = createInstantSearchManager({
           indexName: 'index',
           initialState: {},
-          searchParameters: { index: 'index' },
+          searchParameters: {},
           algoliaClient: client,
         });
 

--- a/packages/react-instantsearch/src/core/indexUtils.js
+++ b/packages/react-instantsearch/src/core/indexUtils.js
@@ -6,6 +6,16 @@ export function getIndex(context) {
     : context.ais.mainTargetedIndex;
 }
 
+export function getResults(searchResults, context) {
+  if (hasMultipleIndex(context)) {
+    return searchResults.results && searchResults.results[getIndex(context)]
+      ? searchResults.results[getIndex(context)]
+      : null;
+  } else {
+    return searchResults.results ? searchResults.results : null;
+  }
+}
+
 export function hasMultipleIndex(context) {
   return context && context.multiIndexContext;
 }

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -4,6 +4,7 @@ import {
   refineValue,
   getCurrentRefinementValue,
   cleanUpValue,
+  getResults,
 } from './indexUtils';
 
 describe('utility method for manipulating the search state', () => {
@@ -186,6 +187,13 @@ describe('utility method for manipulating the search state', () => {
         another: 'another',
         namespace: {},
       });
+    });
+    it('get results', () => {
+      const searchResults = { results: { some: 'results' } };
+
+      const results = getResults(searchResults, context);
+
+      expect(results).toEqual({ some: 'results' });
     });
   });
   describe('when there are multiple index', () => {
@@ -374,6 +382,14 @@ describe('utility method for manipulating the search state', () => {
         page: 1,
         indices: { first: { namespace: {} } },
       });
+    });
+
+    it('get results', () => {
+      const searchResults = { results: { first: { some: 'results' } } };
+
+      const results = getResults(searchResults, context);
+
+      expect(results).toEqual({ some: 'results' });
     });
   });
 });


### PR DESCRIPTION
If no usage of `<Index>`, then there is no need to nest the results under the index name. This PR rollback this behaviour to be the same as v3 regarding single index search. 

