### PR TITLE
docs(storybook): add a11y addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "rheostat": "2.1.1",
     "sass-loader": "6.0.6",
     "stat-mode": "0.2.2",
+    "storybook-addon-a11y": "3.1.9",
     "storybook-addon-jsx": "5.0.0",
     "string": "3.3.3",
     "style-loader": "0.19.0",

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -8,6 +8,7 @@ import {
 import { connectHierarchicalMenu } from '../packages/react-instantsearch/connectors';
 import { withKnobs, object, text } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -17,6 +18,7 @@ const VirtualHierarchicalMenu = connectHierarchicalMenu(() => null);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/ClearAll.stories.js
+++ b/stories/ClearAll.stories.js
@@ -3,6 +3,7 @@ import { setAddon, storiesOf } from '@storybook/react';
 import { ClearAll, RefinementList } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -11,6 +12,7 @@ const stories = storiesOf('ClearAll', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'with refinements to clear',
     () => (

--- a/stories/Conditional.stories.js
+++ b/stories/Conditional.stories.js
@@ -2,10 +2,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { connectStateResults } from '../packages/react-instantsearch/connectors';
 import { WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 
 const stories = storiesOf('Conditionals', module);
 
 stories
+  .addDecorator(checkA11y)
   .add('NoResults/HasResults', () => {
     const Content = connectStateResults(
       ({ searchState, searchResults }) =>

--- a/stories/Configure.stories.js
+++ b/stories/Configure.stories.js
@@ -2,10 +2,11 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Configure } from '../packages/react-instantsearch/dom';
 import { WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 
 const stories = storiesOf('Configure', module);
 
-stories.add('default', () => <ConfigureExample />);
+stories.addDecorator(checkA11y).add('default', () => <ConfigureExample />);
 
 class ConfigureExample extends React.Component {
   constructor() {

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -8,12 +8,13 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 setAddon(JSXAddon);
 
 const stories = storiesOf('CurrentRefinements', module);
 
-stories.addDecorator(withKnobs);
+stories.addDecorator(withKnobs).addDecorator(checkA11y);
 
 stories
   .addWithJSX(

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -7,6 +7,7 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -15,6 +16,7 @@ const stories = storiesOf('HierarchicalMenu', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/Highlight.stories.js
+++ b/stories/Highlight.stories.js
@@ -4,10 +4,11 @@ import { storiesOf } from '@storybook/react';
 import { Highlight, Hits } from '../packages/react-instantsearch/dom';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 
 const stories = storiesOf('Highlight', module);
 
-stories.addDecorator(withKnobs);
+stories.addDecorator(withKnobs).addDecorator(checkA11y);
 
 const Default = ({ hit }) => (
   <article>
@@ -48,6 +49,7 @@ StrongHits.propTypes = {
 };
 
 stories
+  .addDecorator(checkA11y)
   .add('default', () => (
     <WrapWithHits hasPlayground={true} linkedStoryGroup="Highlight">
       <Hits hitComponent={Default} />

--- a/stories/Highlight.stories.js
+++ b/stories/Highlight.stories.js
@@ -49,7 +49,6 @@ StrongHits.propTypes = {
 };
 
 stories
-  .addDecorator(checkA11y)
   .add('default', () => (
     <WrapWithHits hasPlayground={true} linkedStoryGroup="Highlight">
       <Hits hitComponent={Default} />

--- a/stories/Hits.stories.js
+++ b/stories/Hits.stories.js
@@ -4,22 +4,28 @@ import { setAddon, storiesOf } from '@storybook/react';
 import { Hits, Highlight, Snippet } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
 
 const stories = storiesOf('Hits', module);
 
-stories.addDecorator(withKnobs).addWithJSX('default',
-() => (
-  <WrapWithHits linkedStoryGroup="Hits">
-    <Hits />
-  </WrapWithHits>
-),
-{
-  displayName,
-  filterProps,
-});
+stories
+  .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="Hits">
+        <Hits />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  );
 
 stories.add('with custom rendering', () => (
   <WrapWithHits linkedStoryGroup="Hits">

--- a/stories/HitsPerPage.stories.js
+++ b/stories/HitsPerPage.stories.js
@@ -3,6 +3,7 @@ import { setAddon, storiesOf } from '@storybook/react';
 import { HitsPerPage, Panel } from '../packages/react-instantsearch/dom';
 import { withKnobs, number } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -11,6 +12,7 @@ const stories = storiesOf('HitsPerPage', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -3,19 +3,25 @@ import { setAddon, storiesOf } from '@storybook/react';
 import { InfiniteHits } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
 
 const stories = storiesOf('InfiniteHits', module);
 
-stories.addDecorator(withKnobs).addWithJSX('default',
-() => (
-  <WrapWithHits linkedStoryGroup="Hits" pagination={false}>
-    <InfiniteHits />
-  </WrapWithHits>
-),
-{
-  displayName,
-  filterProps,
-});
+stories
+  .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="Hits" pagination={false}>
+        <InfiniteHits />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  );

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -3,6 +3,7 @@ import { setAddon, storiesOf } from '@storybook/react';
 import { Menu, Panel, SearchBox } from '../packages/react-instantsearch/dom';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import { orderBy } from 'lodash';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -12,6 +13,7 @@ const stories = storiesOf('Menu', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -8,6 +8,7 @@ import {
   Panel,
   SearchBox,
 } from '../packages/react-instantsearch/dom';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -16,6 +17,7 @@ const stories = storiesOf('MenuSelect', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -14,10 +14,12 @@ import {
   connectStateResults,
 } from '../packages/react-instantsearch/connectors';
 import Autosuggest from 'react-autosuggest';
+import { checkA11y } from 'storybook-addon-a11y';
 
 const stories = storiesOf('<Index>', module);
 
 stories
+  .addDecorator(checkA11y)
   .add('MultiHits', () => (
     <InstantSearch
       appId="latency"

--- a/stories/MultiRange.stories.js
+++ b/stories/MultiRange.stories.js
@@ -7,6 +7,7 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -15,6 +16,7 @@ const stories = storiesOf('MultiRange', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -7,6 +7,7 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, boolean, number } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -15,6 +16,7 @@ const stories = storiesOf('Pagination', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/PoweredBy.stories.js
+++ b/stories/PoweredBy.stories.js
@@ -2,21 +2,20 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { PoweredBy } from '../packages/react-instantsearch/dom';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
 
 const stories = storiesOf('PoweredBy', module);
 
-stories.addWithJSX(
-  'default',
-  () => (
-    <WrapWithHits linkedStoryGroup="PoweredBy">
-      <PoweredBy />
-    </WrapWithHits>
-  ),
-  {
-    displayName,
-    filterProps,
-  }
-);
+stories.addDecorator(checkA11y).addWithJSX('default',
+() => (
+  <WrapWithHits linkedStoryGroup="PoweredBy">
+    <PoweredBy />
+  </WrapWithHits>
+),
+{
+  displayName,
+  filterProps,
+});

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -7,6 +7,7 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -16,6 +17,7 @@ const stories = storiesOf('RangeInput', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/RangeSlider.stories.js
+++ b/stories/RangeSlider.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import Range from './3rdPartyIntegrations.stories';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -11,6 +12,7 @@ const stories = storiesOf('RangeSlider', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -7,6 +7,7 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, boolean, number, array } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import { orderBy } from 'lodash';
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -16,6 +17,7 @@ const stories = storiesOf('RefinementList', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/ScrollTo.stories.js
+++ b/stories/ScrollTo.stories.js
@@ -3,22 +3,28 @@ import { setAddon, storiesOf } from '@storybook/react';
 import { ScrollTo, Hits, Configure } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
 
 const stories = storiesOf('ScrollTo', module);
 
-stories.addDecorator(withKnobs).addWithJSX('default',
-() => (
-  <WrapWithHits linkedStoryGroup="ScrollTo">
-    <Configure hitsPerPage={5} />
-    <ScrollTo>
-      <Hits />
-    </ScrollTo>
-  </WrapWithHits>
-),
-{
-  displayName,
-  filterProps,
-});
+stories
+  .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="ScrollTo">
+        <Configure hitsPerPage={5} />
+        <ScrollTo>
+          <Hits />
+        </ScrollTo>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  );

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -4,6 +4,7 @@ import { SearchBox } from '../packages/react-instantsearch/dom';
 import { withKnobs, object } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
 import { action } from '@storybook/addon-actions';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -12,6 +13,7 @@ const stories = storiesOf('SearchBox', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/Snippet.stories.js
+++ b/stories/Snippet.stories.js
@@ -3,11 +3,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Snippet, Hits } from '../packages/react-instantsearch/dom';
 import { withKnobs, text } from '@storybook/addon-knobs';
+import { checkA11y } from 'storybook-addon-a11y';
 import { WrapWithHits } from './util';
 
 const stories = storiesOf('Snippet', module);
 
-stories.addDecorator(withKnobs);
+stories.addDecorator(withKnobs).addDecorator(checkA11y);
 
 const Default = ({ hit }) => (
   <article>

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -3,6 +3,7 @@ import { setAddon, storiesOf } from '@storybook/react';
 import { SortBy } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -11,6 +12,7 @@ const stories = storiesOf('SortBy', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/StarRating.stories.js
+++ b/stories/StarRating.stories.js
@@ -8,6 +8,7 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { withKnobs, object, number } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -16,6 +17,7 @@ const stories = storiesOf('StarRating', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/stories/Stats.stories.js
+++ b/stories/Stats.stories.js
@@ -3,6 +3,7 @@ import { setAddon, storiesOf } from '@storybook/react';
 import { Stats } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 
 import JSXAddon from 'storybook-addon-jsx';
 
@@ -10,15 +11,20 @@ setAddon(JSXAddon);
 
 const stories = storiesOf('Stats', module);
 
-stories.addDecorator(withKnobs).addWithJSX('default',
-() => (
-  <WrapWithHits linkedStoryGroup="Stats">
-    <div>
-      <Stats />
-    </div>
-  </WrapWithHits>
-),
-{
-  displayName,
-  filterProps,
-});
+stories
+  .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits linkedStoryGroup="Stats">
+        <div>
+          <Stats />
+        </div>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  );

--- a/stories/Toggle.stories.js
+++ b/stories/Toggle.stories.js
@@ -3,6 +3,7 @@ import { setAddon, storiesOf } from '@storybook/react';
 import { Toggle } from '../packages/react-instantsearch/dom';
 import { withKnobs } from '@storybook/addon-knobs';
 import { displayName, filterProps, WrapWithHits } from './util';
+import { checkA11y } from 'storybook-addon-a11y';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
@@ -11,6 +12,7 @@ const stories = storiesOf('Toggle', module);
 
 stories
   .addDecorator(withKnobs)
+  .addDecorator(checkA11y)
   .addWithJSX(
     'default',
     () => (

--- a/storybook/addons.js
+++ b/storybook/addons.js
@@ -3,3 +3,4 @@ import '@storybook/addon-actions/register';
 import '@storybook/addon-options/register';
 import '@storybook/addons';
 import 'storybook-addon-jsx/register';
+import 'storybook-addon-a11y/register';

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,7 +124,7 @@
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
-"@storybook/react@3.2.14":
+"@storybook/react@3.2.14", "@storybook/react@^3.0.0":
   version "3.2.14"
   resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.2.14.tgz#42612fb96da4bf84e3367e5371e95a484b54a4fb"
   dependencies:
@@ -721,6 +721,10 @@ aws-sign2@~0.7.0:
 aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+axe-core@^2.0.7:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.4.2.tgz#3156d914051ea32597e584071d9d653b66d1579b"
 
 babel-cli@6.26.0, babel-cli@^6.23.0:
   version "6.26.0"
@@ -10286,6 +10290,14 @@ stdout-stream@^1.4.0:
   resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.0.tgz#a2c7c8587e54d9427ea9edb3ac3f2cd522df378b"
   dependencies:
     readable-stream "^2.0.1"
+
+storybook-addon-a11y@3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/storybook-addon-a11y/-/storybook-addon-a11y-3.1.9.tgz#174ef98c132fb7b8eb16687720466bb1670fdf6f"
+  dependencies:
+    "@storybook/react" "^3.0.0"
+    axe-core "^2.0.7"
+    prop-types "^15.5.10"
 
 storybook-addon-jsx@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
**Summary**

Add a new Storybook addon to monitor our components for being accessible.
See #221.

**Result**

There is a new "Accessibility" tab displayed on the right sidebar that shows both the a11y "violations" and the "passes". 

![image](https://user-images.githubusercontent.com/21305268/32376331-d1a89308-c0a4-11e7-907c-37fe5b2aaf64.png)

