### PR TITLE
chore(deps): Use chore(deps) for all Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "pinVersions": true,
   "semanticCommits": true,
-  "depTypes": [{ "depType": "dependencies", "pinVersions": false }],
+  "depTypes": [{ "depType": "dependencies", "pinVersions": false, "semanticPrefix": "chore(deps): " }],
   "ignoreDeps": ["jsdoc-parse", "react-native"]
 }


### PR DESCRIPTION
**Summary**

Renovate uses `chore(deps)` as default semantic commit prefix however overrides it to `fix(deps)` only for updates to `dependencies`.
This configuration change will "override that override" so that you should receive `chore(deps)` as the prefix for all Renovate commits and Pull Request titles.
