### PR TITLE
fix(MultIndex): no need to nest hits, if those are from main index.

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -21,6 +21,7 @@ describe('connectHierarchicalMenu', () => {
       const results = {
         getFacetValues: jest.fn(),
         getFacetByName: () => true,
+        hits: [],
       };
 
       results.getFacetValues.mockImplementationOnce(() => ({}));

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -24,6 +24,7 @@ describe('connectMenu', () => {
       const results = {
         getFacetValues: jest.fn(() => []),
         getFacetByName: () => true,
+        hits: [],
       };
 
       props = getProvidedProps({ attributeName: 'ok' }, {}, {});
@@ -210,6 +211,7 @@ describe('connectMenu', () => {
       const results = {
         getFacetValues: jest.fn(() => []),
         getFacetByName: () => true,
+        hits: [],
       };
       results.getFacetValues.mockImplementation(() => [
         {
@@ -383,6 +385,7 @@ describe('connectMenu', () => {
       const results = {
         getFacetValues: jest.fn(() => []),
         getFacetByName: () => true,
+        hits: [],
       };
       results.getFacetValues.mockClear();
       results.getFacetValues.mockImplementation(() => [

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
@@ -20,6 +20,7 @@ describe('connectMultiRange', () => {
     const results = {
       getFacetStats: () => ({ min: 0, max: 300 }),
       getFacetByName: () => true,
+      hits: [],
     };
 
     it('provides the correct props to the component', () => {

--- a/packages/react-instantsearch/src/connectors/connectPagination.test.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.test.js
@@ -18,14 +18,18 @@ describe('connectPagination', () => {
     const cleanUp = connect.cleanUp.bind(context);
 
     it('provides the correct props to the component', () => {
-      props = getProvidedProps({}, {}, { results: { nbPages: 666 } });
+      props = getProvidedProps({}, {}, { results: { nbPages: 666, hits: [] } });
       expect(props).toEqual({
         currentRefinement: 1,
         nbPages: 666,
         canRefine: true,
       });
 
-      props = getProvidedProps({}, { page: 5 }, { results: { nbPages: 666 } });
+      props = getProvidedProps(
+        {},
+        { page: 5 },
+        { results: { nbPages: 666, hits: [] } }
+      );
       expect(props).toEqual({
         currentRefinement: 5,
         nbPages: 666,
@@ -35,7 +39,7 @@ describe('connectPagination', () => {
       props = getProvidedProps(
         {},
         { page: '5' },
-        { results: { nbPages: 666 } }
+        { results: { nbPages: 666, hits: [] } }
       );
       expect(props).toEqual({
         currentRefinement: 5,
@@ -43,7 +47,11 @@ describe('connectPagination', () => {
         canRefine: true,
       });
 
-      props = getProvidedProps({}, { page: '1' }, { results: { nbPages: 1 } });
+      props = getProvidedProps(
+        {},
+        { page: '1' },
+        { results: { nbPages: 1, hits: [] } }
+      );
       expect(props).toEqual({
         currentRefinement: 1,
         nbPages: 1,

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -38,6 +38,7 @@ describe('connectRange', () => {
           { name: '2', count: 20 },
         ],
         getFacetByName: () => true,
+        hits: [],
       };
       props = getProvidedProps({ attributeName: 'ok' }, {}, { results });
       expect(props).toEqual({

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -23,6 +23,7 @@ describe('connectRefinementList', () => {
     const results = {
       getFacetValues: jest.fn(() => []),
       getFacetByName: () => true,
+      hits: [],
     };
 
     it('provides the correct props to the component', () => {

--- a/packages/react-instantsearch/src/connectors/connectStats.test.js
+++ b/packages/react-instantsearch/src/connectors/connectStats.test.js
@@ -13,7 +13,7 @@ describe('connectStats', () => {
       expect(props).toBe(null);
 
       props = getProvidedProps(null, null, {
-        results: { nbHits: 666, processingTimeMS: 1 },
+        results: { nbHits: 666, processingTimeMS: 1, hits: [] },
       });
       expect(props).toEqual({ nbHits: 666, processingTimeMS: 1 });
     });

--- a/packages/react-instantsearch/src/core/indexUtils.js
+++ b/packages/react-instantsearch/src/core/indexUtils.js
@@ -7,8 +7,8 @@ export function getIndex(context) {
 }
 
 export function getResults(searchResults, context) {
-  if (hasMultipleIndex(context)) {
-    return searchResults.results && searchResults.results[getIndex(context)]
+  if (searchResults.results && !searchResults.results.hits) {
+    return searchResults.results[getIndex(context)]
       ? searchResults.results[getIndex(context)]
       : null;
   } else {

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -189,11 +189,11 @@ describe('utility method for manipulating the search state', () => {
       });
     });
     it('get results', () => {
-      const searchResults = { results: { some: 'results' } };
+      const searchResults = { results: { hits: ['some'] } };
 
       const results = getResults(searchResults, context);
 
-      expect(results).toEqual({ some: 'results' });
+      expect(results).toEqual({ hits: ['some'] });
     });
   });
   describe('when there are multiple index', () => {
@@ -385,9 +385,17 @@ describe('utility method for manipulating the search state', () => {
     });
 
     it('get results', () => {
-      const searchResults = { results: { first: { some: 'results' } } };
+      let searchResults = { results: { first: { some: 'results' } } };
 
-      const results = getResults(searchResults, context);
+      let results = getResults(searchResults, context);
+
+      expect(results).toEqual({ some: 'results' });
+
+      searchResults = { results: { first: { some: 'results' } } };
+
+      results = getResults(searchResults, {
+        ais: { mainTargetedIndex: 'first' },
+      });
 
       expect(results).toEqual({ some: 'results' });
     });


### PR DESCRIPTION
This was a regression due to: https://github.com/algolia/react-instantsearch/pull/36

See: https://github.com/algolia/react-instantsearch/issues/55

Allows this syntax: 

```js
<InstantSearch
      appId=""
      apiKey=""
      indexName="index1"
>
  <SearchBox />
      <CustomHits />
  <Index indexName="index2">
      <CustomHits />
  </Index>
</InstantSearch>
```