### PR TITLE
fix nested attributes for faceting

### DIFF
--- a/packages/react-instantsearch/src/core/indexUtils.js
+++ b/packages/react-instantsearch/src/core/indexUtils.js
@@ -162,13 +162,12 @@ export function getCurrentRefinementValue(
 
 export function cleanUpValue(searchState, context, id) {
   const index = getIndex(context);
-  let namespace;
 
   if (hasMultipleIndex(context)) {
     return omit(searchState, `indices.${index}.${id}`);
   }
 
-  namespace = getNamespaceAndId(id);
+  const namespace = getNamespaceAndId(id);
   if (namespace.namespace && namespace.id) {
     return {
       ...searchState,

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -111,6 +111,8 @@ describe('utility method for manipulating the search state', () => {
         },
       };
 
+      expect.assertions(5); //async assertions
+
       let expectedRefinement = value => expect(value).toEqual('refinement');
 
       getCurrentRefinementValue(
@@ -150,7 +152,7 @@ describe('utility method for manipulating the search state', () => {
         context,
         'refinement',
         'defaultValue',
-        expectedRefinement
+        () => {}
       );
 
       expect(value).toEqual('defaultValue');
@@ -161,7 +163,7 @@ describe('utility method for manipulating the search state', () => {
         context,
         'refinement',
         null,
-        expectedRefinement
+        () => {}
       );
 
       expect(value).toEqual('defaultRefinement');
@@ -336,10 +338,17 @@ describe('utility method for manipulating the search state', () => {
         refinement: 'refinement',
         indices: {
           first: {
-            namespace: { refinement: 'refinement', another: 'another' },
+            refinement: 'refinement',
+            namespace: {
+              refinement: 'refinement',
+              another: 'another',
+              'nested.another': 'nested.another',
+            },
           },
         },
       };
+
+      expect.assertions(6); //async assertions
 
       let expectedRefinement = value => expect(value).toEqual('refinement');
 
@@ -348,6 +357,17 @@ describe('utility method for manipulating the search state', () => {
         searchState,
         context,
         'refinement',
+        null,
+        expectedRefinement
+      );
+
+      expectedRefinement = value => expect(value).toEqual('refinement');
+
+      getCurrentRefinementValue(
+        {},
+        searchState,
+        context,
+        'namespace.refinement',
         null,
         expectedRefinement
       );
@@ -363,13 +383,24 @@ describe('utility method for manipulating the search state', () => {
         expectedRefinement
       );
 
+      expectedRefinement = value => expect(value).toEqual('nested.another');
+
+      getCurrentRefinementValue(
+        {},
+        searchState,
+        context,
+        'namespace.nested.another',
+        null,
+        expectedRefinement
+      );
+
       let value = getCurrentRefinementValue(
         {},
         {},
         context,
         'refinement',
         'defaultValue',
-        expectedRefinement
+        () => {}
       );
 
       expect(value).toEqual('defaultValue');
@@ -380,7 +411,7 @@ describe('utility method for manipulating the search state', () => {
         context,
         'refinement',
         null,
-        expectedRefinement
+        () => {}
       );
 
       expect(value).toEqual('defaultRefinement');
@@ -392,7 +423,11 @@ describe('utility method for manipulating the search state', () => {
         indices: {
           first: {
             refinement: 'refinement',
-            namespace: { refinement: 'refinement', another: 'another' },
+            namespace: {
+              refinement: 'refinement',
+              another: 'another',
+              'nested.another': 'nested.another',
+            },
           },
         },
       };
@@ -403,7 +438,11 @@ describe('utility method for manipulating the search state', () => {
         page: 1,
         indices: {
           first: {
-            namespace: { refinement: 'refinement', another: 'another' },
+            namespace: {
+              refinement: 'refinement',
+              another: 'another',
+              'nested.another': 'nested.another',
+            },
           },
         },
       });
@@ -412,14 +451,42 @@ describe('utility method for manipulating the search state', () => {
 
       expect(searchState).toEqual({
         page: 1,
-        indices: { first: { namespace: { refinement: 'refinement' } } },
+        indices: {
+          first: {
+            namespace: {
+              refinement: 'refinement',
+              'nested.another': 'nested.another',
+            },
+          },
+        },
       });
 
       searchState = cleanUpValue(searchState, context, 'namespace.refinement');
 
       expect(searchState).toEqual({
         page: 1,
-        indices: { first: { namespace: {} } },
+        indices: {
+          first: {
+            namespace: {
+              'nested.another': 'nested.another',
+            },
+          },
+        },
+      });
+
+      searchState = cleanUpValue(
+        searchState,
+        context,
+        'namespace.nested.another'
+      );
+
+      expect(searchState).toEqual({
+        page: 1,
+        indices: {
+          first: {
+            namespace: {},
+          },
+        },
       });
     });
 

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -104,7 +104,11 @@ describe('utility method for manipulating the search state', () => {
         last: 'last',
         refinement: 'refinement',
         another: 'another',
-        namespace: { refinement: 'refinement', another: 'another' },
+        namespace: {
+          refinement: 'refinement',
+          another: 'another',
+          'nested.another': 'nested.another',
+        },
       };
 
       let expectedRefinement = value => expect(value).toEqual('refinement');
@@ -125,6 +129,17 @@ describe('utility method for manipulating the search state', () => {
         searchState,
         context,
         'namespace.another',
+        null,
+        expectedRefinement
+      );
+
+      expectedRefinement = value => expect(value).toEqual('nested.another');
+
+      getCurrentRefinementValue(
+        {},
+        searchState,
+        context,
+        'namespace.nested.another',
         null,
         expectedRefinement
       );
@@ -158,7 +173,11 @@ describe('utility method for manipulating the search state', () => {
         last: 'last',
         refinement: 'refinement',
         another: 'another',
-        namespace: { refinement: 'refinement', another: 'another' },
+        namespace: {
+          refinement: 'refinement',
+          another: 'another',
+          'nested.another': 'nested.another',
+        },
       };
 
       searchState = cleanUpValue(searchState, context, 'refinement');
@@ -167,7 +186,11 @@ describe('utility method for manipulating the search state', () => {
         page: 1,
         last: 'last',
         another: 'another',
-        namespace: { refinement: 'refinement', another: 'another' },
+        namespace: {
+          refinement: 'refinement',
+          another: 'another',
+          'nested.another': 'nested.another',
+        },
       });
 
       searchState = cleanUpValue(searchState, context, 'namespace.another');
@@ -176,10 +199,26 @@ describe('utility method for manipulating the search state', () => {
         page: 1,
         last: 'last',
         another: 'another',
-        namespace: { refinement: 'refinement' },
+        namespace: {
+          refinement: 'refinement',
+          'nested.another': 'nested.another',
+        },
       });
 
       searchState = cleanUpValue(searchState, context, 'namespace.refinement');
+
+      expect(searchState).toEqual({
+        page: 1,
+        last: 'last',
+        another: 'another',
+        namespace: { 'nested.another': 'nested.another' },
+      });
+
+      searchState = cleanUpValue(
+        searchState,
+        context,
+        'namespace.nested.another'
+      );
 
       expect(searchState).toEqual({
         page: 1,


### PR DESCRIPTION
**Summary**

Since the https://github.com/algolia/react-instantsearch/commit/09a4e1dfd98c8989aa292bae4bf792aaf9aa7c48 commit, nested attributes for faceting are no longer working. 

Before, condition if id exists in a state looked like this: [```if (searchState[namespace] && typeof searchState[namespace][id] !== 'undefined') {```](https://github.com/algolia/react-instantsearch/commit/09a4e1dfd98c8989aa292bae4bf792aaf9aa7c48#diff-ff7d5a81ec7fdde10efeed49448d38d5L14). 

Now namespace and id are merged together [```${namespace}.${getId(props)}```](https://github.com/algolia/react-instantsearch/commit/09a4e1dfd98c8989aa292bae4bf792aaf9aa7c48#diff-ff7d5a81ec7fdde10efeed49448d38d5R13) and condition moved to ```indexUtils.getCurrentRefinementValue()``` function and looks like this [```has(searchState, id)```](https://github.com/algolia/react-instantsearch/commit/09a4e1dfd98c8989aa292bae4bf792aaf9aa7c48#diff-9d3b5ecf5b23605ad4be1550c962c5a4R62).

This works in most cases, but if you use nested attributes for faceting, your id looks something like this: ```category.name```. So with the namespace prepended it's ```refinementList.category.name```. And this when run through lodash' ```has()``` function returns `false` even when searchState looks like this:

```
{
  "page": 1,
  "query": "",
  "refinementList": {
    "category.name": ["my category"]
  }
}
```

**Result**

My pull requests just changes ```getCurrentRefinementValue()``` and ```cleanUpValue()``` functions. It splits joined namespace and id using regex and uses them separately. If they are not found, it falls back to the old logic.

I also added some tests that prove that without this fix ```getCurrentRefinementValue()``` and ```cleanUpValue()``` don't return correct results.
