### PR TITLE
Format the count of items appearing in a refinement

### DIFF
--- a/packages/react-instantsearch/src/components/RefinementList.js
+++ b/packages/react-instantsearch/src/components/RefinementList.js
@@ -78,7 +78,7 @@ class RefinementList extends Component {
           {label}
         </span>{' '}
         <span {...cx('itemCount', item.isRefined && 'itemCountSelected')}>
-          {item.count}
+          {item.count.toLocaleString()}
         </span>
       </label>
     );


### PR DESCRIPTION
A small fix to improve the UX of navigating refinements. Right now the numbers appear cluttered:
![image](https://user-images.githubusercontent.com/1284136/28684213-93f6f2aa-72d1-11e7-896e-21b9d2fd8394.png)
With this change, the numbers will look cleaner and will also be shown with language-sensitive representations.
![image](https://user-images.githubusercontent.com/1284136/28684954-42a8de60-72d4-11e7-89af-2d8739c533f6.png)
