### PR TITLE
chore: ignore build/.expo/.next folder from ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,9 @@ packages/react-instantsearch/examples/*/node_modules/
 docs/
 docs-production/
 dist/
+build/
+.expo/
+.next/
 
 # Happo visual regression build
 test/.happo


### PR DESCRIPTION
**Summary**

When the recipes are built ESLint will try to lint them too.

- `build`
- `.next`
- `.expo`
