### PR TITLE
fix: reset page with multi index

### DIFF
--- a/packages/react-instantsearch/src/core/indexUtils.js
+++ b/packages/react-instantsearch/src/core/indexUtils.js
@@ -39,11 +39,12 @@ export function refineValue(
         )
       : refineMultiIndex(searchState, nextRefinement, context, resetPage);
   } else {
-    /* 
-      If we have a multi index page with shared widgets we should also reset their page to 1
-      see: https://github.com/algolia/react-instantsearch/issues/310
-    */
-    if (searchState.indices) {
+    // When we have a multi index page with shared widgets we should also
+    // reset their page to 1 if the resetPage is provided. Otherwise the
+    // indices will always be reset
+    // see: https://github.com/algolia/react-instantsearch/issues/310
+    // see: https://github.com/algolia/react-instantsearch/issues/637
+    if (searchState.indices && resetPage) {
       Object.keys(searchState.indices).forEach(targetedIndex => {
         searchState = refineValue(
           searchState,

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -519,45 +519,61 @@ describe('utility method for manipulating the search state', () => {
 
     it('refine shared widgets should reset indices page to 1 with resetPage', () => {
       context = {};
-      let searchState = {
-        indices: { first: { page: 3 }, second: { page: 3 } },
-      };
-      const nextRefinement = { query: 'new' };
       const resetPage = true;
+      const nextRefinement = { query: 'new' };
+      const searchState = {
+        indices: {
+          first: { page: 3 },
+          second: { page: 3 },
+        },
+      };
 
-      searchState = refineValue(
+      const actual = refineValue(
         searchState,
         nextRefinement,
         context,
         resetPage
       );
 
-      expect(searchState).toEqual({
+      const expectation = {
         query: 'new',
         page: 1,
-        indices: { first: { page: 1 }, second: { page: 1 } },
-      });
+        indices: {
+          first: { page: 1 },
+          second: { page: 1 },
+        },
+      };
+
+      expect(actual).toEqual(expectation);
     });
 
     it('refine shared widgets should not reset indices page to 1 without resetPage', () => {
       context = {};
-      let searchState = {
-        indices: { first: { page: 3 }, second: { page: 3 } },
-      };
-      const nextRefinement = { query: 'new' };
       const resetPage = false;
+      const nextRefinement = { query: 'new' };
+      const searchState = {
+        indices: {
+          first: { page: 3 },
+          second: { page: 3 },
+        },
+      };
 
-      searchState = refineValue(
+      const actual = refineValue(
         searchState,
         nextRefinement,
         context,
         resetPage
       );
 
-      expect(searchState).toEqual({
+      const expectation = {
         query: 'new',
-        indices: { first: { page: 3 }, second: { page: 3 } },
-      });
+        indices: {
+          first: { page: 3 },
+          second: { page: 3 },
+        },
+      };
+
+      expect(actual).toEqual(expectation);
     });
   });
 });

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -517,18 +517,46 @@ describe('utility method for manipulating the search state', () => {
       expect(results).toEqual({ some: 'results' });
     });
 
-    it('refine shared widgets should reset indices page to 1', () => {
+    it('refine shared widgets should reset indices page to 1 with resetPage', () => {
       context = {};
       let searchState = {
         indices: { first: { page: 3 }, second: { page: 3 } },
       };
       const nextRefinement = { query: 'new' };
+      const resetPage = true;
 
-      searchState = refineValue(searchState, nextRefinement, context);
+      searchState = refineValue(
+        searchState,
+        nextRefinement,
+        context,
+        resetPage
+      );
 
       expect(searchState).toEqual({
         query: 'new',
+        page: 1,
         indices: { first: { page: 1 }, second: { page: 1 } },
+      });
+    });
+
+    it('refine shared widgets should not reset indices page to 1 without resetPage', () => {
+      context = {};
+      let searchState = {
+        indices: { first: { page: 3 }, second: { page: 3 } },
+      };
+      const nextRefinement = { query: 'new' };
+      const resetPage = false;
+
+      searchState = refineValue(
+        searchState,
+        nextRefinement,
+        context,
+        resetPage
+      );
+
+      expect(searchState).toEqual({
+        query: 'new',
+        indices: { first: { page: 3 }, second: { page: 3 } },
       });
     });
   });

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -6,6 +6,7 @@ import {
   InstantSearch,
   Index,
   Highlight,
+  Pagination,
   SearchBox,
   SortBy,
 } from '../packages/react-instantsearch/dom';
@@ -146,6 +147,24 @@ stories
           </div>
         </div>
       </Results>
+    </InstantSearch>
+  ))
+  .add('with Hits & Configure', () => (
+    <InstantSearch
+      appId="latency"
+      apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+      indexName="brands"
+    >
+      <Configure hitsPerPage={5} />
+      <SearchBox />
+
+      <CustomCategoriesOrBrands />
+      <Pagination />
+
+      <Index indexName="products">
+        <CustomProducts />
+        <Pagination />
+      </Index>
     </InstantSearch>
   ));
 


### PR DESCRIPTION
**Summary**

Fix #637 

With the multi indices we always reset the page when a shared widget is updated even when `resetPage` property is not passed. This PR aims to fix this, now we reset the page only the property is provided.

**Result**

We can play the example on [Storybook](https://deploy-preview-665--react-instantsearch.netlify.com/react-instantsearch/storybook/?selectedKind=%3CIndex%3E&selectedStory=with%20Hits%20%26%20Configure&full=0&down=1&left=1&panelRight=1&downPanel=kadira%2Fjsx%2Fpanel).