### PR TITLE
fix(InstantSearch): dont fire request/onsearchStateChange when unmounting

### DIFF
--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -49,8 +49,8 @@ class InstantSearch extends Component {
     super(props);
 
     this.isControlled = Boolean(props.searchState);
-
     const initialState = this.isControlled ? props.searchState : {};
+    this.isUnmounting = false;
 
     this.aisManager = createInstantSearchManager({
       indexName: props.indexName,
@@ -70,6 +70,11 @@ class InstantSearch extends Component {
     if (this.isControlled) {
       this.aisManager.onExternalStateUpdate(nextProps.searchState);
     }
+  }
+
+  componentWillUnmount() {
+    this.isUnmounting = true;
+    this.aisManager.skipSearch();
   }
 
   getChildContext() {
@@ -111,7 +116,7 @@ class InstantSearch extends Component {
   }
 
   onSearchStateChange(searchState) {
-    if (this.props.onSearchStateChange) {
+    if (this.props.onSearchStateChange && !this.isUnmounting) {
       this.props.onSearchStateChange(searchState);
     }
   }

--- a/packages/react-instantsearch/src/core/InstantSearch.test.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.test.js
@@ -193,6 +193,31 @@ describe('InstantSearch', () => {
     expect(context.ais.widgetsManager).toBe(ism.widgetsManager);
   });
 
+  it('onSearchStateChange should not be called and search should be skipped if the widget is unmounting', () => {
+    const ism = {
+      skipSearch: jest.fn(),
+    };
+    createInstantSearchManager.mockImplementation(() => ism);
+    const onSearchStateChangeMock = jest.fn();
+    const wrapper = mount(
+      <InstantSearch
+        {...DEFAULT_PROPS}
+        onSearchStateChange={onSearchStateChangeMock}
+      >
+        <div />
+      </InstantSearch>
+    );
+    const {
+      ais: {onSearchStateChange},
+    } = wrapper.instance().getChildContext();
+
+    wrapper.unmount();
+    onSearchStateChange({});
+
+    expect(onSearchStateChangeMock.mock.calls.length).toBe(0);
+    expect(ism.skipSearch.mock.calls.length).toBe(1);
+  });
+
   describe('createHrefForState', () => {
     it('passes through to createURL when it is defined', () => {
       const widgetsIds = [];

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -127,7 +127,7 @@ export default function createConnector(connectorDesc) {
             ...this.context.ais.store.getState(),
             widgets: newState,
           });
-          this.context.ais.onInternalStateUpdate(newState);
+          this.context.ais.onSearchStateChange(newState);
         }
       }
     }

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -451,7 +451,7 @@ describe('createConnector', () => {
       })(() => null);
       const unregister = jest.fn();
       const setState = jest.fn();
-      const onInternalStateUpdate = jest.fn();
+      const onSearchStateChange = jest.fn();
       const wrapper = mount(<Connected />, {context: {
         ais: {
           store: {
@@ -462,20 +462,20 @@ describe('createConnector', () => {
           widgetsManager: {
             registerWidget: () => unregister,
           },
-          onInternalStateUpdate,
+          onSearchStateChange,
         },
       }});
       expect(unregister.mock.calls.length).toBe(0);
       expect(setState.mock.calls.length).toBe(0);
-      expect(onInternalStateUpdate.mock.calls.length).toBe(0);
+      expect(onSearchStateChange.mock.calls.length).toBe(0);
 
       wrapper.unmount();
 
       expect(unregister.mock.calls.length).toBe(1);
       expect(setState.mock.calls.length).toBe(1);
-      expect(onInternalStateUpdate.mock.calls.length).toBe(1);
+      expect(onSearchStateChange.mock.calls.length).toBe(1);
       expect(setState.mock.calls[0][0]).toEqual({widgets: {another: {state: 'state'}}});
-      expect(onInternalStateUpdate.mock.calls[0][0]).toEqual({another: {state: 'state'}});
+      expect(onSearchStateChange.mock.calls[0][0]).toEqual({another: {state: 'state'}});
     });
   });
 

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -41,6 +41,12 @@ export default function createInstantSearchManager({
     searching: false,
   });
 
+  let skip = false;
+
+  function skipSearch() {
+    skip = true;
+  }
+
   function updateClient(client) {
     helper.setClient(client);
     search();
@@ -62,10 +68,12 @@ export default function createInstantSearchManager({
   }
 
   function search() {
-    const widgetSearchParameters = getSearchParameters(helper.state);
+    if (!skip) {
+      const widgetSearchParameters = getSearchParameters(helper.state);
 
-    helper.setState(widgetSearchParameters)
-          .search();
+      helper.setState(widgetSearchParameters)
+            .search();
+    }
   }
 
   function handleSearchSuccess(content) {
@@ -178,5 +186,6 @@ export default function createInstantSearchManager({
     onSearchForFacetValues,
     updateClient,
     updateIndex,
+    skipSearch,
   };
 }

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
@@ -176,6 +176,27 @@ describe('createInstantSearchManager', () => {
         expect(client1.search).toHaveBeenCalledTimes(1);
       });
     });
+    it('should not be called when the search is skipped', () => {
+      const client0 = makeClient(defaultResponse);
+      expect(client0.search).toHaveBeenCalledTimes(0);
+      const ism = createInstantSearchManager({
+        indexName: 'index',
+        initialState: {},
+        searchParameters: {},
+        algoliaClient: client0,
+      });
+
+      ism.skipSearch();
+
+      ism.widgetsManager.registerWidget({
+        getMetadata: () => {},
+        transitionState: () => {},
+      });
+
+      return Promise.resolve().then(() => {
+        expect(client0.search).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Same fix than a31fb4b7b58ee32260a9e0c547f320ec3e4c8cdc but for our v3 version.