### PR TITLE
chore(size): export <Index /> from its own widget

### DIFF
--- a/packages/react-instantsearch/dom.js
+++ b/packages/react-instantsearch/dom.js
@@ -1,17 +1,4 @@
-import createInstantSearch from './src/core/createInstantSearch';
-import createIndex from './src/core/createIndex';
-import algoliasearch from 'algoliasearch/lite';
-
-const InstantSearch = createInstantSearch(algoliasearch, {
-  Root: 'div',
-  props: { className: 'ais-InstantSearch__root' },
-});
-export { InstantSearch };
-const Index = createIndex({
-  Root: 'div',
-  props: { className: 'ais-MultiIndex__root' },
-});
-export { Index };
+export { default as Index } from './src/widgets/Index.js';
 export { default as Configure } from './src/widgets/Configure.js';
 export {
   default as CurrentRefinements,

--- a/packages/react-instantsearch/dom.js
+++ b/packages/react-instantsearch/dom.js
@@ -1,4 +1,5 @@
 export { default as Index } from './src/widgets/Index.js';
+export { default as InstantSearch } from './src/widgets/InstantSearch.js';
 export { default as Configure } from './src/widgets/Configure.js';
 export {
   default as CurrentRefinements,

--- a/packages/react-instantsearch/native.js
+++ b/packages/react-instantsearch/native.js
@@ -1,2 +1,5 @@
 export { default as Index } from './src/widgets/Index.native.js';
+export {
+  default as InstantSearch,
+} from './src/widgets/InstantSearch.native.js';
 export { default as Configure } from './src/widgets/Configure.js';

--- a/packages/react-instantsearch/native.js
+++ b/packages/react-instantsearch/native.js
@@ -1,13 +1,2 @@
-import algoliasearch from 'algoliasearch/reactnative';
-import createInstantSearch from './src/core/createInstantSearch';
-import createIndex from './src/core/createIndex';
-import { View } from 'react-native';
-const InstantSearch = createInstantSearch(algoliasearch, {
-  Root: View,
-});
-export { InstantSearch };
-const Index = createIndex({
-  Root: View,
-});
-export { Index };
+export { default as Index } from './src/widgets/Index.native.js';
 export { default as Configure } from './src/widgets/Configure.js';

--- a/packages/react-instantsearch/server.js
+++ b/packages/react-instantsearch/server.js
@@ -1,8 +1,6 @@
-import { createInstantSearch } from './src/core/createInstantSearchServer';
+import { createInstantSearch as cis } from './src/core/createInstantSearchServer';
 import algoliasearch from 'algoliasearch/lite';
 
-const cis = function() {
-  return createInstantSearch(algoliasearch);
+export const createInstantSearch = function() {
+  return cis(algoliasearch);
 };
-
-export { cis as createInstantSearch };

--- a/packages/react-instantsearch/src/widgets/Index.js
+++ b/packages/react-instantsearch/src/widgets/Index.js
@@ -1,12 +1,5 @@
-import createInstantSearch from '../core/createInstantSearch';
 import createIndex from '../core/createIndex';
-import algoliasearch from 'algoliasearch/lite';
 
-const InstantSearch = createInstantSearch(algoliasearch, {
-  Root: 'div',
-  props: { className: 'ais-InstantSearch__root' },
-});
-export { InstantSearch };
 const Index = createIndex({
   Root: 'div',
   props: { className: 'ais-MultiIndex__root' },

--- a/packages/react-instantsearch/src/widgets/Index.js
+++ b/packages/react-instantsearch/src/widgets/Index.js
@@ -1,0 +1,14 @@
+import createInstantSearch from '../core/createInstantSearch';
+import createIndex from '../core/createIndex';
+import algoliasearch from 'algoliasearch/lite';
+
+const InstantSearch = createInstantSearch(algoliasearch, {
+  Root: 'div',
+  props: { className: 'ais-InstantSearch__root' },
+});
+export { InstantSearch };
+const Index = createIndex({
+  Root: 'div',
+  props: { className: 'ais-MultiIndex__root' },
+});
+export default Index;

--- a/packages/react-instantsearch/src/widgets/Index.native.js
+++ b/packages/react-instantsearch/src/widgets/Index.native.js
@@ -1,12 +1,6 @@
-import algoliasearch from 'algoliasearch/reactnative';
-import createInstantSearch from '../core/createInstantSearch';
 import createIndex from '../core/createIndex';
 import { View } from 'react-native';
 
-const InstantSearch = createInstantSearch(algoliasearch, {
-  Root: View,
-});
-export { InstantSearch };
 const Index = createIndex({
   Root: View,
 });

--- a/packages/react-instantsearch/src/widgets/Index.native.js
+++ b/packages/react-instantsearch/src/widgets/Index.native.js
@@ -1,0 +1,13 @@
+import algoliasearch from 'algoliasearch/reactnative';
+import createInstantSearch from '../core/createInstantSearch';
+import createIndex from '../core/createIndex';
+import { View } from 'react-native';
+
+const InstantSearch = createInstantSearch(algoliasearch, {
+  Root: View,
+});
+export { InstantSearch };
+const Index = createIndex({
+  Root: View,
+});
+export default Index;

--- a/packages/react-instantsearch/src/widgets/InstantSearch.js
+++ b/packages/react-instantsearch/src/widgets/InstantSearch.js
@@ -1,0 +1,8 @@
+import createInstantSearch from '../core/createInstantSearch';
+import algoliasearch from 'algoliasearch/lite';
+
+const InstantSearch = createInstantSearch(algoliasearch, {
+  Root: 'div',
+  props: { className: 'ais-InstantSearch__root' },
+});
+export default InstantSearch;

--- a/packages/react-instantsearch/src/widgets/InstantSearch.native.js
+++ b/packages/react-instantsearch/src/widgets/InstantSearch.native.js
@@ -1,0 +1,8 @@
+import algoliasearch from 'algoliasearch/reactnative';
+import createInstantSearch from '../core/createInstantSearch';
+import { View } from 'react-native';
+
+const InstantSearch = createInstantSearch(algoliasearch, {
+  Root: View,
+});
+export default InstantSearch;


### PR DESCRIPTION
This makes /dom, /react-native "pure modules", which _might_ have advantages in webpack 4 cc @thelarkinn

We'll also need `side-effects: false` in our package.json, see [example](https://github.com/webpack/webpack/tree/next/examples/side-effects), but I'm not sure if we're _actually_ side-effects RN, could you confirm Sean?