### PR TITLE
chore(travis): uses latest distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_script:
 branches:
   only:
     - master
-dist: precise
 addons:
   firefox: 50.0
 before_install:


### PR DESCRIPTION
A while ago, travis updated the ubuntu distribution they were using for builds. It was failing due to some uglify.js issues. 

Seems that those issues are gone now, so there's no need to stay on the `precise` distrubition. 