### PR TITLE
fix(core/InstantSearch): update algoliaClient when it change

### DIFF
--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -68,6 +68,10 @@ class InstantSearch extends Component {
     if (this.props.indexName !== nextProps.indexName) {
       this.aisManager.updateIndex(nextProps.indexName);
     }
+    
+    if (this.props.algoliaClient !== nextProps.algoliaClient) {
+      this.aisManager.updateClient(nextProps.algoliaClient)
+    }
 
     if (this.isControlled) {
       this.aisManager.onExternalStateUpdate(nextProps.searchState);

--- a/packages/react-instantsearch/src/core/InstantSearch.test.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.test.js
@@ -119,6 +119,27 @@ describe('InstantSearch', () => {
     });
   });
 
+  it('updates Algolia client when new one is given in props', () => {
+    const ism = {
+      updateClient: jest.fn(),
+    };
+
+    createInstantSearchManager.mockImplementation(() => ism);
+
+    const wrapper = mount(
+      <InstantSearch {...DEFAULT_PROPS}>
+        <div />
+      </InstantSearch>
+    );
+
+    expect(ism.updateClient.mock.calls.length).toBe(0);
+    wrapper.setProps({
+      ...DEFAULT_PROPS,
+      algoliaClient: {},
+    });
+    expect(ism.updateClient.mock.calls.length).toBe(1);
+  });
+
   it('works as a controlled input', () => {
     const ism = {
       transitionState: searchState => ({ ...searchState, transitioned: true }),


### PR DESCRIPTION
**Summary**

ApiKey parameter is not changed in search query when InstantSearch component is updated with new apiKey props.
Algolia client is updated with new values if appId or apiKey is changed (at createInstantSearch.js:39) but helper in InstantSearchManager (created in InstantSearch component) is not updated.

**Result**

I created component that render InstantSearch with apiKey "exampleApiKey1" then i changed component state (with setTimeout for the example) to render InstantSearch again but with a new apiKey props. (exampleApiKey2)

Without my fix, ajax call is always called with exampleApiKey1

http://image.prntscr.com/image/c5a1670088ad4e7b9edfaff72ec9479b.png

With my fix, ajax get is called with exampleApiKey1 then exampleApiKey2 after rendering with the new props (see screens)

http://image.prntscr.com/image/a68d4384ff16488f83813e98b91478cb.png

Thanks