### PR TITLE
feat(SearchBox): add default width and height to buttons.

### DIFF
--- a/packages/react-instantsearch/src/components/SearchBox.js
+++ b/packages/react-instantsearch/src/components/SearchBox.js
@@ -160,13 +160,13 @@ class SearchBox extends Component {
 
     const submitComponent = this.props.submitComponent
       ? this.props.submitComponent
-      : <svg role="img">
+      : <svg role="img" width="1em" height="1em">
           <use xlinkHref="#sbx-icon-search-13" />
         </svg>;
 
     const resetComponent = this.props.resetComponent
       ? this.props.resetComponent
-      : <svg role="img">
+      : <svg role="img" width="1em" height="1em">
           <use xlinkHref="#sbx-icon-clear-3" />
         </svg>;
 

--- a/packages/react-instantsearch/src/components/__snapshots__/Menu.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/Menu.test.js.snap
@@ -67,7 +67,9 @@ exports[`Menu Menu with search inside items but no search results 1`] = `
           type="submit"
         >
           <svg
+            height="1em"
             role="img"
+            width="1em"
           >
             <use
               xlinkHref="#sbx-icon-search-13"
@@ -81,7 +83,9 @@ exports[`Menu Menu with search inside items but no search results 1`] = `
           type="reset"
         >
           <svg
+            height="1em"
             role="img"
+            width="1em"
           >
             <use
               xlinkHref="#sbx-icon-clear-3"
@@ -228,7 +232,9 @@ exports[`Menu Menu with search inside items with search results 1`] = `
           type="submit"
         >
           <svg
+            height="1em"
             role="img"
+            width="1em"
           >
             <use
               xlinkHref="#sbx-icon-search-13"
@@ -242,7 +248,9 @@ exports[`Menu Menu with search inside items with search results 1`] = `
           type="reset"
         >
           <svg
+            height="1em"
             role="img"
+            width="1em"
           >
             <use
               xlinkHref="#sbx-icon-clear-3"
@@ -345,7 +353,9 @@ exports[`Menu applies translations 1`] = `
           type="submit"
         >
           <svg
+            height="1em"
             role="img"
+            width="1em"
           >
             <use
               xlinkHref="#sbx-icon-search-13"
@@ -359,7 +369,9 @@ exports[`Menu applies translations 1`] = `
           type="reset"
         >
           <svg
+            height="1em"
             role="img"
+            width="1em"
           >
             <use
               xlinkHref="#sbx-icon-clear-3"

--- a/packages/react-instantsearch/src/components/__snapshots__/RefinementList.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/RefinementList.test.js.snap
@@ -68,7 +68,9 @@ exports[`RefinementList applies translations 1`] = `
             type="submit"
           >
             <svg
+              height="1em"
               role="img"
+              width="1em"
             >
               <use
                 xlinkHref="#sbx-icon-search-13"
@@ -82,7 +84,9 @@ exports[`RefinementList applies translations 1`] = `
             type="reset"
           >
             <svg
+              height="1em"
               role="img"
+              width="1em"
             >
               <use
                 xlinkHref="#sbx-icon-clear-3"
@@ -318,7 +322,9 @@ exports[`RefinementList refinement list with search inside items but no search r
             type="submit"
           >
             <svg
+              height="1em"
               role="img"
+              width="1em"
             >
               <use
                 xlinkHref="#sbx-icon-search-13"
@@ -332,7 +338,9 @@ exports[`RefinementList refinement list with search inside items but no search r
             type="reset"
           >
             <svg
+              height="1em"
               role="img"
+              width="1em"
             >
               <use
                 xlinkHref="#sbx-icon-clear-3"
@@ -496,7 +504,9 @@ exports[`RefinementList refinement list with search inside items with search res
             type="submit"
           >
             <svg
+              height="1em"
               role="img"
+              width="1em"
             >
               <use
                 xlinkHref="#sbx-icon-search-13"
@@ -510,7 +520,9 @@ exports[`RefinementList refinement list with search inside items with search res
             type="reset"
           >
             <svg
+              height="1em"
               role="img"
+              width="1em"
             >
               <use
                 xlinkHref="#sbx-icon-clear-3"

--- a/packages/react-instantsearch/src/components/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/SearchBox.test.js.snap
@@ -61,7 +61,9 @@ exports[`SearchBox applies its default props 1`] = `
       type="submit"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-search-13"
@@ -75,7 +77,9 @@ exports[`SearchBox applies its default props 1`] = `
       type="reset"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-clear-3"
@@ -147,7 +151,9 @@ exports[`SearchBox lets you customize its theme 1`] = `
       type="submit"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-search-13"
@@ -161,7 +167,9 @@ exports[`SearchBox lets you customize its theme 1`] = `
       type="reset"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-clear-3"
@@ -233,7 +241,9 @@ exports[`SearchBox lets you customize its translations 1`] = `
       type="submit"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-search-13"
@@ -247,7 +257,9 @@ exports[`SearchBox lets you customize its translations 1`] = `
       type="reset"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-clear-3"
@@ -401,7 +413,9 @@ exports[`SearchBox transfers the autoFocus prop to the underlying input element 
       type="submit"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-search-13"
@@ -415,7 +429,9 @@ exports[`SearchBox transfers the autoFocus prop to the underlying input element 
       type="reset"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-clear-3"
@@ -487,7 +503,9 @@ exports[`SearchBox treats its query prop as its input value 1`] = `
       type="submit"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-search-13"
@@ -501,7 +519,9 @@ exports[`SearchBox treats its query prop as its input value 1`] = `
       type="reset"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-clear-3"
@@ -573,7 +593,9 @@ exports[`SearchBox treats its query prop as its input value 2`] = `
       type="submit"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-search-13"
@@ -587,7 +609,9 @@ exports[`SearchBox treats its query prop as its input value 2`] = `
       type="reset"
     >
       <svg
+        height="1em"
         role="img"
+        width="1em"
       >
         <use
           xlinkHref="#sbx-icon-clear-3"


### PR DESCRIPTION
**Summary**

Since svg allows a width and height attribute, we can use those to provide a default width and height. This has a lower specificity than css defined width or height, because it's an svg.

**Result**

Especially the situation where people don't use the Algolia theme is improved by this.

The SearchBox without styling looks like this:

before|after
---|---
![screen shot 2017-04-13 at 11 53 18](https://cloud.githubusercontent.com/assets/6270048/25002889/f46f3552-204c-11e7-91ab-685162a6ea23.png) | ![screen shot 2017-04-13 at 13 22 13](https://cloud.githubusercontent.com/assets/6270048/25002888/f43a49fa-204c-11e7-8f45-300103f327a6.png)

With styling it still looks the same as before.
