### PR TITLE
fix(error): reset error when receiving results of a query (not when sending it)

### DIFF
--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -13,13 +13,15 @@ import { omit, isEmpty } from 'lodash';
  * @param {object} SearchParameters - optional additional parameters to send to the algolia API
  * @return {InstantSearchManager} a new instance of InstantSearchManager
  */
-export default function createInstantSearchManager({
-  indexName,
-  initialState = {},
-  algoliaClient,
-  searchParameters = {},
-  resultsState,
-}) {
+export default function createInstantSearchManager(
+  {
+    indexName,
+    initialState = {},
+    algoliaClient,
+    searchParameters = {},
+    resultsState,
+  }
+) {
   const baseSP = new SearchParameters({
     ...searchParameters,
     index: indexName,
@@ -84,16 +86,19 @@ export default function createInstantSearchManager({
           widget.multiIndexContext &&
           widget.multiIndexContext.targetedIndex !== indexName
       )
-      .reduce((indices, widget) => {
-        const targetedIndex = widget.multiIndexContext.targetedIndex;
-        const index = indices.find(i => i.targetedIndex === targetedIndex);
-        if (index) {
-          index.widgets.push(widget);
-        } else {
-          indices.push({ targetedIndex, widgets: [widget] });
-        }
-        return indices;
-      }, []);
+      .reduce(
+        (indices, widget) => {
+          const targetedIndex = widget.multiIndexContext.targetedIndex;
+          const index = indices.find(i => i.targetedIndex === targetedIndex);
+          if (index) {
+            index.widgets.push(widget);
+          } else {
+            indices.push({ targetedIndex, widgets: [widget] });
+          }
+          return indices;
+        },
+        []
+      );
 
     const mainIndexParameters = widgetsManager
       .getWidgets()
@@ -164,6 +169,7 @@ export default function createInstantSearchManager({
         ...store.getState(),
         results,
         searching: false,
+        error: null,
       },
       'resultsFacetValues'
     );
@@ -190,7 +196,6 @@ export default function createInstantSearchManager({
       ...store.getState(),
       metadata,
       searching: true,
-      error: null,
     });
 
     // Since the `getSearchParameters` method of widgets also depends on props,
@@ -217,7 +222,6 @@ export default function createInstantSearchManager({
       widgets: nextSearchState,
       metadata,
       searching: true,
-      error: null,
     });
 
     search();


### PR DESCRIPTION
Previously I was resetting the error when sending a new query. Considering that you can send multiple query at the same time, you can have trouble: 

1. Send a first query => error: null
2. Send a second query => error: null
3. First query return in error => error: 'some error'
4. Second query return successfully => error: 'some error' (not ok). 