### PR TITLE
docs(discourse): update links to correct discourse tag

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
   This form is to report issues or new features.
   As for general questions like "How to do routing using React InstantSearch",
-  please search or post a question to our discourse forum: https://discourse.algolia.com/.
+  please search or post a question to our discourse forum: https://discourse.algolia.com/tags/react-instantsearch.
 
   In any case,
     - make sure you are using the latest version of the library;

--- a/docgen/layouts/index.pug
+++ b/docgen/layouts/index.pug
@@ -241,7 +241,7 @@ block content
         ul
           li Share your awesome projects <svg><use xlink:href="#check-icon"></svg>
           li Find useful tips & solutions <svg><use xlink:href="#check-icon"></svg>
-        a(href="https://discourse.algolia.com/c/instantsearch", class="btn btn-ghost btn-ghost-blue") Join us on discourse&nbsp;&gt;
+        a(href="https://discourse.algolia.com/tags/react-instantsearch", class="btn btn-ghost btn-ghost-blue") Join us on discourse&nbsp;&gt;
 
     div.footer__call-to-action
       .container

--- a/docgen/src/examples/Demos.md
+++ b/docgen/src/examples/Demos.md
@@ -32,4 +32,4 @@ examplesEndpoint: examples
 ## Demos
 
 To demonstrate the flexibility of React InstantSearch we created some demos.
-If you think about a new example or have any questions about them, [come talk to us](https://discourse.algolia.com/c/instantsearch).
+If you think about a new example or have any questions about them, [come talk to us](https://discourse.algolia.com/tags/react-instantsearch).

--- a/docgen/src/examples/Recipes.md
+++ b/docgen/src/examples/Recipes.md
@@ -30,4 +30,4 @@ examplesEndpoint: https://github.com/algolia/react-instantsearch/tree/master/pac
 ## Recipes
 
 To demonstrate more complex use cases of React InstantSearch we created some recipes.
-If you think about a new recipe or have any questions about them, [come talk to us](https://discourse.algolia.com/c/instantsearch).
+If you think about a new recipe or have any questions about them, [come talk to us](https://discourse.algolia.com/tags/react-instantsearch).

--- a/docgen/src/guide/Custom_connectors.md
+++ b/docgen/src/guide/Custom_connectors.md
@@ -14,7 +14,7 @@ most use cases in with simple API entries. But we could not plan everything and 
 in some cases the current API may not be able to fulfill this promise of simplicity.
 
 If that's not the case or in doubt, **before diving into custom conectors**
-please expose us your use case and come ask us questions on [discourse](https://discourse.algolia.com/c/instantsearch)
+please expose us your use case and come ask us questions on [discourse](https://discourse.algolia.com/tags/react-instantsearch)
 or [GitHub](https://github.com/algolia/react-instantsearch/issues) first. We will be glad
 that you do so.
 


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Discourse links are outdated/not specific enough

fixes #82 

**Result**

update the links from `/c/instantsearch` and `/` to `/tags/react-instantsearch`
