### PR TITLE
Revert "fix(store): delay call to listener to prevent infinite loops (#143)"

### DIFF
--- a/packages/react-instantsearch/src/core/createStore.js
+++ b/packages/react-instantsearch/src/core/createStore.js
@@ -2,7 +2,7 @@ export default function createStore(initialState) {
   let state = initialState;
   const listeners = [];
   function dispatch() {
-    listeners.forEach(listener => setTimeout(listener, 0));
+    listeners.forEach(listener => listener());
   }
   return {
     getState() {

--- a/packages/react-instantsearch/src/core/createStore.test.js
+++ b/packages/react-instantsearch/src/core/createStore.test.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-console */
 
 import createStore from './createStore';
-jest.useFakeTimers();
 
 describe('createStore', () => {
   describe('getState', () => {
@@ -18,10 +17,7 @@ describe('createStore', () => {
       const initialState = {};
       const store = createStore(initialState);
       const newState = {};
-
       store.setState(newState);
-      jest.runAllTimers();
-
       expect(store.getState()).toBe(newState);
     });
   });
@@ -35,7 +31,6 @@ describe('createStore', () => {
       const newState = {};
       expect(listener.mock.calls.length).toBe(0);
       store.setState(newState);
-      jest.runAllTimers();
       expect(listener.mock.calls.length).toBe(1);
     });
 
@@ -47,12 +42,10 @@ describe('createStore', () => {
       const newState = {};
       expect(listener.mock.calls.length).toBe(0);
       store.setState(newState);
-      jest.runAllTimers();
       expect(listener.mock.calls.length).toBe(1);
       unsubscribe();
       const newerState = {};
       store.setState(newerState);
-      jest.runAllTimers();
       expect(listener.mock.calls.length).toBe(1);
     });
   });


### PR DESCRIPTION
This commit introduced: 

- setState warning
- input delay when a high CPU. 

This fix was for:

- avoid infinite loop when conditionally display based on the search results "loading" boolean
- avoid infinite loop when nesting widgets along with a permanent change of their results. 