### PR TITLE
docs(refreshcache): add guide

### DIFF
--- a/docgen/src/guide/Handling_cache.md
+++ b/docgen/src/guide/Handling_cache.md
@@ -1,0 +1,113 @@
+---
+title: Handling cache
+mainTitle: Guides
+layout: main.pug
+category: guide
+navWeight: 15
+---
+
+
+By default, Algolia caches the search results of the queries, storing them locally in the cache. If the user ends up entering a search (or part of it) that has already been entered previously, the results will be retrieved from the cache, instead of requesting them from Algolia, making the application much faster.
+
+While it is a very convenient feature, in some cases, it is useful to have the ability to clear the cache and make a new request to Algolia. For instance, when changes are made on some records on your index, you might want the frontend side of your application to be updated to reflect that change (in order to avoid displaying stale results retrieved from the cache).
+
+To do so, there is a prop on the `<InstantSearch>` component called `refresh` that, when set to true, clears the cache and triggers a new search.
+
+There are two different approaches to handle the cache:
+ - have the refresh of the cache triggered by an action from the user 
+ - refresh the cache periodically
+ 
+ ## Have the refresh of the cache triggered by an action from the user
+If you know that the cache needs to be refreshed conditionally of a specific event, then you can trigger the refresh based on an user action (adding a new product, clicking on a button for instance).
+
+```jsx
+import React, { Component } from 'react';
+import { InstantSearch, SearchBox } from '../packages/react-instantsearch/dom';
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      refresh: false,
+    };
+  }
+
+  refresh = () => {
+    this.setState(prevState => ({
+      refresh: !prevState.refresh,
+    }));
+  };
+
+  onSearchStateChange = () => {
+    this.setState({ refresh: false });
+  };
+
+  render() {
+    return (
+      <InstantSearch
+        appId="yourAppId"
+        apiKey="yourApiKey"
+        indexName="yourIndexName"
+        refresh={this.state.refresh}
+        onSearchStateChange={this.onSearchStateChange}
+      >
+        <SearchBox />
+        <button
+          onClick={this.refresh}
+        >
+          Refresh cache
+        </button>
+        <CustomHits />
+      </InstantSearch>
+    );
+  }
+}
+```
+
+See the example in this [story](https://community.algolia.com/react-instantsearch/storybook/?selectedKind=RefreshCache&selectedStory=with%20a%20refresh%20button&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs). 
+
+ ## Refresh the cache periodically
+You also have the option to setup an given period of time that will determine how often the cache will be cleared. 
+This method will ensure that the cache is cleared on a regular basis.
+You should use this approach if you cannot use a user action as a specific event to trigger the clearing of the cache.
+
+```jsx
+import React, { Component } from 'react';
+import { InstantSearch, SearchBox } from '../packages/react-instantsearch/dom';
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      refresh: false,
+    };
+  }
+
+  componentDidMount = () => {
+    setInterval(
+      () =>
+        this.setState({ refresh: true }, () =>
+          this.setState({ refresh: false })
+        ),
+      5000
+    );
+  };
+
+  render() {
+    return (
+      <InstantSearch
+        appId="yourAppId"
+        apiKey="yourApiKey"
+        indexName="yourIndexName"
+        refresh={this.state.refresh}
+        onSearchStateChange={this.onSearchStateChange}
+      >
+        <SearchBox />
+        <CustomHits />
+      </InstantSearch>
+    );
+  }
+}
+```
+
+See the example in this [story](https://community.algolia.com/react-instantsearch/storybook/?selectedKind=RefreshCache&selectedStory=with%20setInterval&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs).

--- a/docgen/src/guide/Refreshing_cache.md
+++ b/docgen/src/guide/Refreshing_cache.md
@@ -1,5 +1,5 @@
 ---
-title: Handling cache
+title: Refreshing the cache
 mainTitle: Guides
 layout: main.pug
 category: guide
@@ -11,18 +11,21 @@ By default, Algolia caches the search results of the queries, storing them local
 
 While it is a very convenient feature, in some cases, it is useful to have the ability to clear the cache and make a new request to Algolia. For instance, when changes are made on some records on your index, you might want the frontend side of your application to be updated to reflect that change (in order to avoid displaying stale results retrieved from the cache).
 
-To do so, there is a prop on the `<InstantSearch>` component called `refresh` that, when set to true, clears the cache and triggers a new search.
+To do so, there is a prop on the `<InstantSearch>` component called `refresh` that, when set to `true`, clears the cache and triggers a new search.
 
-There are two different approaches to handle the cache:
- - have the refresh of the cache triggered by an action from the user 
- - refresh the cache periodically
+
+There are two different use cases where you would want to discard the cache:
+- your application data is being directly updated by your users (for example, in a dashboard). In this use case you would want to refresh the cache based on some application state such as the last modification from the user
+- your application data is being updated by another process that you don't manage (for example a CRON job updates users inside Algolia). For this you might want to periodically refresh the cache of your application
+
+
  
  ## Have the refresh of the cache triggered by an action from the user
 If you know that the cache needs to be refreshed conditionally of a specific event, then you can trigger the refresh based on an user action (adding a new product, clicking on a button for instance).
 
 ```jsx
 import React, { Component } from 'react';
-import { InstantSearch, SearchBox } from '../packages/react-instantsearch/dom';
+import { InstantSearch, SearchBox } from 'react-instantsearch/dom';
 
 class App extends Component {
   constructor(props) {
@@ -33,9 +36,7 @@ class App extends Component {
   }
 
   refresh = () => {
-    this.setState(prevState => ({
-      refresh: !prevState.refresh,
-    }));
+    this.setState({refresh: true});
   };
 
   onSearchStateChange = () => {
@@ -64,7 +65,7 @@ class App extends Component {
 }
 ```
 
-See the example in this [story](https://community.algolia.com/react-instantsearch/storybook/?selectedKind=RefreshCache&selectedStory=with%20a%20refresh%20button&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs). 
+See a live example on our [Storybook](https://community.algolia.com/react-instantsearch/storybook/?selectedKind=RefreshCache&selectedStory=with%20a%20refresh%20button&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs). 
 
  ## Refresh the cache periodically
 You also have the option to setup an given period of time that will determine how often the cache will be cleared. 
@@ -73,7 +74,7 @@ You should use this approach if you cannot use a user action as a specific event
 
 ```jsx
 import React, { Component } from 'react';
-import { InstantSearch, SearchBox } from '../packages/react-instantsearch/dom';
+import { InstantSearch, SearchBox } from 'react-instantsearch/dom';
 
 class App extends Component {
   constructor(props) {
@@ -86,13 +87,12 @@ class App extends Component {
   componentDidMount = () => {
     setInterval(
       () =>
-        this.setState({ refresh: true }, () =>
-          this.setState({ refresh: false })
-        ),
-      5000
-    );
+        this.setState({ refresh: true }), 5000 );
   };
 
+   onSearchStateChange = () => {
+    this.setState({ refresh: false });
+  };
   render() {
     return (
       <InstantSearch
@@ -110,4 +110,6 @@ class App extends Component {
 }
 ```
 
-See the example in this [story](https://community.algolia.com/react-instantsearch/storybook/?selectedKind=RefreshCache&selectedStory=with%20setInterval&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs).
+Note that if you need to wait for an action from Algolia, you should use [`waitTask`](https://www.algolia.com/doc/api-reference/api-methods/wait-task/) to avoid refreshing the cache too early.
+
+See a live example on our [Storybook](https://community.algolia.com/react-instantsearch/storybook/?selectedKind=RefreshCache&selectedStory=with%20setInterval&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs)

--- a/docgen/src/guide/Refreshing_cache.md
+++ b/docgen/src/guide/Refreshing_cache.md
@@ -28,8 +28,9 @@ import { InstantSearch, SearchBox, Hits } from 'react-instantsearch/dom';
 class App extends Component {
   constructor(props) {
     super(props);
+
     this.state = {
-      refresh: false,
+      refresh: false
     };
   }
 
@@ -74,8 +75,9 @@ import { InstantSearch, SearchBox, Hits } from 'react-instantsearch/dom';
 class App extends Component {
   constructor(props) {
     super(props);
+
     this.state = {
-      refresh: false,
+      refresh: false
     };
   }
 
@@ -86,6 +88,7 @@ class App extends Component {
   onSearchStateChange = () => {
     this.setState({ refresh: false });
   };
+
   render() {
     return (
       <InstantSearch

--- a/docgen/src/guide/Refreshing_cache.md
+++ b/docgen/src/guide/Refreshing_cache.md
@@ -23,7 +23,7 @@ If you know that the cache needs to be refreshed conditionally of a specific eve
 
 ```jsx
 import React, { Component } from 'react';
-import { InstantSearch, SearchBox } from 'react-instantsearch/dom';
+import { InstantSearch, SearchBox, Hits } from 'react-instantsearch/dom';
 
 class App extends Component {
   constructor(props) {
@@ -52,7 +52,7 @@ class App extends Component {
       >
         <SearchBox />
         <button onClick={this.refresh}>Refresh cache</button>
-        <CustomHits />
+        <Hits />
       </InstantSearch>
     );
   }
@@ -69,7 +69,7 @@ You should use this approach if you cannot use a user action as a specific event
 
 ```jsx
 import React, { Component } from 'react';
-import { InstantSearch, SearchBox } from 'react-instantsearch/dom';
+import { InstantSearch, SearchBox, Hits } from 'react-instantsearch/dom';
 
 class App extends Component {
   constructor(props) {
@@ -96,7 +96,7 @@ class App extends Component {
         onSearchStateChange={this.onSearchStateChange}
       >
         <SearchBox />
-        <CustomHits />
+        <Hits />
       </InstantSearch>
     );
   }

--- a/docgen/src/guide/Refreshing_cache.md
+++ b/docgen/src/guide/Refreshing_cache.md
@@ -30,7 +30,7 @@ class App extends Component {
     super(props);
 
     this.state = {
-      refresh: false
+      refresh: false,
     };
   }
 
@@ -77,7 +77,7 @@ class App extends Component {
     super(props);
 
     this.state = {
-      refresh: false
+      refresh: false,
     };
   }
 

--- a/docgen/src/guide/Refreshing_cache.md
+++ b/docgen/src/guide/Refreshing_cache.md
@@ -6,21 +6,19 @@ category: guide
 navWeight: 15
 ---
 
-
 By default, Algolia caches the search results of the queries, storing them locally in the cache. If the user ends up entering a search (or part of it) that has already been entered previously, the results will be retrieved from the cache, instead of requesting them from Algolia, making the application much faster.
 
 While it is a very convenient feature, in some cases, it is useful to have the ability to clear the cache and make a new request to Algolia. For instance, when changes are made on some records on your index, you might want the frontend side of your application to be updated to reflect that change (in order to avoid displaying stale results retrieved from the cache).
 
 To do so, there is a prop on the `<InstantSearch>` component called `refresh` that, when set to `true`, clears the cache and triggers a new search.
 
-
 There are two different use cases where you would want to discard the cache:
-- your application data is being directly updated by your users (for example, in a dashboard). In this use case you would want to refresh the cache based on some application state such as the last modification from the user
-- your application data is being updated by another process that you don't manage (for example a CRON job updates users inside Algolia). For this you might want to periodically refresh the cache of your application
 
+* your application data is being directly updated by your users (for example, in a dashboard). In this use case you would want to refresh the cache based on some application state such as the last modification from the user
+* your application data is being updated by another process that you don't manage (for example a CRON job updates users inside Algolia). For this you might want to periodically refresh the cache of your application
 
- 
- ## Have the refresh of the cache triggered by an action from the user
+## Have the refresh of the cache triggered by an action from the user
+
 If you know that the cache needs to be refreshed conditionally of a specific event, then you can trigger the refresh based on an user action (adding a new product, clicking on a button for instance).
 
 ```jsx
@@ -36,7 +34,7 @@ class App extends Component {
   }
 
   refresh = () => {
-    this.setState({refresh: true});
+    this.setState({ refresh: true });
   };
 
   onSearchStateChange = () => {
@@ -53,11 +51,7 @@ class App extends Component {
         onSearchStateChange={this.onSearchStateChange}
       >
         <SearchBox />
-        <button
-          onClick={this.refresh}
-        >
-          Refresh cache
-        </button>
+        <button onClick={this.refresh}>Refresh cache</button>
         <CustomHits />
       </InstantSearch>
     );
@@ -65,10 +59,11 @@ class App extends Component {
 }
 ```
 
-See a live example on our [Storybook](https://community.algolia.com/react-instantsearch/storybook/?selectedKind=RefreshCache&selectedStory=with%20a%20refresh%20button&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs). 
+See a live example on our [Storybook](https://community.algolia.com/react-instantsearch/storybook/?selectedKind=RefreshCache&selectedStory=with%20a%20refresh%20button&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs).
 
- ## Refresh the cache periodically
-You also have the option to setup an given period of time that will determine how often the cache will be cleared. 
+## Refresh the cache periodically
+
+You also have the option to setup an given period of time that will determine how often the cache will be cleared.
 This method will ensure that the cache is cleared on a regular basis.
 You should use this approach if you cannot use a user action as a specific event to trigger the clearing of the cache.
 
@@ -84,13 +79,11 @@ class App extends Component {
     };
   }
 
-  componentDidMount = () => {
-    setInterval(
-      () =>
-        this.setState({ refresh: true }), 5000 );
-  };
+  componentDidMount() {
+    setInterval(() => this.setState({ refresh: true }), 5000);
+  }
 
-   onSearchStateChange = () => {
+  onSearchStateChange = () => {
     this.setState({ refresh: false });
   };
   render() {

--- a/stories/RefreshCache.stories.js
+++ b/stories/RefreshCache.stories.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { InstantSearch, SearchBox } from '../packages/react-instantsearch/dom';
 import { CustomHits } from './util';
@@ -15,9 +14,7 @@ class AppWithRefresh extends Component {
   }
 
   refresh = () => {
-    this.setState(prevState => ({
-      refresh: !prevState.refresh,
-    }));
+    this.setState({ refresh: true });
   };
 
   onSearchStateChange = () => {
@@ -130,52 +127,25 @@ class AppWithRefresh extends Component {
 
 stories.add('with a refresh button', () => <AppWithRefresh />);
 
-class StopWatch extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { count: 0 };
-  }
-
-  componentWillReceiveProps = nextProps => {
-    if (nextProps.refresh) {
-      this.setState({ count: 0 });
-    }
-  };
-
-  componentDidMount = () => {
-    setInterval(
-      () =>
-        this.setState(prevState => ({
-          count: prevState.count + 1,
-        })),
-      1000
-    );
-  };
-
-  render = () => <span>{this.state.count}s elasped since refresh</span>;
-}
-
-StopWatch.propTypes = {
-  refresh: PropTypes.bool,
-};
-
 class App extends Component {
   constructor(props) {
     super(props);
     this.state = {
       refresh: false,
+      count: 0,
     };
   }
 
-  componentDidMount = () => {
+  componentDidMount() {
     setInterval(
       () =>
-        this.setState({ refresh: true }, () =>
-          this.setState({ refresh: false })
-        ),
-      5000
+        this.setState(prevState => ({
+          refresh: prevState.count === 5,
+          count: prevState.count === 5 ? 0 : prevState.count + 1,
+        })),
+      1000
     );
-  };
+  }
 
   render() {
     return (
@@ -184,9 +154,9 @@ class App extends Component {
         apiKey="6be0576ff61c053d5f9a3225e2a90f76"
         indexName="ikea"
         refresh={this.state.refresh}
-        onSearchStateChange={this.onSearchStateChange}
       >
-        <StopWatch refresh={this.state.refresh} />
+        <span>{this.state.count}s elasped since refresh</span>
+
         <SearchBox
           translations={{
             placeholder: 'Search our furnitures: chairs, tables etc.',

--- a/stories/RefreshCache.stories.js
+++ b/stories/RefreshCache.stories.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { InstantSearch, SearchBox } from '../packages/react-instantsearch/dom';
 import { CustomHits } from './util';
@@ -128,3 +129,74 @@ class AppWithRefresh extends Component {
 }
 
 stories.add('with a refresh button', () => <AppWithRefresh />);
+
+class StopWatch extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { count: 0 };
+  }
+
+  componentWillReceiveProps = nextProps => {
+    if (nextProps.refresh) {
+      this.setState({ count: 0 });
+    }
+  };
+
+  componentDidMount = () => {
+    setInterval(
+      () =>
+        this.setState(prevState => ({
+          count: prevState.count + 1,
+        })),
+      1000
+    );
+  };
+
+  render = () => <span>{this.state.count}s elasped since refresh</span>;
+}
+
+StopWatch.propTypes = {
+  refresh: PropTypes.bool,
+};
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      refresh: false,
+    };
+  }
+
+  componentDidMount = () => {
+    setInterval(
+      () =>
+        this.setState({ refresh: true }, () =>
+          this.setState({ refresh: false })
+        ),
+      5000
+    );
+  };
+
+  render() {
+    return (
+      <InstantSearch
+        appId="latency"
+        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+        indexName="ikea"
+        refresh={this.state.refresh}
+        onSearchStateChange={this.onSearchStateChange}
+      >
+        <StopWatch refresh={this.state.refresh} />
+        <SearchBox
+          translations={{
+            placeholder: 'Search our furnitures: chairs, tables etc.',
+          }}
+        />
+
+        <CustomHits />
+      </InstantSearch>
+    );
+  }
+}
+
+stories.add('with setInterval', () => <App />);


### PR DESCRIPTION
**Summary**

In the wake of the refresh cache feature (#619), this is a guide on how to refresh the cache with the description of the use case and an explanation of the two different approaches that can be used.