### PR TITLE
chore: increase Dom bundle max size

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "60 kB"
+      "maxSize": "62 kB"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
**Summary**

The size of `Dom.js` has been reached on the PR #544.