### PR TITLE
docs(storybook): allow WrapWithHits usage with a different index

### DIFF
--- a/stories/util.js
+++ b/stories/util.js
@@ -33,6 +33,9 @@ const WrapWithHits = ({
   hasPlayground = false,
   linkedStoryGroup,
   pagination = true,
+  appId = 'latency',
+  apiKey = '6be0576ff61c053d5f9a3225e2a90f76',
+  indexName = 'ikea',
 }) => {
   const sourceCodeUrl = `https://github.com/algolia/react-instantsearch/tree/master/stories/${
     linkedStoryGroup
@@ -61,11 +64,7 @@ const WrapWithHits = ({
   };
 
   return (
-    <InstantSearch
-      appId="latency"
-      apiKey="6be0576ff61c053d5f9a3225e2a90f76"
-      indexName="ikea"
-    >
+    <InstantSearch appId={appId} apiKey={apiKey} indexName={indexName}>
       <Configure {...searchParameters} />
       <div>
         <div className="container widget-container">{children}</div>


### PR DESCRIPTION
**Summary**

This PR aims at allowing us to use our custom component `WrapWithHits` with another index than the Ikea one usually used in the stories.

**Result**

The `WrapWithHits` component can still be used like it was previously:

```
stories.addWithJSX(
  'default',
  () => (
    <WrapWithHits>
      <Hits />
    </WrapWithHits>
  ),
  {
    displayName,
    filterProps,
  }
);
```
However if you need to use a different index, then you would simply need to specify your credentials via the 'appId', 'apiKey' and 'indexName' props. If you don't specify anything, the Ikea dataset will be used by default.

```
stories.addWithJSX(
  'default',
  () => (
    <WrapWithHits
      appId="newAppId"
      apiKey="newSearchOnlyApiKey"
      indexName="newIndexName"
    >
        <Stats />
    </WrapWithHits>
  ),
  {
    displayName,
    filterProps,
  }
);
```
