### PR TITLE
chore(typo): Fix typo in documentation

### DIFF
--- a/docgen/src/guide/Custom_connectors.md
+++ b/docgen/src/guide/Custom_connectors.md
@@ -13,7 +13,7 @@ We tried very hard to make React InstantSearch a pluggable library that is able 
 most use cases in with simple API entries. But we could not plan everything and thus
 in some cases the current API may not be able to fulfill this promise of simplicity.
 
-If that's not the case or in doubt, **before diving into custom conectors**
+If that's not the case or in doubt, **before diving into custom connectors**
 please expose us your use case and come ask us questions on [discourse](https://discourse.algolia.com/tags/react-instantsearch)
 or [GitHub](https://github.com/algolia/react-instantsearch/issues) first. We will be glad
 that you do so.


### PR DESCRIPTION
`s/conectors/connectors`