### PR TITLE
[Bugfix] Properly update search query when using browser navigation

### DIFF
--- a/packages/react-instantsearch/examples/react-router/src/App.js
+++ b/packages/react-instantsearch/examples/react-router/src/App.js
@@ -21,12 +21,19 @@ const createURL = state => `?${qs.stringify(state)}`;
 
 const searchStateToUrl = (props, searchState) =>
   searchState ? `${props.location.pathname}${createURL(searchState)}` : '';
+const urlToSearchState = location => qs.parse(location.search.slice(1));
 
 class App extends Component {
   constructor(props) {
     super(props);
-    this.state = { searchState: qs.parse(props.location.search.slice(1)) };
+    this.state = { searchState: urlToSearchState(props.location) };
     this.onSearchStateChange = this.onSearchStateChange.bind(this);
+  }
+
+  componentWillReceiveProps(props) {
+    if (props.location !== this.props.location) {
+      this.setState({ searchState: urlToSearchState(props.location) });
+    }
   }
 
   onSearchStateChange(searchState) {


### PR DESCRIPTION
**Summary**

This example properly updates the browser history on changes, but if you navigate using the browser back and next buttons, the search query doesn't change to match. This addition of a `componentWillReceiveProps` lifecycle method fixes that issue.

**Result**

Clone the example, run `yarn`, then `yarn start`.  Verify that searching and filtering still work correctly, and that browser navigation and full reload both maintain the search state correctly.
