### PR TITLE
Update Toggle.js type

### DIFF
--- a/packages/react-instantsearch/src/widgets/Toggle.js
+++ b/packages/react-instantsearch/src/widgets/Toggle.js
@@ -12,7 +12,7 @@ import ToggleComponent from '../components/Toggle.js';
  *
  * @propType {string} attributeName - Name of the attribute on which to apply the `value` refinement. Required when `value` is present.
  * @propType {string} label - Label for the toggle.
- * @propType {string} value - Value of the refinement to apply on `attributeName` when checked.
+ * @propType {any} value - Value of the refinement to apply on `attributeName` when checked.
  * @propType {boolean} [defaultRefinement=false] - Default state of the widget. Should the toggle be checked by default?
  * @themeKey ais-Toggle__root - the root of the component
  * @themeKey ais-Toggle__checkbox - the toggle checkbox


### PR DESCRIPTION
From `connectToggle`:

```js
  propTypes: {
    label: PropTypes.string,
    filter: PropTypes.func,
    attributeName: PropTypes.string,
    value: PropTypes.any,
...
```

Additionally this is really confusing if it is supposed to be a string, how do you toggle on a boolean value?


Also I asked this here: https://discourse.algolia.com/t/how-to-create-a-toggle-for-the-absence-of-a-string-attribute/2460
but without response.