### PR TITLE
fix(localizecount): allow localized string for count in MenuSelect

### DIFF
--- a/packages/react-instantsearch/src/components/MenuSelect.js
+++ b/packages/react-instantsearch/src/components/MenuSelect.js
@@ -16,7 +16,10 @@ class MenuSelect extends Component {
       PropTypes.shape({
         label: PropTypes.string.isRequired,
         value: PropTypes.string.isRequired,
-        count: PropTypes.number.isRequired,
+        count: PropTypes.oneOfType([
+          PropTypes.number.isRequired,
+          PropTypes.string.isRequired,
+        ]),
         isRefined: PropTypes.bool.isRequired,
       })
     ),

--- a/packages/react-instantsearch/src/widgets/MenuSelect.js
+++ b/packages/react-instantsearch/src/widgets/MenuSelect.js
@@ -27,12 +27,6 @@ import MenuSelectComponent from '../components/MenuSelect.js';
  *     >
  *       <MenuSelect
  *         attributeName="category"
- *         transformItems={items =>
- *           items.map(item => {
- *             item.count = (item.count + 1000).toLocaleString();
- *             return item;
- *           })
- *         }
  *       />
  *     </InstantSearch>
  *   );

--- a/packages/react-instantsearch/src/widgets/MenuSelect.js
+++ b/packages/react-instantsearch/src/widgets/MenuSelect.js
@@ -27,6 +27,12 @@ import MenuSelectComponent from '../components/MenuSelect.js';
  *     >
  *       <MenuSelect
  *         attributeName="category"
+ *         transformItems={items =>
+ *           items.map(item => {
+ *             item.count = (item.count + 1000).toLocaleString();
+ *             return item;
+ *           })
+ *         }
  *       />
  *     </InstantSearch>
  *   );

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -105,4 +105,25 @@ stories
       displayName,
       filterProps,
     }
+  )
+  .addWithJSX(
+    'with localized count',
+    () => (
+      <WrapWithHits linkedStoryGroup="MenuSelect">
+        <MenuSelect
+          attributeName="category"
+          defaultRefinement={text('defaultSelectedItem', 'Bathroom')}
+          transformItems={items =>
+            items.map(item => {
+              item.count = (item.count + 1000).toLocaleString();
+              return item;
+            })
+          }
+        />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
   );

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -114,10 +114,10 @@ stories
           attributeName="category"
           defaultRefinement={text('defaultSelectedItem', 'Bathroom')}
           transformItems={items =>
-            items.map(item => {
-              item.count = (item.count + 1000).toLocaleString();
-              return item;
-            })
+            items.map(({ count, ...item }) => ({
+              ...item,
+              count: (count + 1000).toLocaleString(),
+            }))
           }
         />
       </WrapWithHits>


### PR DESCRIPTION
**Summary**

MenuSelect prop-types only allow for type `number` for `item.count`. This makes it impossible to `transformItems` in the widget so that the count is localized, because `.toLocaleString()` returns a string which causes prop validation to fail.

**Result**
[packages/react-instantsearch/src/components/MenuSelect.js](https://github.com/devwax/react-instantsearch/commit/57cae7f0efc9a8c71b74bcce9b23be16205f6260#diff-1da44248085324fe2f25d7ada1bfe6e6)
Changed MenuSelect `items` > `item.count` prop-type to accept string as well as number using `PropTypes.oneOfType([...])`.

Require-chaining w/ `oneOfType` keeps the prop mandatory regardless of type. See [prop-types docs](https://www.npmjs.com/package/prop-types).

[stories/MenuSelect.stories.js](https://github.com/devwax/react-instantsearch/commit/57cae7f0efc9a8c71b74bcce9b23be16205f6260#diff-3f49626eb81bbbc733740bcd535a11f0)
Added `with localized count` MenuSelect story to Storybook to demonstrate concept.

[packages/react-instantsearch/src/widgets/MenuSelect.js](https://github.com/devwax/react-instantsearch/commit/57cae7f0efc9a8c71b74bcce9b23be16205f6260#diff-6b74c83409ef6994fe9b6f4018f6bd6f)
Added localize count `transformItems` demonstration to MenuSelect @example docs.