### PR TITLE
test(manager): use algoliasearch/lite

### DIFF
--- a/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
@@ -2,7 +2,7 @@
 
 import createInstantSearchManager from './createInstantSearchManager';
 
-import algoliaClient from 'algoliasearch';
+import algoliaClient from 'algoliasearch/lite';
 
 jest.useFakeTimers();
 


### PR DESCRIPTION
I did a quick preg for all imports of algoliasearch', and this was the only one that is imported without the /lite. Even though this is mocked, and thus doesn't really have usages in the test, it's still best to use the same dependency everywhere.