### PR TITLE
fix(InfiniteHits): add disabled style to the LoadMore button

### DIFF
--- a/packages/react-instantsearch-theme-algolia/styles/_InfiniteHits.scss
+++ b/packages/react-instantsearch-theme-algolia/styles/_InfiniteHits.scss
@@ -4,8 +4,5 @@
 .ais-InfiniteHits__loadMore {
   @include buttonTernary();
   @include buttonLink();
-
-  &[disabled] {
-    @include disabled();
-  }
+  @include disabled();
 }

--- a/packages/react-instantsearch-theme-algolia/styles/_InfiniteHits.scss
+++ b/packages/react-instantsearch-theme-algolia/styles/_InfiniteHits.scss
@@ -1,7 +1,11 @@
 .ais-InfiniteHits__root {
 }
 
-.ais-InfiniteHits__root button {
+.ais-InfiniteHits__loadMore {
   @include buttonTernary();
   @include buttonLink();
+
+  &[disabled] {
+    @include disabled();
+  }
 }


### PR DESCRIPTION
Add a `disabled` style to the LoadMore button on Algolia theme.

fixes https://github.com/algolia/react-instantsearch/issues/119