### PR TITLE
Fix/pagination

### DIFF
--- a/packages/react-instantsearch/src/components/Pagination.js
+++ b/packages/react-instantsearch/src/components/Pagination.js
@@ -8,36 +8,39 @@ import classNames from './classNames.js';
 
 const cx = classNames('Pagination');
 
-function getPagesDisplayedCount(padding, total) {
-  return Math.min(2 * padding + 1, total);
+// Determines the size of the widget (the number of pages displayed - that the user can directly click on)
+function calculateSize(padding, maxPages) {
+  return Math.min(2 * padding + 1, maxPages);
 }
 
-function calculatePaddingLeft(current, padding, total, totalDisplayedPages) {
-  if (current <= padding) {
-    return current;
+function calculatePaddingLeft(currentPage, padding, maxPages, size) {
+  if (currentPage <= padding) {
+    return currentPage;
   }
 
-  if (current >= total - padding) {
-    return totalDisplayedPages - (total - current);
+  if (currentPage >= maxPages - padding) {
+    return size - (maxPages - currentPage);
   }
 
-  return padding;
+  return padding + 1;
 }
 
-function getPages(page, total, padding) {
-  const totalDisplayedPages = getPagesDisplayedCount(padding, total);
-  if (totalDisplayedPages === total) return range(1, total + 1);
+// Retrieve the correct page range to populate the widget
+function getPages(currentPage, maxPages, padding) {
+  const size = calculateSize(padding, maxPages);
+  // If the widget size is equal to the max number of pages, return the entire page range
+  if (size === maxPages) return range(1, maxPages + 1);
 
   const paddingLeft = calculatePaddingLeft(
-    page,
+    currentPage,
     padding,
-    total,
-    totalDisplayedPages
+    maxPages,
+    size
   );
-  const paddingRight = totalDisplayedPages - paddingLeft;
+  const paddingRight = size - paddingLeft;
 
-  const first = page - paddingLeft;
-  const last = page + paddingRight;
+  const first = currentPage - paddingLeft;
+  const last = currentPage + paddingRight;
   return range(first + 1, last + 1);
 }
 
@@ -53,15 +56,10 @@ class Pagination extends Component {
     listComponent: PropTypes.func,
 
     showFirst: PropTypes.bool,
-
     showPrevious: PropTypes.bool,
-
     showNext: PropTypes.bool,
-
     showLast: PropTypes.bool,
-
     pagesPadding: PropTypes.number,
-
     maxPages: PropTypes.number,
   };
 

--- a/packages/react-instantsearch/src/components/Pagination.test.js
+++ b/packages/react-instantsearch/src/components/Pagination.test.js
@@ -319,4 +319,84 @@ describe('Pagination', () => {
     expect(canRefine.mock.calls[1][0]).toEqual(false);
     expect(wrapper.find('.ais-Pagination__noRefinement').length).toBe(1);
   });
+
+  describe('pagesPadding behaviour', () => {
+    it('should be adjusted when currentPage < padding (at the very beginning)', () => {
+      const refine = jest.fn();
+      const wrapper = mount(
+        <Pagination
+          {...REQ_PROPS}
+          nbPages={18}
+          showLast
+          pagesPadding={2}
+          currentRefinement={2}
+          refine={refine}
+        />
+      );
+      const pages = wrapper.find('.ais-Pagination__itemPage');
+      const pageSelected = wrapper.find('.ais-Pagination__itemLinkSelected');
+      // Since pagesPadding = 2, the Pagination widget's size should be 5
+      expect(pages.length).toBe(5);
+
+      expect(pages.first().text()).toEqual('1');
+
+      expect(pageSelected.first().text()).toEqual('2');
+      expect(pages.at(1).text()).toEqual('2');
+
+      expect(pages.at(2).text()).toEqual('3');
+      expect(pages.at(3).text()).toEqual('4');
+      expect(pages.at(4).text()).toEqual('5');
+    });
+    it('should be adjusted when currentPage < maxPages - padding (at the end)', () => {
+      const refine = jest.fn();
+      const wrapper = mount(
+        <Pagination
+          {...REQ_PROPS}
+          nbPages={18}
+          showLast
+          pagesPadding={2}
+          currentRefinement={18}
+          refine={refine}
+        />
+      );
+      const pages = wrapper.find('.ais-Pagination__itemPage');
+      const pageSelected = wrapper.find('.ais-Pagination__itemLinkSelected');
+      // Since pagesPadding = 2, the Pagination widget's size should be 5
+      expect(pages.length).toBe(5);
+
+      expect(pages.first().text()).toEqual('14');
+      expect(pages.at(1).text()).toEqual('15');
+      expect(pages.at(2).text()).toEqual('16');
+      expect(pages.at(3).text()).toEqual('17');
+
+      expect(pageSelected.first().text()).toEqual('18');
+      expect(pages.at(4).text()).toEqual('18');
+    });
+    it('should render the correct padding in every other case', () => {
+      const refine = jest.fn();
+      const wrapper = mount(
+        <Pagination
+          {...REQ_PROPS}
+          nbPages={18}
+          showLast
+          pagesPadding={2}
+          currentRefinement={8}
+          refine={refine}
+        />
+      );
+      const pages = wrapper.find('.ais-Pagination__itemPage');
+      const pageSelected = wrapper.find('.ais-Pagination__itemLinkSelected');
+      // Since pagesPadding = 2, the Pagination widget's size should be 5
+      expect(pages.length).toBe(5);
+
+      expect(pages.first().text()).toEqual('6');
+      expect(pages.at(1).text()).toEqual('7');
+
+      expect(pageSelected.first().text()).toEqual('8');
+      expect(pages.at(2).text()).toEqual('8');
+
+      expect(pages.at(3).text()).toEqual('9');
+      expect(pages.at(4).text()).toEqual('10');
+    });
+  });
 });

--- a/packages/react-instantsearch/src/components/__snapshots__/Pagination.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/Pagination.test.js.snap
@@ -35,6 +35,19 @@ exports[`Pagination allows toggling display of the first page button on and off 
     disabled={undefined}
   >
     <a
+      aria-label="Page 6"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      6
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 7"
       className="ais-Pagination__itemLink"
       href="#"
@@ -106,19 +119,6 @@ exports[`Pagination allows toggling display of the first page button on and off 
       onClick={[Function]}
     >
       12
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 13"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      13
     </a>
   </li>
   <li
@@ -159,6 +159,19 @@ exports[`Pagination allows toggling display of the first page button on and off 
     disabled={undefined}
   >
     <a
+      aria-label="Page 6"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      6
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 7"
       className="ais-Pagination__itemLink"
       href="#"
@@ -230,19 +243,6 @@ exports[`Pagination allows toggling display of the first page button on and off 
       onClick={[Function]}
     >
       12
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 13"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      13
     </a>
   </li>
   <li
@@ -296,6 +296,19 @@ exports[`Pagination allows toggling display of the last page button on and off 1
     disabled={undefined}
   >
     <a
+      aria-label="Page 6"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      6
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 7"
       className="ais-Pagination__itemLink"
       href="#"
@@ -367,19 +380,6 @@ exports[`Pagination allows toggling display of the last page button on and off 1
       onClick={[Function]}
     >
       12
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 13"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      13
     </a>
   </li>
   <li
@@ -446,6 +446,19 @@ exports[`Pagination allows toggling display of the last page button on and off 2
     disabled={undefined}
   >
     <a
+      aria-label="Page 6"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      6
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 7"
       className="ais-Pagination__itemLink"
       href="#"
@@ -517,19 +530,6 @@ exports[`Pagination allows toggling display of the last page button on and off 2
       onClick={[Function]}
     >
       12
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 13"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      13
     </a>
   </li>
   <li
@@ -583,6 +583,19 @@ exports[`Pagination allows toggling display of the next page button on and off 1
     disabled={undefined}
   >
     <a
+      aria-label="Page 6"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      6
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 7"
       className="ais-Pagination__itemLink"
       href="#"
@@ -654,19 +667,6 @@ exports[`Pagination allows toggling display of the next page button on and off 1
       onClick={[Function]}
     >
       12
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 13"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      13
     </a>
   </li>
   <li
@@ -720,6 +720,19 @@ exports[`Pagination allows toggling display of the next page button on and off 2
     disabled={undefined}
   >
     <a
+      aria-label="Page 6"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      6
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 7"
       className="ais-Pagination__itemLink"
       href="#"
@@ -791,19 +804,6 @@ exports[`Pagination allows toggling display of the next page button on and off 2
       onClick={[Function]}
     >
       12
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 13"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      13
     </a>
   </li>
 </ul>
@@ -844,6 +844,19 @@ exports[`Pagination allows toggling display of the previous page button on and o
     disabled={undefined}
   >
     <a
+      aria-label="Page 6"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      6
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 7"
       className="ais-Pagination__itemLink"
       href="#"
@@ -915,19 +928,6 @@ exports[`Pagination allows toggling display of the previous page button on and o
       onClick={[Function]}
     >
       12
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 13"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      13
     </a>
   </li>
   <li
@@ -968,6 +968,19 @@ exports[`Pagination allows toggling display of the previous page button on and o
     disabled={undefined}
   >
     <a
+      aria-label="Page 6"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      6
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 7"
       className="ais-Pagination__itemLink"
       href="#"
@@ -1039,19 +1052,6 @@ exports[`Pagination allows toggling display of the previous page button on and o
       onClick={[Function]}
     >
       12
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 13"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      13
     </a>
   </li>
   <li
@@ -1105,6 +1105,19 @@ exports[`Pagination applies its default props 1`] = `
     disabled={undefined}
   >
     <a
+      aria-label="Page 6"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      6
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 7"
       className="ais-Pagination__itemLink"
       href="#"
@@ -1176,19 +1189,6 @@ exports[`Pagination applies its default props 1`] = `
       onClick={[Function]}
     >
       12
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 13"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      13
     </a>
   </li>
   <li
@@ -1478,6 +1478,19 @@ exports[`Pagination displays the correct padding of links 2`] = `
     disabled={undefined}
   >
     <a
+      aria-label="Page 5"
+      className="ais-Pagination__itemLink"
+      href="#"
+      onClick={[Function]}
+    >
+      5
+    </a>
+  </li>
+  <li
+    className="ais-Pagination__item ais-Pagination__itemPage"
+    disabled={undefined}
+  >
+    <a
       aria-label="Page 6"
       className="ais-Pagination__itemLink"
       href="#"
@@ -1575,19 +1588,6 @@ exports[`Pagination displays the correct padding of links 2`] = `
       onClick={[Function]}
     >
       13
-    </a>
-  </li>
-  <li
-    className="ais-Pagination__item ais-Pagination__itemPage"
-    disabled={undefined}
-  >
-    <a
-      aria-label="Page 14"
-      className="ais-Pagination__itemLink"
-      href="#"
-      onClick={[Function]}
-    >
-      14
     </a>
   </li>
   <li


### PR DESCRIPTION
This fixes the pagesPadding offset: it used to be off-by-one (see screenshot attached where the padding is 3 by default).

![screen shot 2017-08-16 at 10 22 08](https://user-images.githubusercontent.com/21305268/29354138-cf117ac2-826c-11e7-9f0a-5d71c178c02e.png)

**Summary**

Changed the offset + added some tests.

**Result**
The offset no longer exists and the widgets shows the same number of pages on each side of the currently selected page.
<img width="452" alt="screen shot 2017-08-16 at 10 26 25" src="https://user-images.githubusercontent.com/21305268/29354292-620c80b0-826d-11e7-863d-c5aea7c0e16d.png">
