### PR TITLE
Docs/storybookjsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "rheostat": "2.1.1",
     "sass-loader": "6.0.6",
     "stat-mode": "0.2.2",
-    "storybook-addon-jsx": "^5.0.0",
+    "storybook-addon-jsx": "5.0.0",
     "string": "3.3.3",
     "style-loader": "0.19.0",
     "uglify-js": "3.0.25",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "rheostat": "2.1.1",
     "sass-loader": "6.0.6",
     "stat-mode": "0.2.2",
+    "storybook-addon-jsx": "^5.0.0",
     "string": "3.3.3",
     "style-loader": "0.19.0",
     "uglify-js": "3.0.25",

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -7,7 +7,7 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { connectHierarchicalMenu } from '../packages/react-instantsearch/connectors';
 import { withKnobs, object, text } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -36,8 +36,8 @@ stories
       </div>
     ),
     {
-      displayName: changeDisplayName,
-      filterProps: filteredProps,
+      displayName,
+      filterProps,
     }
   )
   .addWithJSX(
@@ -57,7 +57,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );
 
 stories

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -7,7 +7,7 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { connectHierarchicalMenu } from '../packages/react-instantsearch/connectors';
 import { withKnobs, object, text } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -35,7 +35,10 @@ stories
         </WrapWithHits>
       </div>
     ),
