### PR TITLE
Refactor Hits component

### DIFF
--- a/packages/react-instantsearch/src/components/Hits.js
+++ b/packages/react-instantsearch/src/components/Hits.js
@@ -20,7 +20,6 @@ Hits.propTypes = {
   hitComponent: PropTypes.func.isRequired,
 };
 
-/* eslint-disable react/display-name */
 Hits.defaultProps = {
   hitComponent: hit => (
     <div
@@ -34,6 +33,5 @@ Hits.defaultProps = {
     </div>
   ),
 };
-/* eslint-enable react/display-name */
 
 export default Hits;

--- a/packages/react-instantsearch/src/components/Hits.js
+++ b/packages/react-instantsearch/src/components/Hits.js
@@ -21,7 +21,7 @@ Hits.propTypes = {
 };
 
 Hits.defaultProps = {
-  hitComponent: hit => (
+  hitComponent: props => (
     <div
       style={{
         borderBottom: '1px solid #bbb',
@@ -29,7 +29,7 @@ Hits.defaultProps = {
         marginBottom: '5px',
       }}
     >
-      {JSON.stringify(hit).slice(0, 100)}...
+      {JSON.stringify(props).slice(0, 100)}...
     </div>
   ),
 };

--- a/packages/react-instantsearch/src/components/Hits.js
+++ b/packages/react-instantsearch/src/components/Hits.js
@@ -1,19 +1,14 @@
+import React from 'react';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
 import classNames from './classNames.js';
 
 const cx = classNames('Hits');
 
-class Hits extends Component {
-  render() {
-    const { hitComponent: ItemComponent, hits } = this.props;
-    return (
-      <div {...cx('root')}>
-        {hits.map(hit => <ItemComponent key={hit.objectID} hit={hit} />)}
-      </div>
-    );
-  }
-}
+const Hits = ({ hits, hitComponent: HitComponent }) => (
+  <div {...cx('root')}>
+    {hits.map(hit => <HitComponent key={hit.objectID} hit={hit} />)}
+  </div>
+);
 
 Hits.propTypes = {
   hits: PropTypes.array,

--- a/packages/react-instantsearch/src/components/Hits.js
+++ b/packages/react-instantsearch/src/components/Hits.js
@@ -5,6 +5,8 @@ import classNames from './classNames.js';
 const cx = classNames('Hits');
 
 const Hits = ({ hits, hitComponent: HitComponent }) => (
+  // Spread the hit on HitComponent instead of passing the full object. BC.
+  // ex: <HitComponent {...hit} key={hit.objectID} />
   <div {...cx('root')}>
     {hits.map(hit => <HitComponent key={hit.objectID} hit={hit} />)}
   </div>
@@ -16,8 +18,7 @@ Hits.propTypes = {
 };
 
 Hits.defaultProps = {
-  // eslint-disable-next-line react/prop-types
-  hitComponent: ({ hit }) => (
+  hitComponent: props => (
     <div
       style={{
         borderBottom: '1px solid #bbb',
@@ -25,7 +26,7 @@ Hits.defaultProps = {
         marginBottom: '5px',
       }}
     >
-      {JSON.stringify(hit).slice(0, 100)}...
+      {JSON.stringify(props).slice(0, 100)}...
     </div>
   ),
 };

--- a/packages/react-instantsearch/src/components/Hits.js
+++ b/packages/react-instantsearch/src/components/Hits.js
@@ -16,7 +16,8 @@ Hits.propTypes = {
 };
 
 Hits.defaultProps = {
-  hitComponent: props => (
+  // eslint-disable-next-line react/prop-types
+  hitComponent: ({ hit }) => (
     <div
       style={{
         borderBottom: '1px solid #bbb',
@@ -24,7 +25,7 @@ Hits.defaultProps = {
         marginBottom: '5px',
       }}
     >
-      {JSON.stringify(props).slice(0, 100)}...
+      {JSON.stringify(hit).slice(0, 100)}...
     </div>
   ),
 };


### PR DESCRIPTION
Small refactoring around the `Hits` component:

- remove useless ESLint comment
- rename defaultProps parameter it can be confusing to see `hit` instead of `props`
- use functional component instead of class
