### PR TITLE
feat(MultiIndex): remove the need for virtual hits when using connectAutoComplete

### DIFF
--- a/packages/react-instantsearch/examples/autocomplete/public/index.html
+++ b/packages/react-instantsearch/examples/autocomplete/public/index.html
@@ -1,15 +1,16 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>autocomplete with react-instantsearch</title>
-    <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/style.css">
-  </head>
-  <body>
-    <h2>Autocomplete targetting multiple indices</h2>
-    <div id="autocomplete-with-multi-indices"></div>
-    <h2>Autocomplete displaying hits and facets</h2>
-    <div id="autocomplete-with-facets"></div>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>autocomplete with react-instantsearch</title>
+  <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/style.css">
+</head>
+
+<body>
+  <h2>Autocomplete targetting multiple indices</h2>
+  <div id="autocomplete-with-multi-indices"></div>
+</body>
+
 </html>

--- a/packages/react-instantsearch/examples/autocomplete/src/App-Multi-Index.js
+++ b/packages/react-instantsearch/examples/autocomplete/src/App-Multi-Index.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import { InstantSearch, Configure, Index } from 'react-instantsearch/dom';
-import {
-  connectAutoComplete,
-  connectHits,
-} from 'react-instantsearch/connectors';
+import { connectAutoComplete } from 'react-instantsearch/connectors';
 import Autosuggest from 'react-autosuggest';
 import 'react-instantsearch-theme-algolia/style.css';
 
@@ -15,16 +12,10 @@ const App = () => (
   >
     <AutoComplete />
     <Configure hitsPerPage={1} />
-    <Index indexName="bestbuy">
-      <VirtualHits />
-    </Index>
-    <Index indexName="airbnb">
-      <VirtualHits />
-    </Index>
+    <Index indexName="bestbuy" />
+    <Index indexName="airbnb" />
   </InstantSearch>
 );
