### PR TITLE
docs(RN): Added missing Text import in React Native docs example

### DIFF
--- a/docgen/src/Getting_started_React_native.md
+++ b/docgen/src/Getting_started_React_native.md
@@ -49,7 +49,7 @@ It maintains the state of the search, does the queries, and provides the results
 ```jsx
 import React from 'react';
 import { InstantSearch } from 'react-instantsearch/native';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Text } from 'react-native';
 
 export default class App extends React.Component {
   render() {


### PR DESCRIPTION
**Summary**

Example in https://community.algolia.com/react-instantsearch/Getting_started_React_native.html is missing a `Text` import.

**Result**

Simple docs fix.
