### PR TITLE
fix(storybook): process CSS through autoprefixer

### DIFF
--- a/storybook/postcss.config.js
+++ b/storybook/postcss.config.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  plugins: {
+    autoprefixer: {},
+  },
+};

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
     rules: [
       {
         test: /\.scss$/,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
+        use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
       },
     ],
   },


### PR DESCRIPTION
CSS theme is not vendor prefixed into storybook, which leads to the issue #135.

This PR use `postcss-loader` to process css into `autoprefixer` to resolve it 👍 