### PR TITLE
fix(results): revert commit that ensure hits are returned only if right indices

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -22,7 +22,6 @@ describe('connectHierarchicalMenu', () => {
         getFacetValues: jest.fn(),
         getFacetByName: () => true,
         hits: [],
-        index: 'index',
       };
 
       results.getFacetValues.mockImplementationOnce(() => ({}));
@@ -335,7 +334,6 @@ describe('connectHierarchicalMenu', () => {
         first: {
           getFacetValues: jest.fn(),
           getFacetByName: () => true,
-          index: 'first',
         },
       };
 

--- a/packages/react-instantsearch/src/connectors/connectHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHits.test.js
@@ -12,7 +12,7 @@ describe('connectHits', () => {
     it('provides the current hits to the component', () => {
       const hits = [{}];
       const props = getProvidedProps(null, null, {
-        results: { hits, index: 'index' },
+        results: { hits },
       });
       expect(props).toEqual({ hits });
     });
@@ -38,7 +38,7 @@ describe('connectHits', () => {
     it('provides the current hits to the component', () => {
       const hits = [{}];
       const props = getProvidedProps(null, null, {
-        results: { second: { hits, index: 'second' } },
+        results: { second: { hits } },
       });
       expect(props).toEqual({ hits });
     });

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -11,7 +11,7 @@ describe('connectInfiniteHits', () => {
     it('provides the current hits to the component', () => {
       const hits = [{}];
       const props = getProvidedProps(null, null, {
-        results: { hits, page: 0, hitsPerPage: 2, nbPages: 3, index: 'index' },
+        results: { hits, page: 0, hitsPerPage: 2, nbPages: 3 },
       });
       expect(props).toEqual({ hits, hasMore: true });
     });
@@ -20,7 +20,7 @@ describe('connectInfiniteHits', () => {
       const hits = [{}, {}];
       const hits2 = [{}, {}];
       const res1 = getProvidedProps(null, null, {
-        results: { hits, page: 0, hitsPerPage: 2, nbPages: 3, index: 'index' },
+        results: { hits, page: 0, hitsPerPage: 2, nbPages: 3 },
       });
       expect(res1.hits).toEqual(hits);
       expect(res1.hasMore).toBe(true);
@@ -30,7 +30,6 @@ describe('connectInfiniteHits', () => {
           page: 1,
           hitsPerPage: 2,
           nbPages: 3,
-          index: 'index',
         },
       });
       expect(res2.hits).toEqual([...hits, ...hits2]);
@@ -42,7 +41,7 @@ describe('connectInfiniteHits', () => {
       const hits2 = [{}, {}, {}, {}, {}, {}];
       const hits3 = [{}, {}, {}, {}, {}, {}, {}, {}];
       const res1 = getProvidedProps(null, null, {
-        results: { hits, page: 0, hitsPerPage: 6, nbPages: 10, index: 'index' },
+        results: { hits, page: 0, hitsPerPage: 6, nbPages: 10 },
       });
       expect(res1.hits).toEqual(hits);
       expect(res1.hasMore).toBe(true);
@@ -52,7 +51,6 @@ describe('connectInfiniteHits', () => {
           page: 1,
           hitsPerPage: 6,
           nbPages: 10,
-          index: 'index',
         },
       });
       expect(res2.hits).toEqual([...hits, ...hits2]);
@@ -63,7 +61,6 @@ describe('connectInfiniteHits', () => {
           page: 2,
           hitsPerPage: 8,
           nbPages: 10,
-          index: 'index',
         },
       });
       expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
@@ -74,7 +71,6 @@ describe('connectInfiniteHits', () => {
           page: 2,
           hitsPerPage: 8,
           nbPages: 10,
-          index: 'index',
         },
       }); //re-render with the same property
       expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
@@ -94,7 +90,6 @@ describe('connectInfiniteHits', () => {
             page,
             hitsPerPage: hits.length,
             nbPages,
-            index: 'index',
           },
         });
         expect(res.hits).toEqual(allHits);
@@ -110,7 +105,6 @@ describe('connectInfiniteHits', () => {
           page: nbPages - 1,
           hitsPerPage: hits.length,
           nbPages,
-          index: 'index',
         },
       });
       expect(res.hits.length).toEqual(nbPages * 2);
@@ -123,7 +117,7 @@ describe('connectInfiniteHits', () => {
       const hits2 = [{}, {}];
       const hits3 = [{}];
       getProvidedProps(null, null, {
-        results: { hits, page: 0, hitsPerPage: 2, nbPages: 3, index: 'index' },
+        results: { hits, page: 0, hitsPerPage: 2, nbPages: 3 },
       });
       getProvidedProps(null, null, {
         results: {
@@ -131,7 +125,6 @@ describe('connectInfiniteHits', () => {
           page: 1,
           hitsPerPage: 2,
           nbPages: 3,
-          index: 'index',
         },
       });
       const props = getProvidedProps(null, null, {
@@ -140,7 +133,6 @@ describe('connectInfiniteHits', () => {
           page: 2,
           hitsPerPage: 2,
           nbPages: 3,
-          index: 'index',
         },
       });
       expect(props.hits).toEqual([...hits, ...hits2, ...hits3]);
@@ -179,15 +171,7 @@ describe('connectInfiniteHits', () => {
     it('provides the current hits to the component', () => {
       const hits = [{}];
       const props = getProvidedProps(null, null, {
-        results: {
-          second: {
-            hits,
-            page: 0,
-            hitsPerPage: 2,
-            nbPages: 3,
-            index: 'second',
-          },
-        },
+        results: { second: { hits, page: 0, hitsPerPage: 2, nbPages: 3 } },
       });
       expect(props).toEqual({ hits, hasMore: true });
     });
@@ -196,27 +180,13 @@ describe('connectInfiniteHits', () => {
       const hits = [{}, {}];
       const hits2 = [{}, {}];
       const res1 = getProvidedProps(null, null, {
-        results: {
-          second: {
-            hits,
-            page: 0,
-            hitsPerPage: 2,
-            nbPages: 3,
-            index: 'second',
-          },
-        },
+        results: { second: { hits, page: 0, hitsPerPage: 2, nbPages: 3 } },
       });
       expect(res1.hits).toEqual(hits);
       expect(res1.hasMore).toBe(true);
       const res2 = getProvidedProps(null, null, {
         results: {
-          second: {
-            hits: hits2,
-            page: 1,
-            hitsPerPage: 2,
-            nbPages: 3,
-            index: 'second',
-          },
+          second: { hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3 },
         },
       });
       expect(res2.hits).toEqual([...hits, ...hits2]);
@@ -228,53 +198,27 @@ describe('connectInfiniteHits', () => {
       const hits2 = [{}, {}, {}, {}, {}, {}];
       const hits3 = [{}, {}, {}, {}, {}, {}, {}, {}];
       const res1 = getProvidedProps(null, null, {
-        results: {
-          second: {
-            hits,
-            page: 0,
-            hitsPerPage: 6,
-            nbPages: 10,
-            index: 'second',
-          },
-        },
+        results: { second: { hits, page: 0, hitsPerPage: 6, nbPages: 10 } },
       });
       expect(res1.hits).toEqual(hits);
       expect(res1.hasMore).toBe(true);
       const res2 = getProvidedProps(null, null, {
         results: {
-          second: {
-            hits: hits2,
-            page: 1,
-            hitsPerPage: 6,
-            nbPages: 10,
-            index: 'second',
-          },
+          second: { hits: hits2, page: 1, hitsPerPage: 6, nbPages: 10 },
         },
       });
       expect(res2.hits).toEqual([...hits, ...hits2]);
       expect(res2.hasMore).toBe(true);
       let res3 = getProvidedProps(null, null, {
         results: {
-          second: {
-            hits: hits3,
-            page: 2,
-            hitsPerPage: 8,
-            nbPages: 10,
-            index: 'second',
-          },
+          second: { hits: hits3, page: 2, hitsPerPage: 8, nbPages: 10 },
         },
       });
       expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
       expect(res3.hasMore).toBe(true);
       res3 = getProvidedProps(null, null, {
         results: {
-          second: {
-            hits: hits3,
-            page: 2,
-            hitsPerPage: 8,
-            nbPages: 10,
-            index: 'second',
-          },
+          second: { hits: hits3, page: 2, hitsPerPage: 8, nbPages: 10 },
         },
       }); //re-render with the same property
       expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
@@ -295,7 +239,6 @@ describe('connectInfiniteHits', () => {
               page,
               hitsPerPage: hits.length,
               nbPages,
-              index: 'second',
             },
           },
         });
@@ -313,7 +256,6 @@ describe('connectInfiniteHits', () => {
             page: nbPages - 1,
             hitsPerPage: hits.length,
             nbPages,
-            index: 'second',
           },
         },
       });
@@ -327,36 +269,16 @@ describe('connectInfiniteHits', () => {
       const hits2 = [{}, {}];
       const hits3 = [{}];
       getProvidedProps(null, null, {
-        results: {
-          second: {
-            hits,
-            page: 0,
-            hitsPerPage: 2,
-            nbPages: 3,
-            index: 'second',
-          },
-        },
+        results: { second: { hits, page: 0, hitsPerPage: 2, nbPages: 3 } },
       });
       getProvidedProps(null, null, {
         results: {
-          second: {
-            hits: hits2,
-            page: 1,
-            hitsPerPage: 2,
-            nbPages: 3,
-            index: 'second',
-          },
+          second: { hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3 },
         },
       });
       const props = getProvidedProps(null, null, {
         results: {
-          second: {
-            hits: hits3,
-            page: 2,
-            hitsPerPage: 2,
-            nbPages: 3,
-            index: 'second',
-          },
+          second: { hits: hits3, page: 2, hitsPerPage: 2, nbPages: 3 },
         },
       });
       expect(props.hits).toEqual([...hits, ...hits2, ...hits3]);

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -25,7 +25,6 @@ describe('connectMenu', () => {
         getFacetValues: jest.fn(() => []),
         getFacetByName: () => true,
         hits: [],
-        index: 'index',
       };
 
       props = getProvidedProps({ attributeName: 'ok' }, {}, {});
@@ -213,7 +212,6 @@ describe('connectMenu', () => {
         getFacetValues: jest.fn(() => []),
         getFacetByName: () => true,
         hits: [],
-        index: 'index',
       };
       results.getFacetValues.mockImplementation(() => [
         {
@@ -388,7 +386,6 @@ describe('connectMenu', () => {
         getFacetValues: jest.fn(() => []),
         getFacetByName: () => true,
         hits: [],
-        index: 'index',
       };
       results.getFacetValues.mockClear();
       results.getFacetValues.mockImplementation(() => [
@@ -465,7 +462,6 @@ describe('connectMenu', () => {
         first: {
           getFacetValues: jest.fn(() => []),
           getFacetByName: () => true,
-          index: 'first',
         },
       };
 
@@ -654,7 +650,6 @@ describe('connectMenu', () => {
         first: {
           getFacetValues: jest.fn(() => []),
           getFacetByName: () => true,
-          index: 'first',
         },
       };
       results.first.getFacetValues.mockImplementation(() => [

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
@@ -21,7 +21,6 @@ describe('connectMultiRange', () => {
       getFacetStats: () => ({ min: 0, max: 300 }),
       getFacetByName: () => true,
       hits: [],
-      index: 'index',
     };
 
     it('provides the correct props to the component', () => {
@@ -373,7 +372,6 @@ describe('connectMultiRange', () => {
       first: {
         getFacetStats: () => ({ min: 0, max: 300 }),
         getFacetByName: () => true,
-        index: 'first',
       },
     };
 

--- a/packages/react-instantsearch/src/connectors/connectPagination.test.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.test.js
@@ -18,22 +18,29 @@ describe('connectPagination', () => {
     const cleanUp = connect.cleanUp.bind(context);
 
     it('provides the correct props to the component', () => {
-      const results = { nbPages: 666, hits: [], index: 'index' };
-      props = getProvidedProps({}, {}, { results });
+      props = getProvidedProps({}, {}, { results: { nbPages: 666, hits: [] } });
       expect(props).toEqual({
         currentRefinement: 1,
         nbPages: 666,
         canRefine: true,
       });
 
-      props = getProvidedProps({}, { page: 5 }, { results });
+      props = getProvidedProps(
+        {},
+        { page: 5 },
+        { results: { nbPages: 666, hits: [] } }
+      );
       expect(props).toEqual({
         currentRefinement: 5,
         nbPages: 666,
         canRefine: true,
       });
 
-      props = getProvidedProps({}, { page: '5' }, { results });
+      props = getProvidedProps(
+        {},
+        { page: '5' },
+        { results: { nbPages: 666, hits: [] } }
+      );
       expect(props).toEqual({
         currentRefinement: 5,
         nbPages: 666,
@@ -43,7 +50,7 @@ describe('connectPagination', () => {
       props = getProvidedProps(
         {},
         { page: '1' },
-        { results: { nbPages: 1, hits: [], index: 'index' } }
+        { results: { nbPages: 1, hits: [] } }
       );
       expect(props).toEqual({
         currentRefinement: 1,
@@ -99,8 +106,11 @@ describe('connectPagination', () => {
     const cleanUp = connect.cleanUp.bind(context);
 
     it('provides the correct props to the component', () => {
-      const results = { first: { nbPages: 666, index: 'first' } };
-      props = getProvidedProps({}, {}, { results });
+      props = getProvidedProps(
+        {},
+        {},
+        { results: { first: { nbPages: 666 } } }
+      );
       expect(props).toEqual({
         currentRefinement: 1,
         nbPages: 666,
@@ -110,7 +120,7 @@ describe('connectPagination', () => {
       props = getProvidedProps(
         {},
         { indices: { first: { page: 5 } } },
-        { results }
+        { results: { first: { nbPages: 666 } } }
       );
       expect(props).toEqual({
         currentRefinement: 5,

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -39,7 +39,6 @@ describe('connectRange', () => {
         ],
         getFacetByName: () => true,
         hits: [],
-        index: 'index',
       };
       props = getProvidedProps({ attributeName: 'ok' }, {}, { results });
       expect(props).toEqual({
@@ -265,7 +264,6 @@ describe('connectRange', () => {
             { name: '2', count: 20 },
           ],
           getFacetByName: () => true,
-          index: 'first',
         },
       };
       props = getProvidedProps({ attributeName: 'ok' }, {}, { results });

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -24,7 +24,6 @@ describe('connectRefinementList', () => {
       getFacetValues: jest.fn(() => []),
       getFacetByName: () => true,
       hits: [],
-      index: 'index',
     };
 
     it('provides the correct props to the component', () => {

--- a/packages/react-instantsearch/src/connectors/connectStats.test.js
+++ b/packages/react-instantsearch/src/connectors/connectStats.test.js
@@ -13,7 +13,7 @@ describe('connectStats', () => {
       expect(props).toBe(null);
 
       props = getProvidedProps(null, null, {
-        results: { nbHits: 666, processingTimeMS: 1, hits: [], index: 'index' },
+        results: { nbHits: 666, processingTimeMS: 1, hits: [] },
       });
       expect(props).toEqual({ nbHits: 666, processingTimeMS: 1 });
     });
@@ -31,9 +31,7 @@ describe('connectStats', () => {
       expect(props).toBe(null);
 
       props = getProvidedProps(null, null, {
-        results: {
-          second: { nbHits: 666, processingTimeMS: 1, index: 'second' },
-        },
+        results: { second: { nbHits: 666, processingTimeMS: 1 } },
       });
       expect(props).toEqual({ nbHits: 666, processingTimeMS: 1 });
     });

--- a/packages/react-instantsearch/src/core/indexUtils.js
+++ b/packages/react-instantsearch/src/core/indexUtils.js
@@ -7,16 +7,12 @@ export function getIndex(context) {
 }
 
 export function getResults(searchResults, context) {
-  const index = getIndex(context);
   if (searchResults.results && !searchResults.results.hits) {
-    const results = searchResults.results[getIndex(context)];
-    return results && index === results.index
+    return searchResults.results[getIndex(context)]
       ? searchResults.results[getIndex(context)]
       : null;
   } else {
-    return searchResults.results && searchResults.results.index === index
-      ? searchResults.results
-      : null;
+    return searchResults.results ? searchResults.results : null;
   }
 }
 

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -230,20 +230,11 @@ describe('utility method for manipulating the search state', () => {
       });
     });
     it('get results', () => {
-      const searchResults = { results: { hits: ['some'], index: 'index' } };
+      const searchResults = { results: { hits: ['some'] } };
 
       const results = getResults(searchResults, context);
 
-      expect(results.hits).toEqual(['some']);
-    });
-    it('get no results if index name is different than context', () => {
-      const searchResults = {
-        results: { hits: ['some'], index: 'otherIndex' },
-      };
-
-      const results = getResults(searchResults, context);
-
-      expect(results).toBeNull();
+      expect(results).toEqual({ hits: ['some'] });
     });
   });
   describe('when there are multiple index', () => {
@@ -511,23 +502,19 @@ describe('utility method for manipulating the search state', () => {
     });
 
     it('get results', () => {
-      let searchResults = {
-        results: { first: { hits: 'results', index: 'first' } },
-      };
+      let searchResults = { results: { first: { some: 'results' } } };
 
-      let results = getResults(searchResults, {
-        ais: { mainTargetedIndex: 'first' },
-      });
+      let results = getResults(searchResults, context);
 
-      expect(results.hits).toEqual('results');
+      expect(results).toEqual({ some: 'results' });
 
-      searchResults = { results: { second: { some: 'results' } } };
+      searchResults = { results: { first: { some: 'results' } } };
 
       results = getResults(searchResults, {
         ais: { mainTargetedIndex: 'first' },
       });
 
-      expect(results).toBeNull();
+      expect(results).toEqual({ some: 'results' });
     });
   });
 });


### PR DESCRIPTION
I need to revert this commit because it breaks our SortBy feature. 

As for now we don't have a simple way to handle a switch between the multi and mono indices mode. What it means for the user is that a connector can get hits that were meant for another index before getting the right one. 

There's two ways to handle this issue on user side: 
-> Always be in multi indices mode => It means that when you are on a tab that contains only one index you can still add another `<Index/>` but empty. 
-> Check the shape of the hits and decide to proceed with it or not. (i.e => hit.brand ? ... : null). 

Ultimately we will need to find a way to fix this properly. I can see several options: 
-> SearchResults are always namespaced by the indexName. This is a breaking change because the `createConnector` api exposed directly the `SearchResults`. 
-> Clean the hits when performing a new search. (But in a smart way to avoid a blinking effect). 