### PR TITLE
docs(geo-search): fix typo

### DIFF
--- a/packages/react-instantsearch/examples/geo-search/src/App.js
+++ b/packages/react-instantsearch/examples/geo-search/src/App.js
@@ -71,7 +71,7 @@ class App extends Component {
         onSearchStateChange={this.onSearchStateChange}
       >
         {configuration}
-        Either type a destination or click somewhere on the map to see the closest appartement.
+        Either type a destination or click somewhere on the map to see the closest apartment.
         <SearchBox />
         <div className="map">
           <ConnectedHitsMap onLatLngChange={this.onLatLngChange} />


### PR DESCRIPTION


**Summary**

Fix a typo in the geo-search demo

**Result**

appartement -> apartment