### PR TITLE
Fix connectRange ignores boundaries on first call

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -123,7 +123,7 @@ export default createConnector({
   getProvidedProps(props, searchState, searchResults) {
     const { attributeName, min: minBound, max: maxBound } = props;
     const results = getResults(searchResults, this.context);
-    const stats = results ? results.getFacetStats(attributeName) : {};
+    const stats = results ? results.getFacetStats(attributeName) || {} : {};
     const count = results
       ? results.getFacetValues(attributeName).map(v => ({
           value: v.name,

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -32,7 +32,7 @@ function getId(props) {
 const namespace = 'range';
 
 function getCurrentRefinement(props, searchState, context) {
-  return getCurrentRefinementValue(
+  const refinement = getCurrentRefinementValue(
     props,
     searchState,
     context,
@@ -49,6 +49,19 @@ function getCurrentRefinement(props, searchState, context) {
       return { min, max };
     }
   );
+
+  const hasMin = props.min !== undefined;
+  const hasMax = props.max !== undefined;
+
+  if (hasMin && refinement.min === undefined) {
+    refinement.min = props.min;
+  }
+
+  if (hasMax && refinement.max === undefined) {
+    refinement.max = props.max;
+  }
+
+  return refinement;
 }
 
 function refine(props, searchState, nextRefinement, context) {

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -39,7 +39,7 @@ function getCurrentRange(boundaries, stats) {
   } else if (_isFinite(stats.min)) {
     min = stats.min;
   } else {
-    min = -Infinity;
+    min = undefined;
   }
 
   let max;
@@ -48,7 +48,7 @@ function getCurrentRange(boundaries, stats) {
   } else if (_isFinite(stats.max)) {
     max = stats.max;
   } else {
-    max = Infinity;
+    max = undefined;
   }
 
   return {

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -50,14 +50,11 @@ function getCurrentRefinement(props, searchState, context) {
     }
   );
 
-  const hasMin = props.min !== undefined;
-  const hasMax = props.max !== undefined;
-
-  if (hasMin && refinement.min === undefined) {
+  if (props.min !== undefined && refinement.min === undefined) {
     refinement.min = props.min;
   }
 
-  if (hasMax && refinement.max === undefined) {
+  if (props.max !== undefined && refinement.max === undefined) {
     refinement.max = props.max;
   }
 

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { isFinite as _isFinite } from 'lodash';
 import {
   cleanUpValue,
   getIndex,
@@ -62,7 +63,10 @@ function getCurrentRefinement(props, searchState, context) {
 }
 
 function refine(props, searchState, nextRefinement, context) {
-  if (!isFinite(nextRefinement.min) || !isFinite(nextRefinement.max)) {
+  if (
+    !_isFinite(parseFloat(nextRefinement.min)) ||
+    !_isFinite(parseFloat(nextRefinement.max))
+  ) {
     throw new Error(
       "You can't provide non finite values to the range connector"
     );

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -192,36 +192,41 @@ export default createConnector({
   },
 
   getMetadata(props, searchState) {
-    const id = getId(props);
-    const currentRefinement = getCurrentRefinement(
+    const { min: minRange, max: maxRange } = this._currentRange;
+    const { min: minValue, max: maxValue } = getCurrentRefinement(
       props,
       searchState,
       this.context
     );
-    let item;
-    const hasMin = typeof currentRefinement.min !== 'undefined';
-    const hasMax = typeof currentRefinement.max !== 'undefined';
-    if (hasMin || hasMax) {
-      let itemLabel = '';
-      if (hasMin) {
-        itemLabel += `${currentRefinement.min} <= `;
-      }
-      itemLabel += props.attributeName;
-      if (hasMax) {
-        itemLabel += ` <= ${currentRefinement.max}`;
-      }
-      item = {
-        label: itemLabel,
-        currentRefinement,
+
+    const items = [];
+    const hasMin = minValue !== undefined;
+    const hasMax = maxValue !== undefined;
+    const shouldDisplayMinLabel = hasMin && minValue !== minRange;
+    const shouldDisplayMaxLabel = hasMax && maxValue !== maxRange;
+
+    if (shouldDisplayMinLabel || shouldDisplayMaxLabel) {
+      const fragments = [
+        hasMin ? `${minValue} <= ` : '',
+        props.attributeName,
+        hasMax ? ` <= ${maxValue}` : '',
+      ];
+
+      items.push({
+        label: fragments.join(''),
         attributeName: props.attributeName,
         value: nextState => cleanUp(props, nextState, this.context),
-      };
+        currentRefinement: {
+          min: minValue,
+          max: maxValue,
+        },
+      });
     }
 
     return {
-      id,
+      id: getId(props),
       index: getIndex(this.context),
-      items: item ? [item] : [],
+      items,
     };
   },
 });

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -127,14 +127,36 @@ describe('connectRange', () => {
     });
 
     it('calling refine with non finite values should fail', () => {
-      function shouldNotRefine() {
+      function shouldNotRefineWithNaN() {
         refine(
           { attributeName: 'ok' },
           { otherKey: 'val', range: { otherKey: { min: 1, max: 2 } } },
           { min: NaN, max: 5 }
         );
       }
-      expect(shouldNotRefine).toThrowError(
+      expect(shouldNotRefineWithNaN).toThrowError(
+        "You can't provide non finite values to the range connector"
+      );
+
+      function shouldNotRefineWithNull() {
+        refine(
+          { attributeName: 'ok' },
+          { otherKey: 'val', range: { otherKey: { min: 1, max: 2 } } },
+          { min: null, max: 5 }
+        );
+      }
+      expect(shouldNotRefineWithNull).toThrowError(
+        "You can't provide non finite values to the range connector"
+      );
+
+      function shouldNotRefineWithUndefined() {
+        refine(
+          { attributeName: 'ok' },
+          { otherKey: 'val', range: { otherKey: { min: 1, max: 2 } } },
+          { min: undefined, max: 5 }
+        );
+      }
+      expect(shouldNotRefineWithUndefined).toThrowError(
         "You can't provide non finite values to the range connector"
       );
     });

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -30,7 +30,7 @@ describe('connectRange', () => {
         canRefine: false,
       });
 
-      const results = {
+      let results = {
         getFacetStats: () => ({ min: 5, max: 10 }),
         getFacetValues: () => [
           { name: '5', count: 10 },
@@ -46,6 +46,29 @@ describe('connectRange', () => {
         currentRefinement: { min: 5, max: 10 },
         count: [{ value: '5', count: 10 }, { value: '2', count: 20 }],
         canRefine: true,
+      });
+
+      results = {
+        getFacetStats: () => {},
+        getFacetValues: () => [],
+        hits: [],
+      };
+      props = getProvidedProps(
+        {
+          attributeName: 'ok',
+        },
+        {},
+        { results }
+      );
+      expect(props).toEqual({
+        min: -Infinity,
+        max: Infinity,
+        currentRefinement: {
+          min: -Infinity,
+          max: Infinity,
+        },
+        count: [],
+        canRefine: false,
       });
 
       props = getProvidedProps(

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -54,7 +54,16 @@ describe('connectRange', () => {
         { ok: { min: 6, max: 9 } },
         {}
       );
-      expect(props).toEqual({ canRefine: false });
+      expect(props).toEqual({
+        min: -Infinity,
+        max: Infinity,
+        currentRefinement: {
+          min: -Infinity,
+          max: Infinity,
+        },
+        count: [],
+        canRefine: false,
+      });
 
       props = getProvidedProps(
         {

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -14,7 +14,6 @@ describe('connectRange', () => {
     const getProvidedProps = connect.getProvidedProps.bind(context);
     const refine = connect.refine.bind(context);
     const getSearchParameters = connect.getSearchParameters.bind(context);
-    const getMetadata = connect.getMetadata.bind(context);
     const cleanUp = connect.cleanUp.bind(context);
 
     it('provides the correct props to the component', () => {
@@ -195,7 +194,11 @@ describe('connectRange', () => {
     });
 
     it('registers its filter in metadata', () => {
-      let metadata = getMetadata(
+      let metadata = connect.getMetadata.call(
+        {
+          ...context,
+          _currentRange: { min: 0, max: 100 },
+        },
         { attributeName: 'wot' },
         { range: { wot: { min: 5 } } }
       );
@@ -218,7 +221,11 @@ describe('connectRange', () => {
       });
       expect(searchState).toEqual({ range: {} });
 
-      metadata = getMetadata(
+      metadata = connect.getMetadata.call(
+        {
+          ...context,
+          _currentRange: { min: 0, max: 100 },
+        },
         { attributeName: 'wot' },
         { range: { wot: { max: 10 } } }
       );
@@ -235,7 +242,11 @@ describe('connectRange', () => {
         ],
       });
 
-      metadata = getMetadata(
+      metadata = connect.getMetadata.call(
+        {
+          ...context,
+          _currentRange: { min: 0, max: 100 },
+        },
         { attributeName: 'wot' },
         { range: { wot: { min: 5, max: 10 } } }
       );
@@ -254,7 +265,11 @@ describe('connectRange', () => {
     });
 
     it('items value function should clear it from the search state', () => {
-      const metadata = getMetadata(
+      const metadata = connect.getMetadata.call(
+        {
+          ...context,
+          _currentRange: { min: 0, max: 100 },
+        },
         { attributeName: 'one' },
         { range: { one: { min: 5 }, two: { max: 4 } } }
       );
@@ -286,8 +301,9 @@ describe('connectRange', () => {
       });
     });
   });
+
   describe('multi index', () => {
-    let context = {
+    const context = {
       context: {
         ais: { mainTargetedIndex: 'first' },
         multiIndexContext: { targetedIndex: 'first' },
@@ -295,7 +311,6 @@ describe('connectRange', () => {
     };
     const getProvidedProps = connect.getProvidedProps.bind(context);
     const getSearchParameters = connect.getSearchParameters.bind(context);
-    const getMetadata = connect.getMetadata.bind(context);
     const cleanUp = connect.cleanUp.bind(context);
 
     it('provides the correct props to the component', () => {
@@ -339,9 +354,10 @@ describe('connectRange', () => {
     });
 
     it("calling refine updates the widget's search state", () => {
-      let refine = connect.refine.bind(context);
-
-      let nextState = refine(
+      let nextState = connect.refine.call(
+        {
+          ...context,
+        },
         { attributeName: 'ok' },
         {
           otherKey: 'val',
@@ -359,15 +375,13 @@ describe('connectRange', () => {
         },
       });
 
-      context = {
-        context: {
-          ais: { mainTargetedIndex: 'first' },
-          multiIndexContext: { targetedIndex: 'second' },
+      nextState = connect.refine.call(
+        {
+          context: {
+            ais: { mainTargetedIndex: 'first' },
+            multiIndexContext: { targetedIndex: 'second' },
+          },
         },
-      };
-      refine = connect.refine.bind(context);
-
-      nextState = refine(
         { attributeName: 'ok' },
         {
           otherKey: 'val',
@@ -397,7 +411,11 @@ describe('connectRange', () => {
     });
 
     it('registers its filter in metadata', () => {
-      let metadata = getMetadata(
+      let metadata = connect.getMetadata.call(
+        {
+          ...context,
+          _currentRange: { min: 0, max: 100 },
+        },
         { attributeName: 'wot' },
         { indices: { first: { range: { wot: { min: 5 } } } } }
       );
@@ -420,7 +438,11 @@ describe('connectRange', () => {
       });
       expect(searchState).toEqual({ indices: { first: { range: {} } } });
 
-      metadata = getMetadata(
+      metadata = connect.getMetadata.call(
+        {
+          ...context,
+          _currentRange: { min: 0, max: 100 },
+        },
         { attributeName: 'wot' },
         { indices: { first: { range: { wot: { max: 10 } } } } }
       );
@@ -439,7 +461,11 @@ describe('connectRange', () => {
     });
 
     it('items value function should clear it from the search state', () => {
-      const metadata = getMetadata(
+      const metadata = connect.getMetadata.call(
+        {
+          ...context,
+          _currentRange: { min: 0, max: 100 },
+        },
         { attributeName: 'one' },
         { indices: { first: { range: { one: { min: 5 }, two: { max: 4 } } } } }
       );

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -13,7 +13,7 @@ describe('connectRange', () => {
     const context = { context: { ais: { mainTargetedIndex: 'index' } } };
     const getProvidedProps = connect.getProvidedProps.bind(context);
     const refine = connect.refine.bind(context);
-    const getSP = connect.getSearchParameters.bind(context);
+    const getSearchParameters = connect.getSearchParameters.bind(context);
     const getMetadata = connect.getMetadata.bind(context);
     const cleanUp = connect.cleanUp.bind(context);
 
@@ -140,11 +140,23 @@ describe('connectRange', () => {
     });
 
     it('refines the corresponding numeric facet', () => {
-      params = getSP(
+      params = getSearchParameters(
         new SearchParameters(),
         { attributeName: 'facet' },
         { range: { facet: { min: 10, max: 30 } } }
       );
+
+      expect(params.getNumericRefinements('facet')).toEqual({
+        '>=': [10],
+        '<=': [30],
+      });
+
+      params = getSearchParameters(
+        new SearchParameters(),
+        { attributeName: 'facet', min: 10, max: 30 },
+        {}
+      );
+
       expect(params.getNumericRefinements('facet')).toEqual({
         '>=': [10],
         '<=': [30],
@@ -251,7 +263,7 @@ describe('connectRange', () => {
       },
     };
     const getProvidedProps = connect.getProvidedProps.bind(context);
-    const getSP = connect.getSearchParameters.bind(context);
+    const getSearchParameters = connect.getSearchParameters.bind(context);
     const getMetadata = connect.getMetadata.bind(context);
     const cleanUp = connect.cleanUp.bind(context);
 
@@ -342,7 +354,7 @@ describe('connectRange', () => {
     });
 
     it('refines the corresponding numeric facet', () => {
-      params = getSP(
+      params = getSearchParameters(
         new SearchParameters(),
         { attributeName: 'facet' },
         { indices: { first: { range: { facet: { min: 10, max: 30 } } } } }

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -61,11 +61,11 @@ describe('connectRange', () => {
         { results }
       );
       expect(props).toEqual({
-        min: -Infinity,
-        max: Infinity,
+        min: undefined,
+        max: undefined,
         currentRefinement: {
-          min: -Infinity,
-          max: Infinity,
+          min: undefined,
+          max: undefined,
         },
         count: [],
         canRefine: false,
@@ -77,11 +77,11 @@ describe('connectRange', () => {
         {}
       );
       expect(props).toEqual({
-        min: -Infinity,
-        max: Infinity,
+        min: undefined,
+        max: undefined,
         currentRefinement: {
-          min: -Infinity,
-          max: Infinity,
+          min: undefined,
+          max: undefined,
         },
         count: [],
         canRefine: false,

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -262,6 +262,20 @@ describe('connectRange', () => {
           },
         ],
       });
+
+      metadata = connect.getMetadata.call(
+        {
+          ...context,
+          _currentRange: { min: 0, max: 100 },
+        },
+        { attributeName: 'wot' },
+        { range: { wot: { min: 0, max: 100 } } }
+      );
+      expect(metadata).toEqual({
+        id: 'wot',
+        index: 'index',
+        items: [],
+      });
     });
 
     it('items value function should clear it from the search state', () => {
@@ -457,6 +471,20 @@ describe('connectRange', () => {
             value: metadata.items[0].value,
           },
         ],
+      });
+
+      metadata = connect.getMetadata.call(
+        {
+          ...context,
+          _currentRange: { min: 0, max: 100 },
+        },
+        { attributeName: 'wot' },
+        { indices: { first: { range: { wot: { max: 100 } } } } }
+      );
+      expect(metadata).toEqual({
+        id: 'wot',
+        index: 'first',
+        items: [],
       });
     });
 

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -18,16 +18,36 @@ stories
       <RangeInput attributeName="price" />
     </WrapWithHits>
   ))
-  .add('playground', () => (
+  .add('with default value', () => (
     <WrapWithHits linkedStoryGroup="RangeInput">
       <RangeInput
         attributeName="price"
-        min={number('max', 0)}
-        max={number('max', 300)}
-        translations={object('translations', {
-          submit: ' go',
-          separator: 'to',
-        })}
+        defaultRefinement={{ min: 50, max: 200 }}
+      />
+    </WrapWithHits>
+  ))
+  .add('with min boundaries', () => (
+    <WrapWithHits linkedStoryGroup="RangeInput">
+      <RangeInput attributeName="price" min={30} />
+    </WrapWithHits>
+  ))
+  .add('with max boundaries', () => (
+    <WrapWithHits linkedStoryGroup="RangeInput">
+      <RangeInput attributeName="price" max={500} />
+    </WrapWithHits>
+  ))
+  .add('with min / max boundaries', () => (
+    <WrapWithHits linkedStoryGroup="RangeInput">
+      <RangeInput attributeName="price" min={30} max={500} />
+    </WrapWithHits>
+  ))
+  .add('with boundaries and default value', () => (
+    <WrapWithHits linkedStoryGroup="RangeInput">
+      <RangeInput
+        attributeName="price"
+        min={30}
+        max={500}
+        defaultRefinement={{ min: 50, max: 200 }}
       />
     </WrapWithHits>
   ))
@@ -46,5 +66,19 @@ stories
           <SearchBox defaultRefinement="ds" />
         </div>
       </Panel>
+    </WrapWithHits>
+  ))
+  .add('playground', () => (
+    <WrapWithHits linkedStoryGroup="RangeInput">
+      <RangeInput
+        attributeName="price"
+        min={number('min', 0)}
+        max={number('max', 500)}
+        defaultRefinement={object('default value', { min: 100, max: 400 })}
+        translations={object('translations', {
+          submit: ' go',
+          separator: 'to',
+        })}
+      />
     </WrapWithHits>
   ));


### PR DESCRIPTION
**Summary**

Fix #384 

This PR only fix the problem related to missing boundaries on first call.

**Result**

You can play with the `RangeInput` & `RangeSlider` widget on Storybook.

* set boundaries on the widget
* the results should normally be filter with the provided boundaries

**Before**:

<img width="454" alt="screen shot 2017-10-04 at 18 36 21" src="https://user-images.githubusercontent.com/6513513/31187726-075e5be2-a933-11e7-9219-7f66808ec9e5.png">

**After**:

<img width="454" alt="screen shot 2017-10-04 at 18 36 30" src="https://user-images.githubusercontent.com/6513513/31187729-09d78d58-a933-11e7-8df7-9e3f2af2b474.png">