-    { displayName: changeDisplayName }
+    {
+      displayName: changeDisplayName,
+      filterProps: filteredProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -54,7 +57,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );
 
 stories

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import {
   Breadcrumb,
   Panel,
@@ -7,45 +7,57 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { connectHierarchicalMenu } from '../packages/react-instantsearch/connectors';
 import { withKnobs, object, text } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('Breadcrumb', module);
 const VirtualHierarchicalMenu = connectHierarchicalMenu(() => null);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <div>
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <div>
+        <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb">
+          <Breadcrumb
+            attributes={['category', 'sub_category', 'sub_sub_category']}
+          />
+          <hr />
+          <HierarchicalMenu
+            attributes={['category', 'sub_category', 'sub_sub_category']}
+            defaultRefinement="Cooking > Kitchen textiles"
+            limitMax={3}
+            showMore={true}
+          />
+        </WrapWithHits>
+      </div>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
       <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb">
-        <Breadcrumb
-          attributes={['category', 'sub_category', 'sub_sub_category']}
-        />
+        <Panel title="Category">
+          <Breadcrumb
+            attributes={['category', 'sub_category', 'sub_sub_category']}
+            separator=" / "
+          />
+        </Panel>
         <hr />
         <HierarchicalMenu
           attributes={['category', 'sub_category', 'sub_sub_category']}
-          defaultRefinement="Cooking > Kitchen textiles"
-          limitMax={3}
-          showMore={true}
+          defaultRefinement="Cooking > Bakeware"
         />
       </WrapWithHits>
-    </div>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb">
-      <Panel title="Category">
-        <Breadcrumb
-          attributes={['category', 'sub_category', 'sub_sub_category']}
-          separator=" / "
-        />
-      </Panel>
-      <hr />
-      <HierarchicalMenu
-        attributes={['category', 'sub_category', 'sub_sub_category']}
-        defaultRefinement="Cooking > Bakeware"
-      />
-    </WrapWithHits>
-  ))
+    ),
+    { displayName: changeDisplayName }
+  );
+
+stories
   .add('with custom component', () => (
     <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb">
       <Breadcrumb

--- a/stories/ClearAll.stories.js
+++ b/stories/ClearAll.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { ClearAll, RefinementList } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -26,7 +26,7 @@ stories
         </div>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'nothing to clear',
@@ -35,7 +35,7 @@ stories
         <ClearAll />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'clear all refinements and the query',
@@ -51,5 +51,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/ClearAll.stories.js
+++ b/stories/ClearAll.stories.js
@@ -1,38 +1,55 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { ClearAll, RefinementList } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('ClearAll', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('with refinements to clear', () => (
-    <WrapWithHits linkedStoryGroup="ClearAll">
-      <div>
-        <ClearAll />
-        <div style={{ display: 'none' }}>
-          <RefinementList
-            attributeName="category"
-            defaultRefinement={['Dining']}
-          />
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'with refinements to clear',
+    () => (
+      <WrapWithHits linkedStoryGroup="ClearAll">
+        <div>
+          <ClearAll />
+          <div style={{ display: 'none' }}>
+            <RefinementList
+              attributeName="category"
+              defaultRefinement={['Dining']}
+            />
+          </div>
         </div>
-      </div>
-    </WrapWithHits>
-  ))
-  .add('nothing to clear', () => (
-    <WrapWithHits linkedStoryGroup="ClearAll">
-      <ClearAll />
-    </WrapWithHits>
-  ))
-  .add('clear all refinements and the query', () => (
-    <WrapWithHits linkedStoryGroup="ClearAll">
-      <ClearAll
-        clearsQuery
-        translations={{ reset: 'Clear refinements and query' }}
-      />
-      <RefinementList attributeName="category" defaultRefinement={['Dining']} />
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'nothing to clear',
+    () => (
+      <WrapWithHits linkedStoryGroup="ClearAll">
+        <ClearAll />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'clear all refinements and the query',
+    () => (
+      <WrapWithHits linkedStoryGroup="ClearAll">
+        <ClearAll
+          clearsQuery
+          translations={{ reset: 'Clear refinements and query' }}
+        />
+        <RefinementList
+          attributeName="category"
+          defaultRefinement={['Dining']}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/ClearAll.stories.js
+++ b/stories/ClearAll.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { ClearAll, RefinementList } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -26,7 +26,10 @@ stories
         </div>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'nothing to clear',
@@ -35,7 +38,10 @@ stories
         <ClearAll />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'clear all refinements and the query',
@@ -51,5 +57,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import {
   CurrentRefinements,
   RefinementList,
@@ -7,55 +7,73 @@ import {
   Panel,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+setAddon(JSXAddon);
 
 const stories = storiesOf('CurrentRefinements', module);
 
 stories.addDecorator(withKnobs);
 
 stories
-  .add('default', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
-      <div>
-        <CurrentRefinements />
-        <div style={{ display: 'none' }}>
-          <RefinementList
-            attributeName="category"
-            defaultRefinement={['Dining']}
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="CurrentRefinements">
+        <div>
+          <CurrentRefinements />
+          <div style={{ display: 'none' }}>
+            <RefinementList
+              attributeName="category"
+              defaultRefinement={['Dining']}
+            />
+          </div>
+        </div>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with toggle',
+    () => (
+      <WrapWithHits linkedStoryGroup="CurrentRefinements">
+        <div>
+          <CurrentRefinements />
+          <Toggle
+            attributeName="materials"
+            label="Made with solid pine"
+            value={'Solid pine'}
           />
         </div>
-      </div>
-    </WrapWithHits>
-  ))
-  .add('with toggle', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
-      <div>
-        <CurrentRefinements />
-        <Toggle
-          attributeName="materials"
-          label="Made with solid pine"
-          value={'Solid pine'}
-        />
-      </div>
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
-      <Panel title="Current Refinements">
-        <CurrentRefinements />
-        <div style={{ display: 'none' }}>
-          <RefinementList
-            attributeName="category"
-            defaultRefinement={['Dining']}
-          />
-        </div>
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with panel but no refinement', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
-      <Panel title="Current Refinements">
-        <CurrentRefinements />
-      </Panel>
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
+      <WrapWithHits linkedStoryGroup="CurrentRefinements">
+        <Panel title="Current Refinements">
+          <CurrentRefinements />
+          <div style={{ display: 'none' }}>
+            <RefinementList
+              attributeName="category"
+              defaultRefinement={['Dining']}
+            />
+          </div>
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel but no refinement',
+    () => (
+      <WrapWithHits linkedStoryGroup="CurrentRefinements">
+        <Panel title="Current Refinements">
+          <CurrentRefinements />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -7,7 +7,7 @@ import {
   Panel,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 setAddon(JSXAddon);
 
@@ -31,7 +31,7 @@ stories
         </div>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with toggle',
@@ -47,7 +47,7 @@ stories
         </div>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel',
@@ -64,7 +64,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -75,5 +75,5 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -7,7 +7,7 @@ import {
   Panel,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 setAddon(JSXAddon);
 
@@ -31,7 +31,10 @@ stories
         </div>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with toggle',
@@ -47,7 +50,10 @@ stories
         </div>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -64,7 +70,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -75,5 +84,8 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -6,7 +6,7 @@ import {
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -24,7 +24,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with default selected item',
@@ -36,7 +36,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with show more',
@@ -50,7 +50,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel',
@@ -63,7 +63,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -83,7 +83,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -98,5 +98,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -1,76 +1,102 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import {
   HierarchicalMenu,
   Panel,
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('HierarchicalMenu', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
-      <HierarchicalMenu
-        attributes={['category', 'sub_category', 'sub_sub_category']}
-      />
-    </WrapWithHits>
-  ))
-  .add('with default selected item', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
-      <HierarchicalMenu
-        attributes={['category', 'sub_category', 'sub_sub_category']}
-        defaultRefinement="Eating"
-      />
-    </WrapWithHits>
-  ))
-  .add('with show more', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
-      <HierarchicalMenu
-        attributes={['category', 'sub_category', 'sub_sub_category']}
-        limitMin={2}
-        limitMax={5}
-        showMore={true}
-      />
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
-      <Panel title="Category">
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
         <HierarchicalMenu
           attributes={['category', 'sub_category', 'sub_sub_category']}
         />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with panel but no refinement', () => (
-    <WrapWithHits
-      searchBox={false}
-      hasPlayground={true}
-      linkedStoryGroup="HierarchicalMenu"
-    >
-      <Panel title="Category">
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with default selected item',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
         <HierarchicalMenu
           attributes={['category', 'sub_category', 'sub_sub_category']}
+          defaultRefinement="Eating"
         />
-        <div style={{ display: 'none' }}>
-          <SearchBox defaultRefinement="ds" />
-        </div>
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="HierarchicalMenu">
-      <HierarchicalMenu
-        attributes={['category', 'sub_category', 'sub_sub_category']}
-        defaultRefinement={text('defaultSelectedItem', 'Bathroom')}
-        limitMin={number('limitMin', 10)}
-        limitMax={number('limitMax', 20)}
-        showMore={boolean('showMore', true)}
-      />
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with show more',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
+        <HierarchicalMenu
+          attributes={['category', 'sub_category', 'sub_sub_category']}
+          limitMin={2}
+          limitMax={5}
+          showMore={true}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
+        <Panel title="Category">
+          <HierarchicalMenu
+            attributes={['category', 'sub_category', 'sub_sub_category']}
+          />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel but no refinement',
+    () => (
+      <WrapWithHits
+        searchBox={false}
+        hasPlayground={true}
+        linkedStoryGroup="HierarchicalMenu"
+      >
+        <Panel title="Category">
+          <HierarchicalMenu
+            attributes={['category', 'sub_category', 'sub_sub_category']}
+          />
+          <div style={{ display: 'none' }}>
+            <SearchBox defaultRefinement="ds" />
+          </div>
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits linkedStoryGroup="HierarchicalMenu">
+        <HierarchicalMenu
+          attributes={['category', 'sub_category', 'sub_sub_category']}
+          defaultRefinement={text('defaultSelectedItem', 'Bathroom')}
+          limitMin={number('limitMin', 10)}
+          limitMax={number('limitMax', 20)}
+          showMore={boolean('showMore', true)}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -6,7 +6,7 @@ import {
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -24,7 +24,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with default selected item',
@@ -36,7 +39,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with show more',
@@ -50,7 +56,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -63,7 +72,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -83,7 +95,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -98,5 +113,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/Hits.stories.js
+++ b/stories/Hits.stories.js
@@ -1,19 +1,22 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { Hits, Highlight, Snippet } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('Hits', module);
 
-stories.addDecorator(withKnobs);
-
-stories.add('default', () => (
+stories.addDecorator(withKnobs).addWithJSX('default',
+() => (
   <WrapWithHits linkedStoryGroup="Hits">
     <Hits />
   </WrapWithHits>
-));
+),
+{ displayName: changeDisplayName });
 
 stories.add('with custom rendering', () => (
   <WrapWithHits linkedStoryGroup="Hits">

--- a/stories/Hits.stories.js
+++ b/stories/Hits.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { Hits, Highlight, Snippet } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -16,7 +16,7 @@ stories.addDecorator(withKnobs).addWithJSX('default',
     <Hits />
   </WrapWithHits>
 ),
-{ displayName: changeDisplayName });
+{ displayName: changeDisplayName, filterProps: filteredProps });
 
 stories.add('with custom rendering', () => (
   <WrapWithHits linkedStoryGroup="Hits">

--- a/stories/Hits.stories.js
+++ b/stories/Hits.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { Hits, Highlight, Snippet } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -16,7 +16,10 @@ stories.addDecorator(withKnobs).addWithJSX('default',
     <Hits />
   </WrapWithHits>
 ),
-{ displayName: changeDisplayName, filterProps: filteredProps });
+{
+  displayName,
+  filterProps,
+});
 
 stories.add('with custom rendering', () => (
   <WrapWithHits linkedStoryGroup="Hits">

--- a/stories/HitsPerPage.stories.js
+++ b/stories/HitsPerPage.stories.js
@@ -1,38 +1,68 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { HitsPerPage, Panel } from '../packages/react-instantsearch/dom';
 import { withKnobs, number } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('HitsPerPage', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
-      <HitsPerPage
-        defaultRefinement={4}
-        items={[
-          { value: 2, label: '2 hits per page' },
-          { value: 4, label: '4 hits per page' },
-          { value: 6, label: '6 hits per page' },
-          { value: 8, label: '8 hits per page' },
-        ]}
-      />
-    </WrapWithHits>
-  ))
-  .add('without label', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
-      <HitsPerPage
-        defaultRefinement={4}
-        items={[{ value: 2 }, { value: 4 }, { value: 6 }, { value: 8 }]}
-      />
-    </WrapWithHits>
-  ))
-  .add('inside a panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
-      <Panel title="Hits to display">
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
+        <HitsPerPage
+          defaultRefinement={4}
+          items={[
+            { value: 2, label: '2 hits per page' },
+            { value: 4, label: '4 hits per page' },
+            { value: 6, label: '6 hits per page' },
+            { value: 8, label: '8 hits per page' },
+          ]}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'without label',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
+        <HitsPerPage
+          defaultRefinement={4}
+          items={[{ value: 2 }, { value: 4 }, { value: 6 }, { value: 8 }]}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'inside a panel',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
+        <Panel title="Hits to display">
+          <HitsPerPage
+            defaultRefinement={number('default hits per page', 4)}
+            items={[
+              { value: 2, label: '2 hits per page' },
+              { value: 4, label: '4 hits per page' },
+              { value: 6, label: '6 hits per page' },
+              { value: 8, label: '8 hits per page' },
+            ]}
+          />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits linkedStoryGroup="HitsPerPage">
         <HitsPerPage
           defaultRefinement={number('default hits per page', 4)}
           items={[
@@ -42,19 +72,7 @@ stories
             { value: 8, label: '8 hits per page' },
           ]}
         />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="HitsPerPage">
-      <HitsPerPage
-        defaultRefinement={number('default hits per page', 4)}
-        items={[
-          { value: 2, label: '2 hits per page' },
-          { value: 4, label: '4 hits per page' },
-          { value: 6, label: '6 hits per page' },
-          { value: 8, label: '8 hits per page' },
-        ]}
-      />
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/HitsPerPage.stories.js
+++ b/stories/HitsPerPage.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { HitsPerPage, Panel } from '../packages/react-instantsearch/dom';
 import { withKnobs, number } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -26,7 +26,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'without label',
@@ -38,7 +41,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'inside a panel',
@@ -57,7 +63,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -74,5 +83,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/HitsPerPage.stories.js
+++ b/stories/HitsPerPage.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { HitsPerPage, Panel } from '../packages/react-instantsearch/dom';
 import { withKnobs, number } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -26,7 +26,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'without label',
@@ -38,7 +38,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'inside a panel',
@@ -57,7 +57,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -74,5 +74,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -1,15 +1,18 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { InfiniteHits } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('InfiniteHits', module);
 
-stories.addDecorator(withKnobs);
-
-stories.add('default', () => (
+stories.addDecorator(withKnobs).addWithJSX('default',
+() => (
   <WrapWithHits linkedStoryGroup="Hits" pagination={false}>
     <InfiniteHits />
   </WrapWithHits>
-));
+),
+{ displayName: changeDisplayName });

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { InfiniteHits } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -15,4 +15,4 @@ stories.addDecorator(withKnobs).addWithJSX('default',
     <InfiniteHits />
   </WrapWithHits>
 ),
-{ displayName: changeDisplayName });
+{ displayName: changeDisplayName, filterProps: filteredProps });

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { InfiniteHits } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -15,4 +15,7 @@ stories.addDecorator(withKnobs).addWithJSX('default',
     <InfiniteHits />
   </WrapWithHits>
 ),
-{ displayName: changeDisplayName, filterProps: filteredProps });
+{
+  displayName,
+  filterProps,
+});

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -1,87 +1,121 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { Menu, Panel, SearchBox } from '../packages/react-instantsearch/dom';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
 import { orderBy } from 'lodash';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('Menu', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
-      <Menu attributeName="category" />
-    </WrapWithHits>
-  ))
-  .add('with default selected item', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
-      <Menu attributeName="category" defaultRefinement="Eating" />
-    </WrapWithHits>
-  ))
-  .add('with show more', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
-      <Menu
-        attributeName="category"
-        limitMin={2}
-        limitMax={5}
-        showMore={true}
-      />
-    </WrapWithHits>
-  ))
-  .add('with search inside items', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
-      <Menu
-        attributeName="category"
-        withSearchBox
-        transformItems={items =>
-          orderBy(
-            items,
-            ['isRefined', 'count', 'label'],
-            ['desc', 'desc', 'asc']
-          )}
-      />
-    </WrapWithHits>
-  ))
-  .add('with the sort strategy changed', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
-      <Menu
-        attributeName="category"
-        transformItems={items =>
-          orderBy(items, ['label', 'count'], ['asc', 'desc'])}
-      />
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
-      <Panel title="Category">
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
         <Menu attributeName="category" />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with panel but no available refinement', () => (
-    <WrapWithHits
-      searchBox={false}
-      hasPlayground={true}
-      linkedStoryGroup="Menu"
-    >
-      <Panel title="Category">
-        <Menu attributeName="category" />
-        <div style={{ display: 'none' }}>
-          <SearchBox defaultRefinement="dkjsakdjskajdksjakdjaskj" />
-        </div>
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="Menu">
-      <Menu
-        attributeName="category"
-        defaultRefinement={text('defaultSelectedItem', 'Bathroom')}
-        limitMin={number('limitMin', 10)}
-        limitMax={number('limitMax', 20)}
-        showMore={boolean('showMore', true)}
-      />
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with default selected item',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+        <Menu attributeName="category" defaultRefinement="Eating" />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with show more',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+        <Menu
+          attributeName="category"
+          limitMin={2}
+          limitMax={5}
+          showMore={true}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with search inside items',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+        <Menu
+          attributeName="category"
+          withSearchBox
+          transformItems={items =>
+            orderBy(
+              items,
+              ['isRefined', 'count', 'label'],
+              ['desc', 'desc', 'asc']
+            )}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with the sort strategy changed',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+        <Menu
+          attributeName="category"
+          transformItems={items =>
+            orderBy(items, ['label', 'count'], ['asc', 'desc'])}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+        <Panel title="Category">
+          <Menu attributeName="category" />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel but no available refinement',
+    () => (
+      <WrapWithHits
+        searchBox={false}
+        hasPlayground={true}
+        linkedStoryGroup="Menu"
+      >
+        <Panel title="Category">
+          <Menu attributeName="category" />
+          <div style={{ display: 'none' }}>
+            <SearchBox defaultRefinement="dkjsakdjskajdksjakdjaskj" />
+          </div>
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits linkedStoryGroup="Menu">
+        <Menu
+          attributeName="category"
+          defaultRefinement={text('defaultSelectedItem', 'Bathroom')}
+          limitMin={number('limitMin', 10)}
+          limitMax={number('limitMax', 20)}
+          showMore={boolean('showMore', true)}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { Menu, Panel, SearchBox } from '../packages/react-instantsearch/dom';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import { orderBy } from 'lodash';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -19,7 +19,7 @@ stories
         <Menu attributeName="category" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with default selected item',
@@ -28,7 +28,7 @@ stories
         <Menu attributeName="category" defaultRefinement="Eating" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with show more',
@@ -42,7 +42,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with search inside items',
@@ -60,7 +60,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with the sort strategy changed',
@@ -73,7 +73,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel',
@@ -84,7 +84,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel but no available refinement',
@@ -102,7 +102,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -117,5 +117,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { Menu, Panel, SearchBox } from '../packages/react-instantsearch/dom';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import { orderBy } from 'lodash';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -19,7 +19,10 @@ stories
         <Menu attributeName="category" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with default selected item',
@@ -28,7 +31,10 @@ stories
         <Menu attributeName="category" defaultRefinement="Eating" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with show more',
@@ -42,7 +48,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with search inside items',
@@ -60,7 +69,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with the sort strategy changed',
@@ -73,7 +85,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -84,7 +99,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel but no available refinement',
@@ -102,7 +120,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -117,5 +138,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { orderBy } from 'lodash';
 import { setAddon, storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import {
   MenuSelect,
   Panel,
@@ -23,7 +23,7 @@ stories
         <MenuSelect attributeName="category" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with default selected item',
@@ -32,7 +32,7 @@ stories
         <MenuSelect attributeName="category" defaultRefinement="Eating" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with the sort strategy changed',
@@ -45,7 +45,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel',
@@ -56,7 +56,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel but no available refinement',
@@ -74,7 +74,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -86,5 +86,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { orderBy } from 'lodash';
 import { setAddon, storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import {
   MenuSelect,
   Panel,
@@ -23,7 +23,10 @@ stories
         <MenuSelect attributeName="category" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with default selected item',
@@ -32,7 +35,10 @@ stories
         <MenuSelect attributeName="category" defaultRefinement="Eating" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with the sort strategy changed',
@@ -45,7 +51,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -56,7 +65,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel but no available refinement',
@@ -74,7 +86,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -86,5 +101,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -1,65 +1,90 @@
 import React from 'react';
 import { orderBy } from 'lodash';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
-
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
 import {
   MenuSelect,
   Panel,
   SearchBox,
 } from '../packages/react-instantsearch/dom';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('MenuSelect', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
-      <MenuSelect attributeName="category" />
-    </WrapWithHits>
-  ))
-  .add('with default selected item', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
-      <MenuSelect attributeName="category" defaultRefinement="Eating" />
-    </WrapWithHits>
-  ))
-  .add('with the sort strategy changed', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
-      <MenuSelect
-        attributeName="category"
-        transformItems={items =>
-          orderBy(items, ['label', 'count'], ['asc', 'desc'])}
-      />
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
-      <Panel title="Category">
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
         <MenuSelect attributeName="category" />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with panel but no available refinement', () => (
-    <WrapWithHits
-      searchBox={false}
-      hasPlayground={true}
-      linkedStoryGroup="MenuSelect"
-    >
-      <Panel title="Category">
-        <MenuSelect attributeName="category" />
-        <div style={{ display: 'none' }}>
-          <SearchBox defaultRefinement="dkjsakdjskajdksjakdjaskj" />
-        </div>
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="MenuSelect">
-      <MenuSelect
-        attributeName="category"
-        defaultRefinement={text('defaultSelectedItem', 'Bathroom')}
-      />
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with default selected item',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
+        <MenuSelect attributeName="category" defaultRefinement="Eating" />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with the sort strategy changed',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
+        <MenuSelect
+          attributeName="category"
+          transformItems={items =>
+            orderBy(items, ['label', 'count'], ['asc', 'desc'])}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
+        <Panel title="Category">
+          <MenuSelect attributeName="category" />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel but no available refinement',
+    () => (
+      <WrapWithHits
+        searchBox={false}
+        hasPlayground={true}
+        linkedStoryGroup="MenuSelect"
+      >
+        <Panel title="Category">
+          <MenuSelect attributeName="category" />
+          <div style={{ display: 'none' }}>
+            <SearchBox defaultRefinement="dkjsakdjskajdksjakdjaskj" />
+          </div>
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits linkedStoryGroup="MenuSelect">
+        <MenuSelect
+          attributeName="category"
+          defaultRefinement={text('defaultSelectedItem', 'Bathroom')}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/MultiRange.stories.js
+++ b/stories/MultiRange.stories.js
@@ -6,7 +6,7 @@ import {
   Configure,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -30,7 +30,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with a default range selected',
@@ -48,7 +48,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with some non selectable ranges',
@@ -65,7 +65,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel',
@@ -84,7 +84,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel but no available refinements',
@@ -104,5 +104,5 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/MultiRange.stories.js
+++ b/stories/MultiRange.stories.js
@@ -6,7 +6,7 @@ import {
   Configure,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -30,7 +30,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with a default range selected',
@@ -48,7 +51,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with some non selectable ranges',
@@ -65,7 +71,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -84,7 +93,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel but no available refinements',
@@ -104,5 +116,8 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/MultiRange.stories.js
+++ b/stories/MultiRange.stories.js
@@ -1,61 +1,24 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import {
   MultiRange,
   Panel,
   Configure,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('MultiRange', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits linkedStoryGroup="MultiRange">
-      <MultiRange
-        attributeName="price"
-        items={[
-          { end: 10, label: '<$10' },
-          { start: 10, end: 100, label: '$10-$100' },
-          { start: 100, end: 500, label: '$100-$500' },
-          { start: 500, label: '>$500' },
-        ]}
-      />
-    </WrapWithHits>
-  ))
-  .add('with a default range selected', () => (
-    <WrapWithHits linkedStoryGroup="MultiRange">
-      <MultiRange
-        attributeName="price"
-        items={[
-          { end: 10, label: '<$10' },
-          { start: 10, end: 100, label: '$10-$100' },
-          { start: 100, end: 500, label: '$100-$500' },
-          { start: 500, label: '>$500' },
-        ]}
-        defaultRefinement=":10"
-      />
-    </WrapWithHits>
-  ))
-  .add('with some non selectable ranges', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="MultiRange">
-      <MultiRange
-        attributeName="price"
-        items={[
-          { end: 10, label: '<$10' },
-          { start: 10, end: 100, label: '$10-$100' },
-          { start: 100, end: 500, label: '$100-$500' },
-          { start: 90000, label: '>$90000' },
-        ]}
-      />
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits linkedStoryGroup="MultiRange">
-      <Panel title="Price">
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="MultiRange">
         <MultiRange
           attributeName="price"
           items={[
@@ -65,13 +28,14 @@ stories
             { start: 500, label: '>$500' },
           ]}
         />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with panel but no available refinements', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="MultiRange">
-      <Panel title="Price">
-        <Configure filters="price>200000" />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with a default range selected',
+    () => (
+      <WrapWithHits linkedStoryGroup="MultiRange">
         <MultiRange
           attributeName="price"
           items={[
@@ -80,7 +44,65 @@ stories
             { start: 100, end: 500, label: '$100-$500' },
             { start: 500, label: '>$500' },
           ]}
+          defaultRefinement=":10"
         />
-      </Panel>
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with some non selectable ranges',
+    () => (
+      <WrapWithHits searchBox={false} linkedStoryGroup="MultiRange">
+        <MultiRange
+          attributeName="price"
+          items={[
+            { end: 10, label: '<$10' },
+            { start: 10, end: 100, label: '$10-$100' },
+            { start: 100, end: 500, label: '$100-$500' },
+            { start: 90000, label: '>$90000' },
+          ]}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
+      <WrapWithHits linkedStoryGroup="MultiRange">
+        <Panel title="Price">
+          <MultiRange
+            attributeName="price"
+            items={[
+              { end: 10, label: '<$10' },
+              { start: 10, end: 100, label: '$10-$100' },
+              { start: 100, end: 500, label: '$100-$500' },
+              { start: 500, label: '>$500' },
+            ]}
+          />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel but no available refinements',
+    () => (
+      <WrapWithHits searchBox={false} linkedStoryGroup="MultiRange">
+        <Panel title="Price">
+          <Configure filters="price>200000" />
+          <MultiRange
+            attributeName="price"
+            items={[
+              { end: 10, label: '<$10' },
+              { start: 10, end: 100, label: '$10-$100' },
+              { start: 100, end: 500, label: '$100-$500' },
+              { start: 500, label: '>$500' },
+            ]}
+          />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -6,7 +6,7 @@ import {
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, boolean, number } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -22,7 +22,10 @@ stories
         <Pagination />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with all props',
@@ -38,7 +41,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -49,7 +55,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -67,7 +76,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -83,5 +95,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -1,65 +1,87 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import {
   Pagination,
   Panel,
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, boolean, number } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('Pagination', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
-      <Pagination />
-    </WrapWithHits>
-  ))
-  .add('with all props', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
-      <Pagination
-        showFirst={true}
-        showLast={true}
-        showPrevious={true}
-        showNext={true}
-        pagesPadding={2}
-        maxPages={3}
-      />
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
-      <Panel title="Pages">
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
         <Pagination />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with panel but no refinement', () => (
-    <WrapWithHits
-      searchBox={false}
-      hasPlayground={true}
-      linkedStoryGroup="Pagination"
-    >
-      <Panel title="Pages">
-        <Pagination />
-        <div style={{ display: 'none' }}>
-          <SearchBox defaultRefinement="ds" />
-        </div>
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="Pagination">
-      <Pagination
-        showFirst={boolean('show First', true)}
-        showLast={boolean('show Last', true)}
-        showPrevious={boolean('show Previous', true)}
-        showNext={boolean('show Next', true)}
-        pagesPadding={number('pages Padding', 2)}
-        maxPages={number('max Pages', 3)}
-      />
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with all props',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
+        <Pagination
+          showFirst={true}
+          showLast={true}
+          showPrevious={true}
+          showNext={true}
+          pagesPadding={2}
+          maxPages={3}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
+        <Panel title="Pages">
+          <Pagination />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel but no refinement',
+    () => (
+      <WrapWithHits
+        searchBox={false}
+        hasPlayground={true}
+        linkedStoryGroup="Pagination"
+      >
+        <Panel title="Pages">
+          <Pagination />
+          <div style={{ display: 'none' }}>
+            <SearchBox defaultRefinement="ds" />
+          </div>
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits linkedStoryGroup="Pagination">
+        <Pagination
+          showFirst={boolean('show First', true)}
+          showLast={boolean('show Last', true)}
+          showPrevious={boolean('show Previous', true)}
+          showNext={boolean('show Next', true)}
+          pagesPadding={number('pages Padding', 2)}
+          maxPages={number('max Pages', 3)}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -6,7 +6,7 @@ import {
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, boolean, number } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -22,7 +22,7 @@ stories
         <Pagination />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with all props',
@@ -38,7 +38,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel',
@@ -49,7 +49,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -67,7 +67,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -83,5 +83,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/PoweredBy.stories.js
+++ b/stories/PoweredBy.stories.js
@@ -1,12 +1,19 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { PoweredBy } from '../packages/react-instantsearch/dom';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('PoweredBy', module);
 
-stories.add('default', () => (
-  <WrapWithHits linkedStoryGroup="PoweredBy">
-    <PoweredBy />
-  </WrapWithHits>
-));
+stories.addWithJSX(
+  'default',
+  () => (
+    <WrapWithHits linkedStoryGroup="PoweredBy">
+      <PoweredBy />
+    </WrapWithHits>
+  ),
+  { displayName: changeDisplayName }
+);

--- a/stories/PoweredBy.stories.js
+++ b/stories/PoweredBy.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { PoweredBy } from '../packages/react-instantsearch/dom';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -15,5 +15,8 @@ stories.addWithJSX(
       <PoweredBy />
     </WrapWithHits>
   ),
-  { displayName: changeDisplayName, filterProps: filteredProps }
+  {
+    displayName,
+    filterProps,
+  }
 );

--- a/stories/PoweredBy.stories.js
+++ b/stories/PoweredBy.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { PoweredBy } from '../packages/react-instantsearch/dom';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -15,5 +15,5 @@ stories.addWithJSX(
       <PoweredBy />
     </WrapWithHits>
   ),
-  { displayName: changeDisplayName }
+  { displayName: changeDisplayName, filterProps: filteredProps }
 );

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -6,7 +6,7 @@ import {
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -23,7 +23,10 @@ stories
         <RangeInput attributeName="price" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -34,7 +37,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with no refinement',
@@ -46,7 +52,10 @@ stories
         </div>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with precision of 0',
@@ -55,7 +64,10 @@ stories
         <RangeInput attributeName="price" precision={0} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with default value',
@@ -67,7 +79,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with min boundaries',
@@ -76,7 +91,10 @@ stories
         <RangeInput attributeName="price" min={30} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with max boundaries',
@@ -85,7 +103,10 @@ stories
         <RangeInput attributeName="price" max={500} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with min / max boundaries',
@@ -94,7 +115,10 @@ stories
         <RangeInput attributeName="price" min={30} max={500} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with boundaries and default value',
@@ -108,7 +132,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -122,7 +149,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -141,5 +171,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -1,88 +1,145 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import {
   RangeInput,
   Panel,
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('RangeInput', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
-      <RangeInput attributeName="price" />
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
-      <Panel title="Price">
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
         <RangeInput attributeName="price" />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with no refinement', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput">
-      <RangeInput attributeName="price" />
-      <div style={{ display: 'none' }}>
-        <SearchBox defaultRefinement="ds" />
-      </div>
-    </WrapWithHits>
-  ))
-  .add('with precision of 0', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
-      <RangeInput attributeName="price" precision={0} />
-    </WrapWithHits>
-  ))
-  .add('with default value', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
-      <RangeInput
-        attributeName="price"
-        defaultRefinement={{ min: 50, max: 200 }}
-      />
-    </WrapWithHits>
-  ))
-  .add('with min boundaries', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
-      <RangeInput attributeName="price" min={30} />
-    </WrapWithHits>
-  ))
-  .add('with max boundaries', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
-      <RangeInput attributeName="price" max={500} />
-    </WrapWithHits>
-  ))
-  .add('with min / max boundaries', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
-      <RangeInput attributeName="price" min={30} max={500} />
-    </WrapWithHits>
-  ))
-  .add('with boundaries and default value', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
-      <RangeInput
-        attributeName="price"
-        min={30}
-        max={500}
-        defaultRefinement={{ min: 50, max: 200 }}
-      />
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
-      <RangeInput
-        attributeName="price"
-        min={number('min', 0)}
-        max={number('max', 500)}
-        precision={number('precision', 0)}
-        defaultRefinement={object('default value', { min: 100, max: 400 })}
-        translations={object('translations', {
-          submit: ' go',
-          separator: 'to',
-        })}
-      />
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
+        <Panel title="Price">
+          <RangeInput attributeName="price" />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with no refinement',
+    () => (
+      <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput">
+        <RangeInput attributeName="price" />
+        <div style={{ display: 'none' }}>
+          <SearchBox defaultRefinement="ds" />
+        </div>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with precision of 0',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
+        <RangeInput attributeName="price" precision={0} />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with default value',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
+        <RangeInput
+          attributeName="price"
+          defaultRefinement={{ min: 50, max: 200 }}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with min boundaries',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
+        <RangeInput attributeName="price" min={30} />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with max boundaries',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
+        <RangeInput attributeName="price" max={500} />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with min / max boundaries',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
+        <RangeInput attributeName="price" min={30} max={500} />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with boundaries and default value',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
+        <RangeInput
+          attributeName="price"
+          min={30}
+          max={500}
+          defaultRefinement={{ min: 50, max: 200 }}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel but no refinement',
+    () => (
+      <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput">
+        <Panel title="Price">
+          <RangeInput attributeName="price" />
+          <div style={{ display: 'none' }}>
+            <SearchBox defaultRefinement="ds" />
+          </div>
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
+        <RangeInput
+          attributeName="price"
+          min={number('min', 0)}
+          max={number('max', 500)}
+          precision={number('precision', 0)}
+          defaultRefinement={object('default value', { min: 100, max: 400 })}
+          translations={object('translations', {
+            submit: ' go',
+            separator: 'to',
+          })}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -6,7 +6,7 @@ import {
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -23,7 +23,7 @@ stories
         <RangeInput attributeName="price" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel',
@@ -34,7 +34,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with no refinement',
@@ -46,7 +46,7 @@ stories
         </div>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with precision of 0',
@@ -55,7 +55,7 @@ stories
         <RangeInput attributeName="price" precision={0} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with default value',
@@ -67,7 +67,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with min boundaries',
@@ -76,7 +76,7 @@ stories
         <RangeInput attributeName="price" min={30} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with max boundaries',
@@ -85,7 +85,7 @@ stories
         <RangeInput attributeName="price" max={500} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with min / max boundaries',
@@ -94,7 +94,7 @@ stories
         <RangeInput attributeName="price" min={30} max={500} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with boundaries and default value',
@@ -108,7 +108,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -122,7 +122,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -141,5 +141,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/RangeSlider.stories.js
+++ b/stories/RangeSlider.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import Range from './3rdPartyIntegrations.stories';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -18,7 +18,10 @@ stories
         <Range attributeName="price" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'providing default value',
@@ -30,7 +33,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'custom min/max bounds',
@@ -39,7 +45,10 @@ stories
         <Range attributeName="price" min={30} max={100} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -53,5 +62,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/RangeSlider.stories.js
+++ b/stories/RangeSlider.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import Range from './3rdPartyIntegrations.stories';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -18,7 +18,7 @@ stories
         <Range attributeName="price" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'providing default value',
@@ -30,7 +30,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'custom min/max bounds',
@@ -39,7 +39,7 @@ stories
         <Range attributeName="price" min={30} max={100} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -53,5 +53,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/RangeSlider.stories.js
+++ b/stories/RangeSlider.stories.js
@@ -1,35 +1,57 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
 import Range from './3rdPartyIntegrations.stories';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
+
 const stories = storiesOf('RangeSlider', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
-      <Range attributeName="price" />
-    </WrapWithHits>
-  ))
-  .add('providing default value', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
-      <Range attributeName="price" defaultRefinement={{ min: 50, max: 200 }} />
-    </WrapWithHits>
-  ))
-  .add('custom min/max bounds', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
-      <Range attributeName="price" min={30} max={100} />
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="RangeSlider">
-      <Range
-        attributeName="price"
-        defaultRefinement={object('default value', { min: 150, max: 200 })}
-        min={number('min', 100)}
-        max={number('max', 400)}
-      />
-    </WrapWithHits>
-  ));
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
+        <Range attributeName="price" />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'providing default value',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
+        <Range
+          attributeName="price"
+          defaultRefinement={{ min: 50, max: 200 }}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'custom min/max bounds',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
+        <Range attributeName="price" min={30} max={100} />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeSlider">
+        <Range
+          attributeName="price"
+          defaultRefinement={object('default value', { min: 150, max: 200 })}
+          min={number('min', 100)}
+          max={number('max', 400)}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -6,7 +6,7 @@ import {
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, boolean, number, array } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import { orderBy } from 'lodash';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -23,7 +23,7 @@ stories
         <RefinementList attributeName="category" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with selected item',
@@ -35,7 +35,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with show more',
@@ -49,7 +49,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with search inside items',
@@ -58,7 +58,7 @@ stories
         <RefinementList attributeName="category" withSearchBox />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with the sort strategy changed',
@@ -71,7 +71,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel',
@@ -82,7 +82,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -100,7 +100,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -118,5 +118,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -6,7 +6,7 @@ import {
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, boolean, number, array } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import { orderBy } from 'lodash';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -23,7 +23,10 @@ stories
         <RefinementList attributeName="category" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with selected item',
@@ -35,7 +38,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with show more',
@@ -49,7 +55,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with search inside items',
@@ -58,7 +67,10 @@ stories
         <RefinementList attributeName="category" withSearchBox />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with the sort strategy changed',
@@ -71,7 +83,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -82,7 +97,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -100,7 +118,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -118,5 +139,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -1,85 +1,122 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import {
   RefinementList,
   Panel,
   SearchBox,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, boolean, number, array } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
 import { orderBy } from 'lodash';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('RefinementList', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
-      <RefinementList attributeName="category" />
-    </WrapWithHits>
-  ))
-  .add('with selected item', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
-      <RefinementList attributeName="category" defaultRefinement={['Dining']} />
-    </WrapWithHits>
-  ))
-  .add('with show more', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
-      <RefinementList
-        attributeName="category"
-        limitMin={2}
-        limitMax={5}
-        showMore={true}
-      />
-    </WrapWithHits>
-  ))
-  .add('with search inside items', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
-      <RefinementList attributeName="category" withSearchBox />
-    </WrapWithHits>
-  ))
-  .add('with the sort strategy changed', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
-      <RefinementList
-        attributeName="category"
-        transformItems={items =>
-          orderBy(items, ['label', 'count'], ['asc', 'desc'])}
-      />
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
-      <Panel title="Category">
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
         <RefinementList attributeName="category" />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with panel but no refinement', () => (
-    <WrapWithHits
-      searchBox={false}
-      linkedStoryGroup="RefinementList"
-      hasPlayground={true}
-    >
-      <Panel title="Category">
-        <RefinementList attributeName="category" />
-        <div style={{ display: 'none' }}>
-          <SearchBox defaultRefinement="ds" />
-        </div>
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList">
-      <RefinementList
-        attributeName="category"
-        defaultRefinement={array('defaultSelectedItem', [
-          'Decoration',
-          'Lighting',
-        ])}
-        limitMin={number('limitMin', 10)}
-        limitMax={number('limitMax', 20)}
-        showMore={boolean('showMore', true)}
-      />
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with selected item',
+    () => (
+      <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+        <RefinementList
+          attributeName="category"
+          defaultRefinement={['Dining']}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with show more',
+    () => (
+      <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+        <RefinementList
+          attributeName="category"
+          limitMin={2}
+          limitMax={5}
+          showMore={true}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with search inside items',
+    () => (
+      <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+        <RefinementList attributeName="category" withSearchBox />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with the sort strategy changed',
+    () => (
+      <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+        <RefinementList
+          attributeName="category"
+          transformItems={items =>
+            orderBy(items, ['label', 'count'], ['asc', 'desc'])}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
+      <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+        <Panel title="Category">
+          <RefinementList attributeName="category" />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel but no refinement',
+    () => (
+      <WrapWithHits
+        searchBox={false}
+        linkedStoryGroup="RefinementList"
+        hasPlayground={true}
+      >
+        <Panel title="Category">
+          <RefinementList attributeName="category" />
+          <div style={{ display: 'none' }}>
+            <SearchBox defaultRefinement="ds" />
+          </div>
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits linkedStoryGroup="RefinementList">
+        <RefinementList
+          attributeName="category"
+          defaultRefinement={array('defaultSelectedItem', [
+            'Decoration',
+            'Lighting',
+          ])}
+          limitMin={number('limitMin', 10)}
+          limitMax={number('limitMax', 20)}
+          showMore={boolean('showMore', true)}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/ScrollTo.stories.js
+++ b/stories/ScrollTo.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { ScrollTo, Hits, Configure } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -18,4 +18,4 @@ stories.addDecorator(withKnobs).addWithJSX('default',
     </ScrollTo>
   </WrapWithHits>
 ),
-{ displayName: changeDisplayName });
+{ displayName: changeDisplayName, filterProps: filteredProps });

--- a/stories/ScrollTo.stories.js
+++ b/stories/ScrollTo.stories.js
@@ -1,18 +1,21 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { ScrollTo, Hits, Configure } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('ScrollTo', module);
 
-stories.addDecorator(withKnobs);
-
-stories.add('default', () => (
+stories.addDecorator(withKnobs).addWithJSX('default',
+() => (
   <WrapWithHits linkedStoryGroup="ScrollTo">
     <Configure hitsPerPage={5} />
     <ScrollTo>
       <Hits />
     </ScrollTo>
   </WrapWithHits>
-));
+),
+{ displayName: changeDisplayName });

--- a/stories/ScrollTo.stories.js
+++ b/stories/ScrollTo.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { ScrollTo, Hits, Configure } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -18,4 +18,7 @@ stories.addDecorator(withKnobs).addWithJSX('default',
     </ScrollTo>
   </WrapWithHits>
 ),
-{ displayName: changeDisplayName, filterProps: filteredProps });
+{
+  displayName,
+  filterProps,
+});

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -1,65 +1,83 @@
 import React, { Component } from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { SearchBox } from '../packages/react-instantsearch/dom';
 import { withKnobs, object } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
 import { action } from '@storybook/addon-actions';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('SearchBox', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits
-      searchBox={false}
-      hasPlayground={true}
-      linkedStoryGroup="SearchBox"
-    >
-      <SearchBox />
-    </WrapWithHits>
-  ))
-  .add('with a default query', () => (
-    <WrapWithHits
-      searchBox={false}
-      hasPlayground={true}
-      linkedStoryGroup="SearchBox"
-    >
-      <SearchBox defaultRefinement="battery" />
-    </WrapWithHits>
-  ))
-  .add('with submit and reset components', () => (
-    <WrapWithHits
-      searchBox={false}
-      hasPlayground={true}
-      linkedStoryGroup="SearchBox"
-    >
-      <SearchBox
-        submitComponent={<span>🔍</span>}
-        resetComponent={
-          <svg viewBox="200 198 108 122">
-            <path d="M200.8 220l45 46.7-20 47.4 31.7-34 50.4 39.3-34.3-52.6 30.2-68.3-49.7 51.7" />
-          </svg>
-        }
-      />
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox">
-      <SearchBox
-        focusShortcuts={['s']}
-        searchAsYouType={true}
-        autoFocus={true}
-        translations={object('translations', {
-          submit: null,
-          reset: null,
-          submitTitle: 'Submit your search query.',
-          resetTitle: 'Clear your search query.',
-          placeholder: 'Search your website.',
-        })}
-      />
-    </WrapWithHits>
-  ));
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits
+        searchBox={false}
+        hasPlayground={true}
+        linkedStoryGroup="SearchBox"
+      >
+        <SearchBox />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with a default query',
+    () => (
+      <WrapWithHits
+        searchBox={false}
+        hasPlayground={true}
+        linkedStoryGroup="SearchBox"
+      >
+        <SearchBox defaultRefinement="battery" />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with submit and reset components',
+    () => (
+      <WrapWithHits
+        searchBox={false}
+        hasPlayground={true}
+        linkedStoryGroup="SearchBox"
+      >
+        <SearchBox
+          submitComponent={<span>🔍</span>}
+          resetComponent={
+            <svg viewBox="200 198 108 122">
+              <path d="M200.8 220l45 46.7-20 47.4 31.7-34 50.4 39.3-34.3-52.6 30.2-68.3-49.7 51.7" />
+            </svg>
+          }
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox">
+        <SearchBox
+          focusShortcuts={['s']}
+          searchAsYouType={true}
+          autoFocus={true}
+          translations={object('translations', {
+            submit: null,
+            reset: null,
+            submitTitle: 'Submit your search query.',
+            resetTitle: 'Clear your search query.',
+            placeholder: 'Search your website.',
+          })}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );
 
 // with event listeners
 // --------------------

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { SearchBox } from '../packages/react-instantsearch/dom';
 import { withKnobs, object } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import { action } from '@storybook/addon-actions';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -23,7 +23,7 @@ stories
         <SearchBox />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with a default query',
@@ -36,7 +36,7 @@ stories
         <SearchBox defaultRefinement="battery" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with submit and reset components',
@@ -56,7 +56,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -76,7 +76,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );
 
 // with event listeners

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { SearchBox } from '../packages/react-instantsearch/dom';
 import { withKnobs, object } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import { action } from '@storybook/addon-actions';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -23,7 +23,10 @@ stories
         <SearchBox />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with a default query',
@@ -36,7 +39,10 @@ stories
         <SearchBox defaultRefinement="battery" />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with submit and reset components',
@@ -56,7 +62,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -76,7 +85,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );
 
 // with event listeners

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { SortBy } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -25,7 +25,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'without label',
@@ -41,5 +44,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -1,35 +1,45 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { SortBy } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('SortBy', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits linkedStoryGroup="SortBy">
-      <SortBy
-        items={[
-          { value: 'ikea', label: 'Featured' },
-          { value: 'ikea_price_asc', label: 'Price asc.' },
-          { value: 'ikea_price_desc', label: 'Price desc.' },
-        ]}
-        defaultRefinement="ikea"
-      />
-    </WrapWithHits>
-  ))
-  .add('without label', () => (
-    <WrapWithHits linkedStoryGroup="SortBy">
-      <SortBy
-        items={[
-          { value: 'ikea' },
-          { value: 'ikea_price_asc' },
-          { value: 'ikea_price_desc' },
-        ]}
-        defaultRefinement="ikea"
-      />
-    </WrapWithHits>
-  ));
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="SortBy">
+        <SortBy
+          items={[
+            { value: 'ikea', label: 'Featured' },
+            { value: 'ikea_price_asc', label: 'Price asc.' },
+            { value: 'ikea_price_desc', label: 'Price desc.' },
+          ]}
+          defaultRefinement="ikea"
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'without label',
+    () => (
+      <WrapWithHits linkedStoryGroup="SortBy">
+        <SortBy
+          items={[
+            { value: 'ikea' },
+            { value: 'ikea_price_asc' },
+            { value: 'ikea_price_desc' },
+          ]}
+          defaultRefinement="ikea"
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { SortBy } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -25,7 +25,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'without label',
@@ -41,5 +41,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/StarRating.stories.js
+++ b/stories/StarRating.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import {
   StarRating,
   Panel,
@@ -7,59 +7,85 @@ import {
   Configure,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('StarRating', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
-      <StarRating attributeName="rating" max={6} min={1} />
-    </WrapWithHits>
-  ))
-  .add('with panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
-      <Panel title="Ratings">
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
         <StarRating attributeName="rating" max={6} min={1} />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with some unavailable refinements', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
-      <Configure filters="rating>=4" />
-      <Panel title="Ratings">
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
+        <Panel title="Ratings">
+          <StarRating attributeName="rating" max={6} min={1} />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with some unavailable refinements',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
+        <Configure filters="rating>=4" />
+        <Panel title="Ratings">
+          <StarRating attributeName="rating" max={6} min={1} />
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with panel but no refinement',
+    () => (
+      <WrapWithHits
+        searchBox={false}
+        hasPlayground={true}
+        linkedStoryGroup="StarRating"
+      >
+        <Panel title="Ratings">
+          <StarRating attributeName="rating" max={6} min={1} />
+          <div style={{ display: 'none' }}>
+            <SearchBox defaultRefinement="ds" />
+          </div>
+        </Panel>
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'with filter on rating',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
+        <Configure filters="rating>2" />
         <StarRating attributeName="rating" max={6} min={1} />
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with panel but no refinement', () => (
-    <WrapWithHits
-      searchBox={false}
-      hasPlayground={true}
-      linkedStoryGroup="StarRating"
-    >
-      <Panel title="Ratings">
-        <StarRating attributeName="rating" max={6} min={1} />
-        <div style={{ display: 'none' }}>
-          <SearchBox defaultRefinement="ds" />
-        </div>
-      </Panel>
-    </WrapWithHits>
-  ))
-  .add('with filter on rating', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
-      <Configure filters="rating>2" />
-      <StarRating attributeName="rating" max={6} min={1} />
-    </WrapWithHits>
-  ))
-  .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="StarRating">
-      <StarRating
-        attributeName="rating"
-        max={number('max', 6)}
-        translations={object('translations', { ratingLabel: ' & Up' })}
-      />
-    </WrapWithHits>
-  ));
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'playground',
+    () => (
+      <WrapWithHits linkedStoryGroup="StarRating">
+        <StarRating
+          attributeName="rating"
+          max={number('max', 6)}
+          translations={object('translations', { ratingLabel: ' & Up' })}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/StarRating.stories.js
+++ b/stories/StarRating.stories.js
@@ -7,7 +7,7 @@ import {
   Configure,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -23,7 +23,10 @@ stories
         <StarRating attributeName="rating" max={6} min={1} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel',
@@ -34,7 +37,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with some unavailable refinements',
@@ -46,7 +52,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -64,7 +73,10 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'with filter on rating',
@@ -74,7 +86,10 @@ stories
         <StarRating attributeName="rating" max={6} min={1} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'playground',
@@ -87,5 +102,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/StarRating.stories.js
+++ b/stories/StarRating.stories.js
@@ -7,7 +7,7 @@ import {
   Configure,
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -23,7 +23,7 @@ stories
         <StarRating attributeName="rating" max={6} min={1} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel',
@@ -34,7 +34,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with some unavailable refinements',
@@ -46,7 +46,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with panel but no refinement',
@@ -64,7 +64,7 @@ stories
         </Panel>
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'with filter on rating',
@@ -74,7 +74,7 @@ stories
         <StarRating attributeName="rating" max={6} min={1} />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'playground',
@@ -87,5 +87,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/Stats.stories.js
+++ b/stories/Stats.stories.js
@@ -1,17 +1,21 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { Stats } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('Stats', module);
 
-stories.addDecorator(withKnobs);
-
-stories.add('default', () => (
+stories.addDecorator(withKnobs).addWithJSX('default',
+() => (
   <WrapWithHits linkedStoryGroup="Stats">
     <div>
       <Stats />
     </div>
   </WrapWithHits>
-));
+),
+{ displayName: changeDisplayName });

--- a/stories/Stats.stories.js
+++ b/stories/Stats.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { Stats } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -18,4 +18,7 @@ stories.addDecorator(withKnobs).addWithJSX('default',
     </div>
   </WrapWithHits>
 ),
-{ displayName: changeDisplayName, filterProps: filteredProps });
+{
+  displayName,
+  filterProps,
+});

--- a/stories/Stats.stories.js
+++ b/stories/Stats.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { Stats } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -18,4 +18,4 @@ stories.addDecorator(withKnobs).addWithJSX('default',
     </div>
   </WrapWithHits>
 ),
-{ displayName: changeDisplayName });
+{ displayName: changeDisplayName, filterProps: filteredProps });

--- a/stories/Toggle.stories.js
+++ b/stories/Toggle.stories.js
@@ -1,30 +1,40 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { setAddon, storiesOf } from '@storybook/react';
 import { Toggle } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { WrapWithHits } from './util';
+import { changeDisplayName, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
 
 const stories = storiesOf('Toggle', module);
 
-stories.addDecorator(withKnobs);
-
 stories
-  .add('default', () => (
-    <WrapWithHits linkedStoryGroup="Toggle">
-      <Toggle
-        attributeName="materials"
-        label="Made with solid pine"
-        value={'Solid pine'}
-      />
-    </WrapWithHits>
-  ))
-  .add('checked by default', () => (
-    <WrapWithHits linkedStoryGroup="Toggle">
-      <Toggle
-        attributeName="materials"
-        label="Made with solid pine"
-        value={'Solid pine'}
-        defaultRefinement={true}
-      />
-    </WrapWithHits>
-  ));
+  .addDecorator(withKnobs)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="Toggle">
+        <Toggle
+          attributeName="materials"
+          label="Made with solid pine"
+          value={'Solid pine'}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  )
+  .addWithJSX(
+    'checked by default',
+    () => (
+      <WrapWithHits linkedStoryGroup="Toggle">
+        <Toggle
+          attributeName="materials"
+          label="Made with solid pine"
+          value={'Solid pine'}
+          defaultRefinement={true}
+        />
+      </WrapWithHits>
+    ),
+    { displayName: changeDisplayName }
+  );

--- a/stories/Toggle.stories.js
+++ b/stories/Toggle.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { Toggle } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, WrapWithHits } from './util';
+import { changeDisplayName, filteredProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -22,7 +22,7 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   )
   .addWithJSX(
     'checked by default',
@@ -36,5 +36,5 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName }
+    { displayName: changeDisplayName, filterProps: filteredProps }
   );

--- a/stories/Toggle.stories.js
+++ b/stories/Toggle.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { Toggle } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
-import { changeDisplayName, filteredProps, WrapWithHits } from './util';
+import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -22,7 +22,10 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   )
   .addWithJSX(
     'checked by default',
@@ -36,5 +39,8 @@ stories
         />
       </WrapWithHits>
     ),
-    { displayName: changeDisplayName, filterProps: filteredProps }
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/util.js
+++ b/stories/util.js
@@ -152,7 +152,7 @@ const getReactElementDisplayName = element =>
     : element.type);
 
 // displays the right name for the JSX addon in Storybook
-const changeDisplayName = element => {
+const displayName = element => {
   // display 'InstantSearch' instead of 'WrapWithHits'
   if (getReactElementDisplayName(element) === 'WrapWithHits') {
     const instantSearch = 'InstantSearch';
@@ -187,5 +187,5 @@ const changeDisplayName = element => {
   return getReactElementDisplayName(element);
 };
 
-const filteredProps = ['linkedStoryGroup', 'hasPlayground'];
-export { changeDisplayName, filteredProps, Wrap, WrapWithHits };
+const filterProps = ['linkedStoryGroup', 'hasPlayground'];
+export { displayName, filterProps, Wrap, WrapWithHits };

--- a/stories/util.js
+++ b/stories/util.js
@@ -125,6 +125,9 @@ const CustomHits = connectHits(({ hits }) => (
 ));
 
 WrapWithHits.propTypes = {
+  appId: PropTypes.string,
+  apiKey: PropTypes.string,
+  indexName: PropTypes.string,
   children: PropTypes.node,
   searchBox: PropTypes.bool,
   linkedStoryGroup: PropTypes.string,
@@ -133,4 +136,39 @@ WrapWithHits.propTypes = {
   searchParameters: PropTypes.object,
 };
 
-export { Wrap, WrapWithHits };
+// defaultProps added so that they're displayed in the JSX addon
+WrapWithHits.defaultProps = {
+  appId: 'latency',
+  apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
+  indexName: 'ikea',
+};
+
+// retrieves the displayName of the React Component
+const getReactElementDisplayName = element =>
+  element.type.displayName ||
+  element.type.name ||
+  (typeof element.type === 'function' // function without a name, provide one
+    ? 'No Display Name'
+    : element.type);
+
+// displays the right name for the JSX addon in Storybook
+const transformDisplayName = element => {
+  // display 'InstantSearch' instead of 'WrapWithHits'
+  if (getReactElementDisplayName(element) === 'WrapWithHits') {
+    const instantSearch = 'InstantSearch';
+    return instantSearch;
+  }
+
+  // wrapped component: AlgoliaWidgetName(Translatable..)" => "WidgetName"
+  if (
+    React.Component.isPrototypeOf(element.type) &&
+    getReactElementDisplayName(element).startsWith('Algolia')
+  ) {
+    const rawName = element.type.displayName;
+    return rawName.split('(')[0].replace('Algolia', '');
+  }
+
+  return getReactElementDisplayName(element);
+};
+
+export { transformDisplayName, Wrap, WrapWithHits };

--- a/stories/util.js
+++ b/stories/util.js
@@ -187,4 +187,5 @@ const changeDisplayName = element => {
   return getReactElementDisplayName(element);
 };
 
-export { changeDisplayName, Wrap, WrapWithHits };
+const filteredProps = ['linkedStoryGroup', 'hasPlayground'];
+export { changeDisplayName, filteredProps, Wrap, WrapWithHits };

--- a/storybook/addons.js
+++ b/storybook/addons.js
@@ -1,3 +1,5 @@
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-actions/register';
 import '@storybook/addon-options/register';
+import '@storybook/addons';
+import 'storybook-addon-jsx/register';

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -3,6 +3,11 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        include: /node_modules\/(stringify-object|get-own-enumerable-property-symbols)/,
+      },
+      {
         test: /\.scss$/,
         use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2595,7 +2595,7 @@ coffee-script@^1.12.4:
   version "1.12.7"
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
 
-collapse-white-space@^1.0.0:
+collapse-white-space@1.0.3, collapse-white-space@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.3.tgz#4b906f670e5a963a87b76b0e1689643341b6023c"
 
@@ -3080,6 +3080,12 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+copy-to-clipboard@^3:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
+  dependencies:
+    toggle-selection "^1.0.3"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -3708,6 +3714,10 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+editions@^1.1.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.3.tgz#0907101bdda20fac3cbe334c27cbd0688dc99a5b"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -4762,6 +4772,10 @@ generate-object-property@^1.1.0:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-own-enumerable-property-symbols@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
 
 get-pkg-repo@^1.0.0:
   version "1.4.0"
@@ -5917,7 +5931,7 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
-is-obj@^1.0.0:
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
@@ -5941,7 +5955,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.4:
+is-plain-object@2.0.4, is-plain-object@^2.0.1, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
@@ -5972,6 +5986,10 @@ is-regex@^1.0.3, is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
 
 is-relative@^0.2.1:
   version "0.2.1"
@@ -9049,6 +9067,13 @@ react-color@^2.11.4:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
+react-copy-to-clipboard@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
+
 react-datetime@^2.10.3:
   version "2.10.3"
   resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.10.3.tgz#9807a7d9be1dd4ee01b3466b0416614e3543378e"
@@ -9090,6 +9115,16 @@ react-dom@16.0.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-element-to-jsx-string@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-13.0.0.tgz#5c6c90883ac172acd69ed3d664ba17ea648db0df"
+  dependencies:
+    collapse-white-space "1.0.3"
+    is-plain-object "2.0.4"
+    lodash "4.17.4"
+    sortobject "1.1.1"
+    stringify-object "3.2.1"
 
 react-event-listener@^0.5.1:
   version "0.5.1"
@@ -10289,6 +10324,12 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortobject@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sortobject/-/sortobject-1.1.1.tgz#4f695d4d44ed0a4c06482c34c2582a2dcdc2ab34"
+  dependencies:
+    editions "^1.1.1"
+
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
@@ -10422,6 +10463,13 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
+storybook-addon-jsx@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/storybook-addon-jsx/-/storybook-addon-jsx-5.0.0.tgz#412574c20a45eec5d70460cc7d25e23f614f9865"
+  dependencies:
+    react-copy-to-clipboard "5.0.1"
+    react-element-to-jsx-string "13.0.0"
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
@@ -10538,6 +10586,14 @@ stringify-entities@^1.0.1:
     character-entities-legacy "^1.0.0"
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
+
+stringify-object@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.1.tgz#2720c2eff940854c819f6ee252aaeb581f30624d"
+  dependencies:
+    get-own-enumerable-property-symbols "^2.0.1"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
@@ -10902,6 +10958,10 @@ to-fast-properties@^1.0.3:
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 token-stream@0.0.1:
   version "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10463,7 +10463,7 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
-storybook-addon-jsx@^5.0.0:
+storybook-addon-jsx@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/storybook-addon-jsx/-/storybook-addon-jsx-5.0.0.tgz#412574c20a45eec5d70460cc7d25e23f614f9865"
   dependencies:


### PR DESCRIPTION
**Summary**

Add a new Storybook addon to display the example usage of every widget (see #60).
 
**Result**

Our users can now have a better idea of how the widgets are used. 
They can see the widget in action and get the same configuration as the one displayed in the story.
![image](https://user-images.githubusercontent.com/21305268/32101202-88c58cf0-bb17-11e7-8163-44a4d152aef1.png)

It also works for the 'playground' story where the props can be modified.
![addonjsx](https://user-images.githubusercontent.com/21305268/32101363-302f657e-bb18-11e7-957b-3a5c2a91d889.gif)
