### PR TITLE
fix(PoweredBy): add a label to the Algolia logo

### DIFF
--- a/packages/react-instantsearch/src/components/PoweredBy.js
+++ b/packages/react-instantsearch/src/components/PoweredBy.js
@@ -52,7 +52,12 @@ class PoweredBy extends Component {
         <span {...cx('searchBy')}>
           {translate('searchBy')}{' '}
         </span>
-        <a href={url} target="_blank" {...cx('algoliaLink')}>
+        <a
+          href={url}
+          target="_blank"
+          {...cx('algoliaLink')}
+          ariaLabel="Algolia"
+        >
           <AlgoliaLogo />
         </a>
       </div>

--- a/packages/react-instantsearch/src/components/__snapshots__/PoweredBy.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/PoweredBy.test.js.snap
@@ -11,6 +11,7 @@ exports[`PoweredBy applies translations 1`] = `
      
   </span>
   <a
+    ariaLabel="Algolia"
     className="ais-PoweredBy__algoliaLink"
     href="url"
     target="_blank"
@@ -66,6 +67,7 @@ exports[`PoweredBy default 1`] = `
      
   </span>
   <a
+    ariaLabel="Algolia"
     className="ais-PoweredBy__algoliaLink"
     href="url"
     target="_blank"


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The Algolia logo in the PoweredBy component didn't have an `aria-label`. This was noticed in #209 by @davidfurlong.

**Result**

The label says "Algolia", since the text before it is "powered by "

fixes #209 
