### PR TITLE
docs(website): widgets and connectors have the same desc

### DIFF
--- a/docgen/layouts/common/meta.pug
+++ b/docgen/layouts/common/meta.pug
@@ -1,4 +1,4 @@
-- var description = "Add instant-search and autocomplete to your React and React Native apps with a few lines of code. Powered by Algolia."
+- var long_desc = "Add instant-search and autocomplete to your React and React Native apps with a few lines of code. Powered by Algolia."
 - var project     = "React InstantSearch"
 - var image       = "https://res.cloudinary.com/hilnmyskv/image/upload/v1502375309/InstantSearch-React-OG_zbf1tb.png"
 - var url         = "https://community.algolia.com/react-instantsearch/"
@@ -14,7 +14,7 @@ html
     meta(content='width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no', name='viewport')
     link(rel='icon', href="assets/img/favicon.png")
     meta(content='IE=edge,chrome=1', http-equiv='X-UA-Compatible')
-    meta(content=description, name='description')
+    meta(content=long_desc, name='description')
     meta(content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0', name='viewport')
     // / Twitter card
     meta(content='summary_large_image', name='twitter:card')


### PR DESCRIPTION
Widgets and connectors had an hardcoded description (same global variable name shared between our jsdoc parsing and the meta.pug file) 