### PR TITLE
Fix RangeInput react@16

### DIFF
--- a/packages/react-instantsearch/src/components/Panel.js
+++ b/packages/react-instantsearch/src/components/Panel.js
@@ -20,11 +20,16 @@ class Panel extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { canRefine: true };
-    this.canRefine = canRefine => {
-      this.setState({ canRefine });
+
+    this.state = {
+      canRefine: true,
     };
   }
+
+  canRefine = canRefine => {
+    this.setState({ canRefine });
+  };
+
   render() {
     return (
       <div {...cx('root', !this.state.canRefine && 'noRefinement')}>

--- a/packages/react-instantsearch/src/components/RangeInput.js
+++ b/packages/react-instantsearch/src/components/RangeInput.js
@@ -50,9 +50,11 @@ export class RawRangeInput extends Component {
     // to avoid to override current state when values are not yet refined. In the react documentation,
     // they DON'T categorically say that setState never run componentWillReceiveProps.
     // see: https://reactjs.org/docs/react-component.html#componentwillreceiveprops
+
     if (
       nextProps.canRefine &&
-      (this.props.currentRefinement.min !== nextProps.currentRefinement.min ||
+      (this.props.canRefine !== nextProps.canRefine ||
+        this.props.currentRefinement.min !== nextProps.currentRefinement.min ||
         this.props.currentRefinement.max !== nextProps.currentRefinement.max)
     ) {
       this.setState({

--- a/packages/react-instantsearch/src/components/RangeInput.js
+++ b/packages/react-instantsearch/src/components/RangeInput.js
@@ -6,8 +6,9 @@ import classNames from './classNames.js';
 
 const cx = classNames('RangeInput');
 
-class RangeInput extends Component {
+export class RawRangeInput extends Component {
   static propTypes = {
+    canRefine: PropTypes.bool.isRequired,
     translate: PropTypes.func.isRequired,
     refine: PropTypes.func.isRequired,
     min: PropTypes.number,
@@ -16,7 +17,10 @@ class RangeInput extends Component {
       min: PropTypes.number,
       max: PropTypes.number,
     }),
-    canRefine: PropTypes.bool.isRequired,
+  };
+
+  static defaultProps = {
+    currentRefinement: {},
   };
 
   static contextTypes = {
@@ -25,23 +29,37 @@ class RangeInput extends Component {
 
   constructor(props) {
     super(props);
-    this.state = this.props.canRefine
-      ? { from: props.currentRefinement.min, to: props.currentRefinement.max }
-      : { from: '', to: '' };
+
+    this.state = {
+      from: this.props.canRefine ? props.currentRefinement.min : '',
+      to: this.props.canRefine ? props.currentRefinement.max : '',
+    };
   }
 
   componentWillMount() {
-    if (this.context.canRefine) this.context.canRefine(this.props.canRefine);
+    if (this.context.canRefine) {
+      this.context.canRefine(this.props.canRefine);
+    }
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.canRefine) {
+    if (
+      nextProps.canRefine &&
+      (this.props.currentRefinement.min !== nextProps.currentRefinement.min ||
+        this.props.currentRefinement.max !== nextProps.currentRefinement.max)
+    ) {
       this.setState({
         from: nextProps.currentRefinement.min,
         to: nextProps.currentRefinement.max,
       });
     }
-    if (this.context.canRefine) this.context.canRefine(nextProps.canRefine);
+
+    if (
+      this.context.canRefine &&
+      this.props.canRefine !== nextProps.canRefine
+    ) {
+      this.context.canRefine(nextProps.canRefine);
+    }
   }
 
   onSubmit = e => {
@@ -92,4 +110,4 @@ class RangeInput extends Component {
 export default translatable({
   submit: 'ok',
   separator: 'to',
-})(RangeInput);
+})(RawRangeInput);

--- a/packages/react-instantsearch/src/components/RangeInput.js
+++ b/packages/react-instantsearch/src/components/RangeInput.js
@@ -43,6 +43,13 @@ export class RawRangeInput extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    // In react@16.0.0 the call to setState on the inputs trigger this lifecycle hook
+    // because the context has changed (for react). I don't think that the bug is related
+    // to react because I failed to reproduce it with a simple hierarchy of components.
+    // The workaround here is to check the differences between previous & next props in order
+    // to avoid to override current state when values are not yet refined. In the react documentation,
+    // they DON'T categorically say that setState never run componentWillReceiveProps.
+    // see: https://reactjs.org/docs/react-component.html#componentwillreceiveprops
     if (
       nextProps.canRefine &&
       (this.props.currentRefinement.min !== nextProps.currentRefinement.min ||

--- a/packages/react-instantsearch/src/components/RangeInput.test.js
+++ b/packages/react-instantsearch/src/components/RangeInput.test.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 import React from 'react';
 import renderer from 'react-test-renderer';
-import Enzyme, { mount } from 'enzyme';
+import Enzyme, { mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 Enzyme.configure({ adapter: new Adapter() });
 
-import RangeInput from './RangeInput';
+import RangeInput, { RawRangeInput } from './RangeInput';
 
 describe('RangeInput', () => {
   it('supports passing max/min values', () => {
@@ -44,6 +44,121 @@ describe('RangeInput', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('expect to applies changes when props have changed ', () => {
+    const wrapper = shallow(
+      <RawRangeInput
+        createURL={() => '#'}
+        refine={() => {}}
+        min={0}
+        max={100}
+        currentRefinement={{ min: 0, max: 100 }}
+        canRefine={true}
+        translate={x => x}
+      />
+    );
+
+    wrapper.setProps({
+      currentRefinement: {
+        min: 10,
+        max: 90,
+      },
+    });
+
+    wrapper.update();
+
+    expect(wrapper.state()).toEqual({
+      from: 10,
+      to: 90,
+    });
+  });
+
+  it("expect to don't applies changes when props don't have changed", () => {
+    const wrapper = shallow(
+      <RawRangeInput
+        createURL={() => '#'}
+        refine={() => {}}
+        min={0}
+        max={100}
+        currentRefinement={{ min: 0, max: 100 }}
+        canRefine={true}
+        translate={x => x}
+      />
+    );
+
+    wrapper.setState({
+      from: 10,
+      to: 90,
+    });
+
+    wrapper.setProps({
+      currentRefinement: {
+        min: 0,
+        max: 100,
+      },
+    });
+
+    wrapper.update();
+
+    expect(wrapper.state()).toEqual({
+      from: 10,
+      to: 90,
+    });
+  });
+
+  it('expect to call context canRefine when props changed', () => {
+    const context = {
+      canRefine: jest.fn(),
+    };
+
+    const wrapper = shallow(
+      <RawRangeInput
+        createURL={() => '#'}
+        refine={() => {}}
+        min={0}
+        max={100}
+        currentRefinement={{ min: 0, max: 100 }}
+        canRefine={true}
+        translate={x => x}
+      />,
+      {
+        context,
+      }
+    );
+
+    wrapper.setProps({
+      canRefine: false,
+    });
+
+    expect(context.canRefine).toHaveBeenCalledTimes(2);
+  });
+
+  it("expect to not call context canRefine when props don't have changed", () => {
+    const context = {
+      canRefine: jest.fn(),
+    };
+
+    const wrapper = shallow(
+      <RawRangeInput
+        createURL={() => '#'}
+        refine={() => {}}
+        min={0}
+        max={100}
+        currentRefinement={{ min: 0, max: 100 }}
+        canRefine={true}
+        translate={x => x}
+      />,
+      {
+        context,
+      }
+    );
+
+    wrapper.setProps({
+      canRefine: true,
+    });
+
+    expect(context.canRefine).toHaveBeenCalledTimes(1);
   });
 
   it('refines its value on change', () => {

--- a/packages/react-instantsearch/src/components/RangeInput.test.js
+++ b/packages/react-instantsearch/src/components/RangeInput.test.js
@@ -54,12 +54,13 @@ describe('RangeInput', () => {
         min={0}
         max={100}
         currentRefinement={{ min: 0, max: 100 }}
-        canRefine={true}
+        canRefine={false}
         translate={x => x}
       />
     );
 
     wrapper.setProps({
+      canRefine: true,
       currentRefinement: {
         min: 10,
         max: 90,
@@ -93,6 +94,7 @@ describe('RangeInput', () => {
     });
 
     wrapper.setProps({
+      canRefine: true,
       currentRefinement: {
         min: 0,
         max: 100,


### PR DESCRIPTION
**Summary**

Since we upgraded to `react@16` the `RangeInput` with a `Panel` has stopped working. The problem is that: for an strange reason when we call `setState` for update the current value inside the inputs, the lifecycle hook `componentWillReceiveProps` is called. Since we don't check that the previous values have **really** changed the state is always override with the original values from set on the `searchState`.

This is only a workaround the real problem is that the hook is called and it should not be called. I tried to dig a little and actually for `react` the `context` really changed before & after the setState that's why the hook is called. But I don't figure out why it changed... I tried to always return the same object from the `Panel::getChildContext`, it actually works but nobody does that and nobody have a problem with that ;) As I said in the code comment I don't think that's a bug related to `react` because I failed to reproduce the same behaviour with a simple hierarchy of components.

Actually inside the documentation of `react` they don't categorically say that `setState` never run the hook `componentWillReceiveProps`. But they say to **always** verify that real changes occur inside this hook.

[See documentation](https://reactjs.org/docs/react-component.html#componentwillreceiveprops)

**Result**

You can play with the `RangeInput` with `Panel` on Storybook. And you can also try the ecommerce example inside the documentation.

**Before**:

![before](https://user-images.githubusercontent.com/6513513/31553563-2da1e90e-b03b-11e7-926c-42dca78133ce.gif)

**After**:

![after](https://user-images.githubusercontent.com/6513513/31553571-34148882-b03b-11e7-81c0-b84f7c95d0f7.gif)