-
-const VirtualHits = connectHits(() => null);
 
 const AutoComplete = connectAutoComplete(
   ({ hits, currentRefinement, refine }) => (

--- a/packages/react-instantsearch/examples/autocomplete/src/index.js
+++ b/packages/react-instantsearch/examples/autocomplete/src/index.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App-Multi-Index';
-import App2 from './App-Hits-And-Facets';
 
 ReactDOM.render(
   <App />,
   document.getElementById('autocomplete-with-multi-indices')
 );
-ReactDOM.render(<App2 />, document.getElementById('autocomplete-with-facets'));

--- a/packages/react-instantsearch/src/core/Index.js
+++ b/packages/react-instantsearch/src/core/Index.js
@@ -31,12 +31,38 @@ import React, { Component, Children } from 'react';
  * }
  */
 class Index extends Component {
+  constructor(props, context) {
+    super(props);
+    const { ais: { widgetsManager } } = context;
+
+    /*
+     we want <Index> to be seen as a regular widget. 
+     It means that with only <Index> present a new query will be sent to Algolia.
+     That way you don't need a virtual hits widget to use the connectAutoComplete. 
+    */
+    this.unregisterWidget = widgetsManager.registerWidget({
+      getSearchParameters: searchParameters =>
+        this.getSearchParameters.call(this, searchParameters, this.props),
+      multiIndexContext: {
+        targetedIndex: this.props.indexName,
+      },
+    });
+  }
+
+  componentWillUnmount() {
+    this.unregisterWidget();
+  }
+
   getChildContext() {
     return {
       multiIndexContext: {
         targetedIndex: this.props.indexName,
       },
     };
+  }
+
+  getSearchParameters(searchParameters, props) {
+    return searchParameters.setIndex(props.indexName);
   }
 
   render() {
@@ -58,8 +84,12 @@ Index.propTypes = {
 };
 
 Index.childContextTypes = {
-  // @TODO: more precise widgets manager propType
   multiIndexContext: PropTypes.object.isRequired,
+};
+
+Index.contextTypes = {
+  // @TODO: more precise widgets manager propType
+  ais: PropTypes.object.isRequired,
 };
 
 export default Index;

--- a/packages/react-instantsearch/src/core/Index.test.js
+++ b/packages/react-instantsearch/src/core/Index.test.js
@@ -1,0 +1,64 @@
+/* eslint-env jest, jasmine */
+/* eslint-disable max-len */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import Index from './Index';
+
+describe('Index', () => {
+  const DEFAULT_PROPS = {
+    indexName: 'foobar',
+    root: {
+      Root: 'div',
+    },
+  };
+
+  const registerWidget = jest.fn();
+  const widgetsManager = { registerWidget };
+
+  const context = {
+    ais: { widgetsManager },
+  };
+
+  it('validates its props', () => {
+    expect(() => {
+      mount(
+        <Index {...DEFAULT_PROPS}>
+          <div />
+        </Index>,
+        { context }
+      );
+    }).not.toThrow();
+
+    expect(() => {
+      mount(<Index {...DEFAULT_PROPS} />, { context });
+    }).not.toThrow();
+
+    expect(() => {
+      mount(
+        <Index {...DEFAULT_PROPS}>
+          <div />
+          <div />
+        </Index>,
+        { context }
+      );
+    }).not.toThrow();
+
+    expect(registerWidget.mock.calls.length).toBe(3);
+  });
+
+  it('exposes multi index context', () => {
+    const wrapper = mount(
+      <Index {...DEFAULT_PROPS}>
+        <div />
+      </Index>,
+      { context }
+    );
+
+    const childContext = wrapper.instance().getChildContext();
+    expect(childContext.multiIndexContext.targetedIndex).toBe(
+      DEFAULT_PROPS.indexName
+    );
+  });
+});

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
@@ -67,6 +67,11 @@ describe('createInstantSearchManager', () => {
           multiIndexContext: { targetedIndex: 'first' },
         });
 
+        ism.widgetsManager.registerWidget({
+          getSearchParameters: params => params.setIndex('second'),
+          multiIndexContext: { targetedIndex: 'second' },
+        });
+
         expect(ism.store.getState().results).toBe(null);
 
         return Promise.resolve().then(() => {
@@ -130,6 +135,10 @@ describe('createInstantSearchManager', () => {
         ism.widgetsManager.registerWidget({
           getSearchParameters: params => params.setPage(3),
           multiIndexContext: { targetedIndex: 'first' },
+        });
+        ism.widgetsManager.registerWidget({
+          getSearchParameters: params => params.setIndex('second'),
+          multiIndexContext: { targetedIndex: 'second' },
         });
 
         ism.onExternalStateUpdate({});

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -127,7 +127,7 @@ export default function createInstantSearchManager({
         const derivedHelper = helper.derive(() => {
           const parameters = derivatedSearchParameters.widgets.reduce(
             (res, widget) => widget.getSearchParameters(res),
-            sharedParameters.setIndex(index)
+            sharedParameters
           );
           indexMapping[parameters.index] = index;
           return parameters;

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -40,18 +40,12 @@ stories
       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
       indexName="ikea"
     >
-      <AutoComplete />
       <Configure hitsPerPage={1} />
-      <Index indexName="bestbuy">
-        <VirtualHits />
-      </Index>
-      <Index indexName="airbnb">
-        <VirtualHits />
-      </Index>
+      <Index indexName="bestbuy" />
+      <Index indexName="airbnb" />
+      <AutoComplete />
     </InstantSearch>
   ));
-
-const VirtualHits = connectHits(() => null);
 
 const AutoComplete = connectAutoComplete(
   ({ hits, currentRefinement, refine }) => (


### PR DESCRIPTION
see #15.

Now you can use `connectAutoComplete` like:

```js
<InstantSearch
      appId=""
      apiKey=""
      indexName="ikea"
    >
      <Configure hitsPerPage={1} />
      <Index indexName="bestbuy" />
      <Index indexName="airbnb" />
      <AutoComplete />
</InstantSearch>
```