### PR TITLE
fix: track all index in the manager

### DIFF
--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -121,6 +121,8 @@ export default function createInstantSearchManager({
         sharedParameters
       );
 
+    indexMapping[mainIndexParameters.index] = indexName;
+
     return { sharedParameters, mainIndexParameters, derivatedWidgets };
   }
 

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -7,6 +7,7 @@ import {
   Index,
   Highlight,
   SearchBox,
+  SortBy,
 } from '../packages/react-instantsearch/dom';
 import {
   connectHits,
@@ -60,6 +61,47 @@ stories
         <Configure hitsPerPage={5} />
       </Index>
       <AutoComplete />
+    </InstantSearch>
+  ))
+  .add('with SortBy nested in same Index as Root', () => (
+    <InstantSearch
+      appId="latency"
+      apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+      indexName="categories"
+    >
+      <SearchBox />
+
+      <div className="multi-index_content">
+        <div className="multi-index_categories-or-brands">
+          <Index indexName="categories">
+            <Configure hitsPerPage={3} />
+
+            <SortBy
+              defaultRefinement="categories"
+              items={[
+                { value: 'categories', label: 'Categories' },
+                { value: 'bestbuy', label: 'Best buy' },
+              ]}
+            />
+
+            <CustomCategoriesOrBrands />
+          </Index>
+
+          <Index indexName="products">
+            <Configure hitsPerPage={3} />
+
+            <SortBy
+              defaultRefinement="products"
+              items={[
+                { value: 'products', label: 'Products' },
+                { value: 'brands', label: 'Brands' },
+              ]}
+            />
+
+            <CustomCategoriesOrBrands />
+          </Index>
+        </div>
+      </div>
     </InstantSearch>
   ))
   .add('with conditional rendering', () => (


### PR DESCRIPTION
**Summary**

Fix #636 

We already track the index for the `shared` parameters, but not for the `main` parameters. This PR aims to fix this issue by tracking all the indices.

**Result**

You can play with the example on [Storybook](https://deploy-preview-660--react-instantsearch.netlify.com/react-instantsearch/storybook/?selectedKind=%3CIndex%3E&selectedStory=with%20SortBy%20nested%20in%20same%20Index%20as%20Root&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs).