### PR TITLE
docs(Widgets): update example imports

### DIFF
--- a/packages/react-instantsearch/src/widgets/ClearAll.js
+++ b/packages/react-instantsearch/src/widgets/ClearAll.js
@@ -14,7 +14,7 @@ import ClearAllComponent from '../components/ClearAll.js';
  * @example
  * import React from 'react';
  *
- * import {ClearAll, RefinementList} from '../packages/react-instantsearch/dom';
+ * import { ClearAll, RefinementList, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/Configure.js
+++ b/packages/react-instantsearch/src/widgets/Configure.js
@@ -18,7 +18,7 @@ import Configure from '../components/Configure';
  * @example
  * import React from 'react';
  *
- * import {Configure} from '../packages/react-instantsearch/dom';
+ * import { Configure, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/CurrentRefinements.js
+++ b/packages/react-instantsearch/src/widgets/CurrentRefinements.js
@@ -19,7 +19,7 @@ import CurrentRefinementsComponent from '../components/CurrentRefinements.js';
  * @example
  * import React from 'react';
  *
- * import {ClearAll, RefinementList} from '../packages/react-instantsearch/dom';
+ * import { CurrentRefinements, RefinementList, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
@@ -58,10 +58,7 @@ import HierarchicalMenuComponent from '../components/HierarchicalMenu.js';
  * @example
  * import React from 'react';
 
- * import {
- *   InstantSearch,
- *   HierarchicalMenu,
- * } from 'react-instantsearch/dom';
+ * import { HierarchicalMenu, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/Highlight.js
+++ b/packages/react-instantsearch/src/widgets/Highlight.js
@@ -13,7 +13,7 @@ import HighlightComponent from '../components/Highlight.js';
  * @example
  * import React from 'react';
  *
- * import {InstantSearch, connectHits, Highlight} from 'InstantSearch';
+ * import { connectHits, Highlight, InstantSearch } from 'react-instantsearch/dom';
  *
  * const CustomHits = connectHits(hits => {
  *  return hits.map((hit) => <p><Highlight attributeName="description" hit={hit}/></p>);

--- a/packages/react-instantsearch/src/widgets/Hits.js
+++ b/packages/react-instantsearch/src/widgets/Hits.js
@@ -16,10 +16,7 @@ import HitsComponent from '../components/Hits.js';
  * @example
  * import React from 'react';
 
- * import {
- *   InstantSearch,
- *   Hits,
- * } from 'react-instantsearch/dom';
+ * import { Hits, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/HitsPerPage.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage.js
@@ -17,10 +17,7 @@ import HitsPerPageSelectComponent from '../components/HitsPerPage.js';
  * @example
  * import React from 'react';
 
- * import {
- *   InstantSearch,
- *   HitsPerPage,
- * } from 'react-instantsearch/dom';
+ * import { HitsPerPage, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/InfiniteHits.js
+++ b/packages/react-instantsearch/src/widgets/InfiniteHits.js
@@ -17,10 +17,7 @@ import InfiniteHitsComponent from '../components/InfiniteHits.js';
  * @example
  * import React from 'react';
 
- * import {
- *   InstantSearch,
- *   Hits,
- * } from 'react-instantsearch/dom';
+ * import { InfiniteHits, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/Menu.js
+++ b/packages/react-instantsearch/src/widgets/Menu.js
@@ -31,7 +31,7 @@ import MenuComponent from '../components/Menu.js';
  * @example
  * import React from 'react';
  *
- * import {Menu, InstantSearch} from '../packages/react-instantsearch/dom';
+ * import { Menu, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/MultiRange.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange.js
@@ -24,9 +24,9 @@ import MultiRangeComponent from '../components/MultiRange.js';
  * @translationkey all - The label of the largest range added automatically by react instantsearch
  * @example
  * import React from 'react';
- *
- * import {InstantSearch, MultiRange} from '../packages/react-instantsearch/dom';
- *
+ * 
+ * import { MultiRange, InstantSearch } from 'react-instantsearch/dom';
+ * 
  * export default function App() {
  *   return (
  *     <InstantSearch
@@ -34,14 +34,15 @@ import MultiRangeComponent from '../components/MultiRange.js';
  *       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
  *       indexName="ikea"
  *     >
- *       <MultiRange attributeName="price"
- *           items={[
- *             {end: 10, label: '<$10'},
- *             {start: 10, end: 100, label: '$10-$100'},
- *             {start: 100, end: 500, label: '$100-$500'},
- *             {start: 500, label: '>$500'},
- *           ]}
- *        />
+ *       <MultiRange
+ *         attributeName="price"
+ *         items={[
+ *           { end: 10, label: '<$10' },
+ *           { start: 10, end: 100, label: '$10-$100' },
+ *           { start: 100, end: 500, label: '$100-$500' },
+ *           { start: 500, label: '>$500' },
+ *         ]}
+ *       />
  *     </InstantSearch>
  *   );
  * }

--- a/packages/react-instantsearch/src/widgets/Pagination.js
+++ b/packages/react-instantsearch/src/widgets/Pagination.js
@@ -35,7 +35,7 @@ import PaginationComponent from '../components/Pagination.js';
  * @example
  * import React from 'react';
  *
- * import {Pagination, InstantSearch} from '../packages/react-instantsearch/dom';
+ * import { Pagination, InstantSearch } from '../packages/react-instantsearch/dom';
  *
  * export default function App() {
  *   return (
@@ -44,7 +44,7 @@ import PaginationComponent from '../components/Pagination.js';
  *       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
  *       indexName="ikea"
  *     >
- *         <Pagination/>
+ *       <Pagination />
  *     </InstantSearch>
  *   );
  * }

--- a/packages/react-instantsearch/src/widgets/Panel.js
+++ b/packages/react-instantsearch/src/widgets/Panel.js
@@ -12,11 +12,11 @@ import Panel from '../components/Panel.js';
  * @themeKey ais-Panel__root - Container of the widget
  * @themeKey ais-Panel__title - The panel title
  * @themeKey ais-Panel__noRefinement - Present if the panel content is empty
-* @example
+ * @example
  * import React from 'react';
- *
- * import {Panel, RefinementList, InstantSearch} from '../packages/react-instantsearch/dom';
- *
+ * 
+ * import { Panel, RefinementList, InstantSearch } from 'react-instantsearch/dom';
+ * 
  * export default function App() {
  *   return (
  *     <InstantSearch
@@ -25,7 +25,7 @@ import Panel from '../components/Panel.js';
  *       indexName="ikea"
  *     >
  *       <Panel title="category">
- *            <RefinementList attributeName="category" />
+ *         <RefinementList attributeName="category" />
  *       </Panel>
  *     </InstantSearch>
  *   );

--- a/packages/react-instantsearch/src/widgets/PoweredBy.js
+++ b/packages/react-instantsearch/src/widgets/PoweredBy.js
@@ -14,7 +14,7 @@ import PoweredByComponent from '../components/PoweredBy.js';
  * @example
  * import React from 'react';
  *
- * import {PoweredBy, InstantSearch} from '../packages/react-instantsearch/dom';
+ * import { PoweredBy, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/RangeInput.js
+++ b/packages/react-instantsearch/src/widgets/RangeInput.js
@@ -23,7 +23,7 @@ import RangeInputComponent from '../components/RangeInput.js';
  * @example
  * import React from 'react';
  *
- * import {RangeInput, InstantSearch} from '../packages/react-instantsearch/dom';
+ * import { RangeInput, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (
@@ -32,7 +32,7 @@ import RangeInputComponent from '../components/RangeInput.js';
  *       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
  *       indexName="ikea"
  *     >
- *        <RangeInput attributeName="price"/>
+ *       <RangeInput attributeName="price"/>
  *     </InstantSearch>
  *   );
  * }

--- a/packages/react-instantsearch/src/widgets/RefinementList.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList.js
@@ -32,7 +32,7 @@ import RefinementListComponent from '../components/RefinementList.js';
  * @example
  * import React from 'react';
  *
- * import {RefinementList, InstantSearch} from '../packages/react-instantsearch/dom';
+ * import { RefinementList, InstantSearch } from '../packages/react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/ScrollTo.js
+++ b/packages/react-instantsearch/src/widgets/ScrollTo.js
@@ -12,7 +12,7 @@ import ScrollToComponent from '../components/ScrollTo.js';
  * @example
  * import React from 'react';
  *
- * import {ScrollTo, Hits, InstantSearch} from '../packages/react-instantsearch/dom';
+ * import { ScrollTo, Hits, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (
@@ -22,7 +22,7 @@ import ScrollToComponent from '../components/ScrollTo.js';
  *       indexName="ikea"
  *     >
  *       <ScrollTo>
- *            <Hits />
+ *         <Hits />
  *       </ScrollTo>
  *     </InstantSearch>
  *   );

--- a/packages/react-instantsearch/src/widgets/SearchBox.js
+++ b/packages/react-instantsearch/src/widgets/SearchBox.js
@@ -25,7 +25,7 @@ import SearchBoxComponent from '../components/SearchBox.js';
  * @example
  * import React from 'react';
  *
- * import {SearchBox, InstantSearch} from '../packages/react-instantsearch/dom';
+ * import { SearchBox, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/Snippet.js
+++ b/packages/react-instantsearch/src/widgets/Snippet.js
@@ -13,7 +13,7 @@ import SnippetComponent from '../components/Snippet.js';
  * @example
  * import React from 'react';
  *
- * import {InstantSearch, connectHits, Snippet} from 'InstantSearch';
+ * import { connectHits, Snippet, InstantSearch } from 'react-instantsearch/dom';
  *
  * const CustomHits = connectHits(hits => {
  *  return hits.map((hit) => <p><Snippet attributeName="description" hit={hit}/></p>);

--- a/packages/react-instantsearch/src/widgets/SortBy.js
+++ b/packages/react-instantsearch/src/widgets/SortBy.js
@@ -13,9 +13,9 @@ import SortByComponent from '../components/SortBy.js';
  * @themeKey ais-SortBy__root - the root of the component
  * @example
  * import React from 'react';
- *
- * import {SortBy, InstantSearch} from '../packages/react-instantsearch/dom';
- *
+ * 
+ * import { SortBy, InstantSearch } from 'react-instantsearch/dom';
+ * 
  * export default function App() {
  *   return (
  *     <InstantSearch
@@ -24,14 +24,15 @@ import SortByComponent from '../components/SortBy.js';
  *       indexName="ikea"
  *     >
  *       <SortBy
- *          items={[
- *            {value: 'ikea', label: 'Featured'},
- *            {value: 'ikea_price_asc', label: 'Price asc.'},
- *            {value: 'ikea_price_desc', label: 'Price desc.'},
- *          ]}
- *          defaultRefinement="ikea"
- *        />
+ *         items={[
+ *           { value: 'ikea', label: 'Featured' },
+ *           { value: 'ikea_price_asc', label: 'Price asc.' },
+ *           { value: 'ikea_price_desc', label: 'Price desc.' },
+ *         ]}
+ *         defaultRefinement="ikea"
+ *       />
  *     </InstantSearch>
  *   );
- * } */
+ * }
+ */
 export default connectSortBy(SortByComponent);

--- a/packages/react-instantsearch/src/widgets/StarRating.js
+++ b/packages/react-instantsearch/src/widgets/StarRating.js
@@ -33,7 +33,7 @@ import StarRatingComponent from '../components/StarRating.js';
  * @example
  * import React from 'react';
  *
- * import {StarRating, InstantSearch} from '../packages/react-instantsearch/dom';
+ * import { StarRating, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/Stats.js
+++ b/packages/react-instantsearch/src/widgets/Stats.js
@@ -10,7 +10,7 @@ import StatsComponent from '../components/Stats.js';
  * @example
  * import React from 'react';
  *
- * import {Stats, InstantSearch} from '../packages/react-instantsearch/dom';
+ * import { Stats, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (

--- a/packages/react-instantsearch/src/widgets/Toggle.js
+++ b/packages/react-instantsearch/src/widgets/Toggle.js
@@ -14,9 +14,9 @@ import ToggleComponent from '../components/Toggle.js';
  * @themeKey ais-Toggle__label - the toggle label
  * @example
  * import React from 'react';
- *
- * import {Toggle, InstantSearch} from '../packages/react-instantsearch/dom';
- *
+ * 
+ * import { Toggle, InstantSearch } from 'react-instantsearch/dom';
+ * 
  * export default function App() {
  *   return (
  *     <InstantSearch
@@ -24,10 +24,11 @@ import ToggleComponent from '../components/Toggle.js';
  *       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
  *       indexName="ikea"
  *     >
- *       <Toggle attributeName="materials"
- *           label="Made with solid pine"
- *           value={'Solid pine'}
- *        />
+ *       <Toggle
+ *         attributeName="materials"
+ *         label="Made with solid pine"
+ *         value={'Solid pine'}
+ *       />
  *     </InstantSearch>
  *   );
  * }


### PR DESCRIPTION
**Summary**

The examples in the widget jsdoc were outdated, and using wrong imports.

**Result**

All examples of the widget now have the correct imported widgets, *and* the correct package imported from.

closes #50

cc @davidfurlong