### PR TITLE
docs(cloudinary): Use https link for Cloudinary images

### DIFF
--- a/docgen/assets/data/community-projects.json
+++ b/docgen/assets/data/community-projects.json
@@ -32,7 +32,7 @@
 	{
 		"name":"magento",
 		"url":"https://community.algolia.com/magento/",
-		"logo":"http://res.cloudinary.com/hilnmyskv/image/upload/v1477318624/magento-icon-white.svg",
+		"logo":"https://res.cloudinary.com/hilnmyskv/image/upload/v1477318624/magento-icon-white.svg",
 		"backgroundColor": "linear-gradient(to bottom right, #ed9259, #e76d22)"
 	}
 ]

--- a/docgen/layouts/common/meta.pug
+++ b/docgen/layouts/common/meta.pug
@@ -17,7 +17,7 @@ html
     // / OG meta
     meta(content='https://community.algolia.com/react-instantsearch/', property='og:url')
     meta(content='React InstantSearch', property='og:title')
-    meta(content='http//res.cloudinary.com/hilnmyskv/image/upload/v1481193392/meta-instant-search-react_hrf6st.jpg', property='og:image')
+    meta(content='https://res.cloudinary.com/hilnmyskv/image/upload/v1481193392/meta-instant-search-react_hrf6st.jpg', property='og:image')
     meta(content='website', property='og:type')
     meta(content='⚡ Lightning-fast search for React and React Native apps', property='og:description')
     meta(content='React InstantSearch', property='og:site_name')

--- a/docgen/layouts/common/meta.pug
+++ b/docgen/layouts/common/meta.pug
@@ -13,11 +13,11 @@ html
     meta(content='Algolia', name='twitter:creator')
     meta(content='React InstantSearch', name='twitter:title')
     meta(content='⚡ Lightning-fast search for React and React Native apps', name='twitter:description')
-    meta(content='http://res.cloudinary.com/hilnmyskv/image/upload/v1481193392/meta-instant-search-react_hrf6st.jpg', name='twitter:image')
+    meta(content='https://res.cloudinary.com/hilnmyskv/image/upload/v1481193392/meta-instant-search-react_hrf6st.jpg', name='twitter:image')
     // / OG meta
     meta(content='https://community.algolia.com/react-instantsearch/', property='og:url')
     meta(content='React InstantSearch', property='og:title')
-    meta(content='http://res.cloudinary.com/hilnmyskv/image/upload/v1481193392/meta-instant-search-react_hrf6st.jpg', property='og:image')
+    meta(content='http//res.cloudinary.com/hilnmyskv/image/upload/v1481193392/meta-instant-search-react_hrf6st.jpg', property='og:image')
     meta(content='website', property='og:type')
     meta(content='⚡ Lightning-fast search for React and React Native apps', property='og:description')
     meta(content='React InstantSearch', property='og:site_name')


### PR DESCRIPTION
The website was loading Cloudinary assets using and http protocol,
resulting in Mixed-Content warning and images not displayed.

I changed it in the OG meta as well, even if I'm not sure it was necessary.