### PR TITLE
docs(video): Fixing link to video in Getting Started

### DIFF
--- a/docgen/src/Getting_started.md
+++ b/docgen/src/Getting_started.md
@@ -19,7 +19,7 @@ In this tutorial, you'll learn how to:
  - add widgets to filter the results
  - connect your own component to the search
 
-**If you prefer to get started by watching a video, [we created one for you](videos/index.html).**
+**If you prefer to get started by watching a video, [we created one for you](videos/).**
 
 ## Before we start
 

--- a/docgen/src/Getting_started.md
+++ b/docgen/src/Getting_started.md
@@ -19,7 +19,7 @@ In this tutorial, you'll learn how to:
  - add widgets to filter the results
  - connect your own component to the search
 
-**If you prefer to get started by watching a video, [we created one for you](videos/Index.html).**
+**If you prefer to get started by watching a video, [we created one for you](videos/index.html).**
 
 ## Before we start
 


### PR DESCRIPTION
The link to the video was using a capitalized `Index.html` which
failed to resolve, resulting in a 404. Using the lowercase version
works better.