### PR TITLE
fix(MultiIndex): handle if namespace isn't in search state

### DIFF
--- a/packages/react-instantsearch/src/core/indexUtils.js
+++ b/packages/react-instantsearch/src/core/indexUtils.js
@@ -138,6 +138,7 @@ export function getCurrentRefinementValue(
     (hasMultipleIndex(context) &&
       searchState.indices &&
       namespace &&
+      searchState.indices[`${index}`] &&
       has(searchState.indices[`${index}`][namespace], `${attributeName}`)) ||
     (hasMultipleIndex(context) &&
       searchState.indices &&

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -348,7 +348,7 @@ describe('utility method for manipulating the search state', () => {
         },
       };
 
-      expect.assertions(6); //async assertions
+      expect.assertions(7); //async assertions
 
       let expectedRefinement = value => expect(value).toEqual('refinement');
 
@@ -399,6 +399,17 @@ describe('utility method for manipulating the search state', () => {
         {},
         context,
         'refinement',
+        'defaultValue',
+        () => {}
+      );
+
+      expect(value).toEqual('defaultValue');
+
+      value = getCurrentRefinementValue(
+        {},
+        searchState,
+        context,
+        'anotherNamespace.refinement.top',
         'defaultValue',
         () => {}
       );


### PR DESCRIPTION
Use case: you handle a tab navigation without any router and you're switching between a multiple indices display and several only one indices display. 
At some point, before the rendering of only one indices, the namespace with the index name is not here yet, so without this check it crashed. 