### PR TITLE
fix(InfiniteHits): changing hitsPerPage were causing duplicates

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -51,16 +51,14 @@ export default createConnector({
       };
     }
 
-    const { hits, page, nbPages, hitsPerPage } = results;
+    const { hits, page, nbPages } = results;
 
     if (page === 0) {
       this._allResults = hits;
     } else {
-      const previousPage = this._allResults.length / hitsPerPage - 1;
-
-      if (page > previousPage) {
+      if (page > this.previousPage) {
         this._allResults = [...this._allResults, ...hits];
-      } else if (page < previousPage) {
+      } else if (page < this.previousPage) {
         this._allResults = hits;
       }
       // If it is the same page we do not touch the page result list
@@ -68,6 +66,7 @@ export default createConnector({
 
     const lastPageIndex = nbPages - 1;
     const hasMore = page < lastPageIndex;
+    this.previousPage = page;
     return {
       hits: this._allResults,
       hasMore,

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -36,6 +36,47 @@ describe('connectInfiniteHits', () => {
       expect(res2.hasMore).toBe(true);
     });
 
+    it('accumulate hits internally while changing hitsPerPage configuration', () => {
+      const hits = [{}, {}, {}, {}, {}, {}];
+      const hits2 = [{}, {}, {}, {}, {}, {}];
+      const hits3 = [{}, {}, {}, {}, {}, {}, {}, {}];
+      const res1 = getProvidedProps(null, null, {
+        results: { hits, page: 0, hitsPerPage: 6, nbPages: 10 },
+      });
+      expect(res1.hits).toEqual(hits);
+      expect(res1.hasMore).toBe(true);
+      const res2 = getProvidedProps(null, null, {
+        results: {
+          hits: hits2,
+          page: 1,
+          hitsPerPage: 6,
+          nbPages: 10,
+        },
+      });
+      expect(res2.hits).toEqual([...hits, ...hits2]);
+      expect(res2.hasMore).toBe(true);
+      let res3 = getProvidedProps(null, null, {
+        results: {
+          hits: hits3,
+          page: 2,
+          hitsPerPage: 8,
+          nbPages: 10,
+        },
+      });
+      expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
+      expect(res3.hasMore).toBe(true);
+      res3 = getProvidedProps(null, null, {
+        results: {
+          hits: hits3,
+          page: 2,
+          hitsPerPage: 8,
+          nbPages: 10,
+        },
+      }); //re-render with the same property
+      expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
+      expect(res3.hasMore).toBe(true);
+    });
+
     it('should not reset while accumulating results', () => {
       const nbPages = 100;
       let allHits = [];
@@ -150,6 +191,38 @@ describe('connectInfiniteHits', () => {
       });
       expect(res2.hits).toEqual([...hits, ...hits2]);
       expect(res2.hasMore).toBe(true);
+    });
+
+    it('accumulate hits internally while changing hitsPerPage configuration', () => {
+      const hits = [{}, {}, {}, {}, {}, {}];
+      const hits2 = [{}, {}, {}, {}, {}, {}];
+      const hits3 = [{}, {}, {}, {}, {}, {}, {}, {}];
+      const res1 = getProvidedProps(null, null, {
+        results: { second: { hits, page: 0, hitsPerPage: 6, nbPages: 10 } },
+      });
+      expect(res1.hits).toEqual(hits);
+      expect(res1.hasMore).toBe(true);
+      const res2 = getProvidedProps(null, null, {
+        results: {
+          second: { hits: hits2, page: 1, hitsPerPage: 6, nbPages: 10 },
+        },
+      });
+      expect(res2.hits).toEqual([...hits, ...hits2]);
+      expect(res2.hasMore).toBe(true);
+      let res3 = getProvidedProps(null, null, {
+        results: {
+          second: { hits: hits3, page: 2, hitsPerPage: 8, nbPages: 10 },
+        },
+      });
+      expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
+      expect(res3.hasMore).toBe(true);
+      res3 = getProvidedProps(null, null, {
+        results: {
+          second: { hits: hits3, page: 2, hitsPerPage: 8, nbPages: 10 },
+        },
+      }); //re-render with the same property
+      expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
+      expect(res3.hasMore).toBe(true);
     });
 
     it('should not reset while accumulating results', () => {


### PR DESCRIPTION
see: https://jsfiddle.net/spondbob/sm3cad75/ and https://github.com/algolia/react-instantsearch/issues/123
