### PR TITLE
fix(connectAutoComplete): allow usage with hits from a single index

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectAutoComplete.js
+++ b/packages/react-instantsearch/src/connectors/connectAutoComplete.js
@@ -14,6 +14,29 @@ function getCurrentRefinement(props, searchState) {
   return '';
 }
 
+function getHits(searchResults) {
+  if (searchResults.results) {
+    if (
+      searchResults.results.hits && Array.isArray(searchResults.results.hits)
+    ) {
+      return searchResults.results.hits;
+    } else {
+      return Object.keys(searchResults.results).reduce(
+        (hits, index) => [
+          ...hits,
+          {
+            index,
+            hits: searchResults.results[index].hits,
+          },
+        ],
+        []
+      );
+    }
+  } else {
+    return [];
+  }
+}
+
 /**
  * connectAutoComplete connector provides the logic to create connected
  * components that will render the results retrieved from
@@ -32,14 +55,8 @@ export default createConnector({
   displayName: 'AlgoliaAutoComplete',
 
   getProvidedProps(props, searchState, searchResults) {
-    const hits = [];
-    if (searchResults.results) {
-      Object.keys(searchResults.results).forEach(index => {
-        hits.push({ index, hits: searchResults.results[index].hits });
-      });
-    }
     return {
-      hits,
+      hits: getHits(searchResults),
       currentRefinement: getCurrentRefinement(props, searchState),
     };
   },

--- a/packages/react-instantsearch/src/connectors/connectAutoComplete.js
+++ b/packages/react-instantsearch/src/connectors/connectAutoComplete.js
@@ -1,10 +1,8 @@
 import createConnector from '../core/createConnector';
-import { omit } from 'lodash';
 import {
   cleanUpValue,
   refineValue,
   getCurrentRefinementValue,
-  getIndex,
 } from '../core/indexUtils';
 
 const getId = () => 'query';

--- a/packages/react-instantsearch/src/connectors/connectAutoComplete.test.js
+++ b/packages/react-instantsearch/src/connectors/connectAutoComplete.test.js
@@ -5,62 +5,14 @@ import { SearchParameters } from 'algoliasearch-helper';
 
 jest.mock('../core/createConnector');
 
-const { getSearchParameters, refine } = connect;
-
 describe('connectAutoComplete', () => {
-  const context = {};
-  const getProvidedProps = connect.getProvidedProps.bind(context);
-  describe('provides current hits to the component', () => {
-    it('for multi-index', () => {
-      const firstHits = [{}];
-      const secondHits = [{}];
-      let props = getProvidedProps(
-        {},
-        {},
-        {
-          results: { first: { hits: firstHits }, second: { hits: secondHits } },
-        }
-      );
-      expect(props).toEqual({
-        hits: [
-          { hits: firstHits, index: 'first' },
-          { hits: secondHits, index: 'second' },
-        ],
-        currentRefinement: '',
-      });
-
-      props = getProvidedProps(
-        {},
-        { query: 'query' },
-        {
-          results: { first: { hits: firstHits }, second: { hits: secondHits } },
-        }
-      );
-      expect(props).toEqual({
-        hits: [
-          { hits: firstHits, index: 'first' },
-          { hits: secondHits, index: 'second' },
-        ],
-        currentRefinement: 'query',
-      });
-
-      props = getProvidedProps(
-        { defaultRefinement: 'query' },
-        {},
-        {
-          results: { first: { hits: firstHits }, second: { hits: secondHits } },
-        }
-      );
-      expect(props).toEqual({
-        hits: [
-          { hits: firstHits, index: 'first' },
-          { hits: secondHits, index: 'second' },
-        ],
-        currentRefinement: 'query',
-      });
-    });
-
-    it('for single index', () => {
+  describe('single index', () => {
+    const context = { context: { ais: { mainTargetedIndex: 'index' } } };
+    const getProvidedProps = connect.getProvidedProps.bind(context);
+    const refine = connect.refine.bind(context);
+    const getSearchParameters = connect.getSearchParameters.bind(context);
+    const cleanUp = connect.cleanUp.bind(context);
+    it('provides current hits to the component', () => {
       const hits = [{}];
       let props = getProvidedProps(
         {},
@@ -98,22 +50,121 @@ describe('connectAutoComplete', () => {
         currentRefinement: 'query',
       });
     });
-  });
+    it('refines the query parameter', () => {
+      const params = getSearchParameters(
+        new SearchParameters(),
+        {},
+        { query: 'bar' }
+      );
+      expect(params.query).toBe('bar');
+    });
 
-  it('refines the query parameter', () => {
-    const params = getSearchParameters(
-      new SearchParameters(),
-      {},
-      { query: 'bar' }
-    );
-    expect(params.query).toBe('bar');
+    it("calling refine updates the widget's search state", () => {
+      const nextState = refine({}, { otherKey: 'val' }, 'yep');
+      expect(nextState).toEqual({
+        otherKey: 'val',
+        query: 'yep',
+        page: 1,
+      });
+    });
+    it('should return the right searchState when clean up', () => {
+      const searchState = cleanUp(
+        {},
+        {
+          query: { searchState: 'searchState' },
+          another: { searchState: 'searchState' },
+        }
+      );
+      expect(searchState).toEqual({ another: { searchState: 'searchState' } });
+    });
   });
+  describe('multi index', () => {
+    let context = {
+      context: {
+        ais: { mainTargetedIndex: 'first' },
+        multiIndexContext: { targetedIndex: 'first' },
+      },
+    };
+    const getProvidedProps = connect.getProvidedProps.bind(context);
+    const getSearchParameters = connect.getSearchParameters.bind(context);
+    const refine = connect.refine.bind(context);
+    const cleanUp = connect.cleanUp.bind(context);
+    it('provides current hits to the component', () => {
+      const firstHits = [{}];
+      const secondHits = [{}];
+      let props = getProvidedProps(
+        {},
+        {},
+        {
+          results: { first: { hits: firstHits }, second: { hits: secondHits } },
+        }
+      );
+      expect(props).toEqual({
+        hits: [
+          { hits: firstHits, index: 'first' },
+          { hits: secondHits, index: 'second' },
+        ],
+        currentRefinement: '',
+      });
 
-  it("calling refine updates the widget's search state", () => {
-    const nextState = refine({}, { otherKey: 'val' }, 'yep');
-    expect(nextState).toEqual({
-      otherKey: 'val',
-      query: 'yep',
+      props = getProvidedProps(
+        {},
+        { indices: { first: { query: 'query' } } },
+        {
+          results: { first: { hits: firstHits }, second: { hits: secondHits } },
+        }
+      );
+      expect(props).toEqual({
+        hits: [
+          { hits: firstHits, index: 'first' },
+          { hits: secondHits, index: 'second' },
+        ],
+        currentRefinement: 'query',
+      });
+
+      props = getProvidedProps(
+        { defaultRefinement: 'query' },
+        {},
+        {
+          results: { first: { hits: firstHits }, second: { hits: secondHits } },
+        }
+      );
+      expect(props).toEqual({
+        hits: [
+          { hits: firstHits, index: 'first' },
+          { hits: secondHits, index: 'second' },
+        ],
+        currentRefinement: 'query',
+      });
+    });
+    it('refines the query parameter', () => {
+      const params = getSearchParameters(
+        new SearchParameters(),
+        {},
+        { indices: { first: { query: 'bar' } } }
+      );
+      expect(params.query).toBe('bar');
+    });
+
+    it("calling refine updates the widget's search state", () => {
+      const nextState = refine({}, { otherKey: 'val' }, 'yep');
+      expect(nextState).toEqual({
+        otherKey: 'val',
+        indices: { first: { query: 'yep', page: 1 } },
+      });
+    });
+    it('should return the right searchState when clean up', () => {
+      const searchState = cleanUp(
+        {},
+        {
+          indices: { first: { query: '' } },
+          another: { searchState: 'searchState' },
+        }
+      );
+      expect(searchState).toEqual({
+        indices: { first: {} },
+        another: { searchState: 'searchState' },
+      });
     });
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectAutoComplete.test.js
+++ b/packages/react-instantsearch/src/connectors/connectAutoComplete.test.js
@@ -10,52 +10,93 @@ const { getSearchParameters, refine } = connect;
 describe('connectAutoComplete', () => {
   const context = {};
   const getProvidedProps = connect.getProvidedProps.bind(context);
-  it('provides current hits to the component', () => {
-    const firstHits = [{}];
-    const secondHits = [{}];
-    let props = getProvidedProps(
-      {},
-      {},
-      {
-        results: { first: { hits: firstHits }, second: { hits: secondHits } },
-      }
-    );
-    expect(props).toEqual({
-      hits: [
-        { hits: firstHits, index: 'first' },
-        { hits: secondHits, index: 'second' },
-      ],
-      currentRefinement: '',
+  describe('provides current hits to the component', () => {
+    it('for multi-index', () => {
+      const firstHits = [{}];
+      const secondHits = [{}];
+      let props = getProvidedProps(
+        {},
+        {},
+        {
+          results: { first: { hits: firstHits }, second: { hits: secondHits } },
+        }
+      );
+      expect(props).toEqual({
+        hits: [
+          { hits: firstHits, index: 'first' },
+          { hits: secondHits, index: 'second' },
+        ],
+        currentRefinement: '',
+      });
+
+      props = getProvidedProps(
+        {},
+        { query: 'query' },
+        {
+          results: { first: { hits: firstHits }, second: { hits: secondHits } },
+        }
+      );
+      expect(props).toEqual({
+        hits: [
+          { hits: firstHits, index: 'first' },
+          { hits: secondHits, index: 'second' },
+        ],
+        currentRefinement: 'query',
+      });
+
+      props = getProvidedProps(
+        { defaultRefinement: 'query' },
+        {},
+        {
+          results: { first: { hits: firstHits }, second: { hits: secondHits } },
+        }
+      );
+      expect(props).toEqual({
+        hits: [
+          { hits: firstHits, index: 'first' },
+          { hits: secondHits, index: 'second' },
+        ],
+        currentRefinement: 'query',
+      });
     });
 
-    props = getProvidedProps(
-      {},
-      { query: 'query' },
-      {
-        results: { first: { hits: firstHits }, second: { hits: secondHits } },
-      }
-    );
-    expect(props).toEqual({
-      hits: [
-        { hits: firstHits, index: 'first' },
-        { hits: secondHits, index: 'second' },
-      ],
-      currentRefinement: 'query',
-    });
+    it('for single index', () => {
+      const hits = [{}];
+      let props = getProvidedProps(
+        {},
+        {},
+        {
+          results: { hits },
+        }
+      );
+      expect(props).toEqual({
+        hits,
+        currentRefinement: '',
+      });
 
-    props = getProvidedProps(
-      { defaultRefinement: 'query' },
-      {},
-      {
-        results: { first: { hits: firstHits }, second: { hits: secondHits } },
-      }
-    );
-    expect(props).toEqual({
-      hits: [
-        { hits: firstHits, index: 'first' },
-        { hits: secondHits, index: 'second' },
-      ],
-      currentRefinement: 'query',
+      props = getProvidedProps(
+        {},
+        { query: 'query' },
+        {
+          results: { hits },
+        }
+      );
+      expect(props).toEqual({
+        hits,
+        currentRefinement: 'query',
+      });
+
+      props = getProvidedProps(
+        { defaultRefinement: 'query' },
+        {},
+        {
+          results: { hits },
+        }
+      );
+      expect(props).toEqual({
+        hits,
+        currentRefinement: 'query',
+      });
     });
   });
 

--- a/packages/react-instantsearch/src/connectors/connectAutoComplete.test.js
+++ b/packages/react-instantsearch/src/connectors/connectAutoComplete.test.js
@@ -79,7 +79,7 @@ describe('connectAutoComplete', () => {
     });
   });
   describe('multi index', () => {
-    let context = {
+    const context = {
       context: {
         ais: { mainTargetedIndex: 'first' },
         multiIndexContext: { targetedIndex: 'first' },


### PR DESCRIPTION
**Summary**

fixes #74

the strategy to get the hits from all indices assumed it needed to loop over the index names, but that’s only true if we’re in a situation with multiple hits. 

You can detect this if there is a `hits` key on the `searchResults`, and in that case we can just return the hits

**Result**

No more iteration over the `searchResults` object if there is a `hits` (which is an array) key on it.