### PR TITLE
chore(tests): run jest with --runInBand in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release": "./scripts/release.sh",
     "lint": "if [ \"$CI\" = \"true\" ]; then eslint .; else eslint . --cache; fi",
     "docs:doctoc": "doctoc --maxlevel 1 README.md",
-    "test": "jest && yarn lint && NODE_ENV=production yarn test:build",
+    "test": "./scripts/test.sh",
     "test:build": "./scripts/test:build.sh",
     "dev": "jest --watch --bail",
     "docs:storybook-start": "NODE_ENV=development start-storybook -p 6006 -c ./storybook -s ./storybook/public",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# cause test to fail if one fails
+set -e
+
+if [ "$CI" = "true" ]
+  then jest --runInBand
+  else jest
+fi
+yarn lint
+NODE_ENV=production yarn test:build

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,9 @@
 # cause test to fail if one fails
 set -e
 
-jest
+if [ "$CI" = "true" ]
+  then jest --runInBand
+  else jest
+fi
 yarn lint
 NODE_ENV=production yarn test:build

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,9 +3,6 @@
 # cause test to fail if one fails
 set -e
 
-if [ "$CI" = "true" ]
-  then jest --runInBand
-  else jest
-fi
+jest
 yarn lint
 NODE_ENV=production yarn test:build


### PR DESCRIPTION
**Summary**

Run jest with [--runInBand](http://facebook.github.io/jest/docs/cli.html#runinband) in CI. I heard a few times that this makes the tests faster on Travis, so let's give it a try


**Result**

before|after
---|---
±5 min | 3 min 55 sec
4 min 38 sec | 3 min 55 sec
||4 min 7 sec
||3 min 56 sec