### PR TITLE
fix(highlight): wrong parsing between client and server

### DIFF
--- a/packages/react-instantsearch/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchServer.js
@@ -9,6 +9,7 @@ import ReactDom from 'react-dom/server';
 import { getIndex, hasMultipleIndex } from './indexUtils';
 import { isEmpty } from 'lodash';
 import cis from './createInstantSearch';
+import highlightTags from './highlightTags.js';
 
 const createInstantSearch = function(algoliasearch) {
   const InstantSearch = cis(algoliasearch, {
@@ -48,7 +49,7 @@ const createInstantSearch = function(algoliasearch) {
             searchParameter.props,
             searchParameter.searchState
           ),
-        new SearchParameters({ index: indexName })
+        new SearchParameters({ index: indexName, ...highlightTags })
       );
 
     const mergedSearchParameters = searchParameters

--- a/packages/react-instantsearch/src/core/highlightTags.js
+++ b/packages/react-instantsearch/src/core/highlightTags.js
@@ -1,6 +1,4 @@
-const timestamp = Date.now().toString();
-
 export default {
-  highlightPreTag: `<ais-highlight-${timestamp}>`,
-  highlightPostTag: `</ais-highlight-${timestamp}>`,
+  highlightPreTag: `<ais-highlight>`,
+  highlightPostTag: `</ais-highlight>`,
 };


### PR DESCRIPTION
See https://github.com/algolia/react-instantsearch/issues/168

The Server-side html is rendered perfectly but then when rendered on the client using the `resultsState` props, results are containing the server old timestamp and `<Highlight>` the new client one. The `<Highlight/>` component then doesn't see any highlighted values and that's why we can see the little glitch. 

For now, the solution is to remove the `timestamp` when dealing with highlighting tags. 