### PR TITLE
fix(Highlighting): revert breaking change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_script:
 branches:
   only:
     - master
+dist: precise
 addons:
   firefox: 50.0
 before_install:

--- a/packages/react-instantsearch/src/core/highlightTags.js
+++ b/packages/react-instantsearch/src/core/highlightTags.js
@@ -1,4 +1,4 @@
 export default {
-  highlightPreTag: `<ais-highlight>`,
-  highlightPostTag: `</ais-highlight>`,
+  highlightPreTag: `<ais-highlight-0000000000>`,
+  highlightPostTag: `</ais-highlight-0000000000>`,
 };


### PR DESCRIPTION
We introduce a breaking change when switching from timestamped highlighting tags to the opposite to make it compatible with SSR. 

Who is concerned by the breaking change: people using regex to parse our tags (if Highlight can't handle a use case). 

Indeed, I think we can avoid such a breaking change (and then bumping to version 5) by adding 10 fix numbers to our tags. 