### PR TITLE
[RFC] Adds support for any type of renderable element in List component

### DIFF
--- a/packages/react-instantsearch/src/components/List.js
+++ b/packages/react-instantsearch/src/components/List.js
@@ -5,7 +5,7 @@ import SearchBox from '../components/SearchBox';
 const itemsPropType = PropTypes.arrayOf(
   PropTypes.shape({
     value: PropTypes.any,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
     items: (...args) => itemsPropType(...args),
   })
 );


### PR DESCRIPTION
**Summary**
I have been using the `<MultiRange />` like this:

```jsx
<MultiRange
  attributeName="computed_price"
  items={[
    {
      end: 10,
      label: [
        <span key={0}>&lt; </span>,
        <Price key={1} pence={1000} displayCurrency="GBP" />
      ]
    },
    {
      start: 10,
      end: 100,
      label: [
        <Price key={0} pence={1000} displayCurrency="GBP" />,
        <span key={1}> - </span>,
        <Price key={2} pence={10000} displayCurrency="GBP" />
      ]
    },
    {
      start: 100,
      end: 500,
      label: [
        <Price key={0} pence={10000} displayCurrency="GBP" />,
        <span key={1}> - </span>,
        <Price key={2} pence={50000} displayCurrency="GBP" />
      ]
    },
    {
      start: 500,
      label: [
        <span key={0}> &gt; </span>,
        <Price key={1} pence={50000} displayCurrency="GBP" />
      ]
    }
  ]}
/>
```

According to the propTypes, defined in the MultiRange component, it's meant to accept any renderable element ([`PropTypes.node`](https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch/src/components/MultiRange.js#L13))

Using the component like mentioned above, would throw a proptypes validation error of:
```
Warning: Failed prop type: Invalid prop `items[0].label` of type `array` supplied to `List`, expected `string`.
    in List (created by MultiRange)
    in MultiRange (created by Translatable(MultiRange))
```

Digging further, the `MultiRange` component uses the `List` component whose propTypes [don't match the same propTypes](https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch/src/components/List.js#L8)

**Result**

The updated propTypes remove the warning from showing up. Accepting a `node` here makes sense, as it wouldn't start throwing any other warning in other components, whatever is passed to it, as long as it is an item that can be rendered.

**Related**

https://github.com/algolia/react-instantsearch/issues/102