### PR TITLE
docs(HitsPerPage): fix typo + wrong data type

### DIFF
--- a/packages/react-instantsearch/src/widgets/HitsPerPage.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage.js
@@ -28,7 +28,7 @@ import HitsPerPageSelectComponent from '../components/HitsPerPage.js';
  *     >
  *       <HitsPerPage
  *         defaultRefinement={20}
- *         items={[{value: '30', label: 'Show 20 hits'}, {value: '50', label: 'Show 50 hits'}]}
+ *         items={[{value: 20, label: 'Show 20 hits'}, {value: 50, label: 'Show 50 hits'}]}
  *       />
  *     </InstantSearch>
  *   );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
The documentation suggests you should provide the `value` property as a `String` but the PropType suggests otherwise.

**Result**
Ammended so the example shows the correct implementation.
