### PR TITLE
fix(createInstantSearch): remove the client from the Snapshot

### DIFF
--- a/packages/react-instantsearch/examples/geo-search/src/__snapshots__/App.test.js.snap
+++ b/packages/react-instantsearch/examples/geo-search/src/__snapshots__/App.test.js.snap
@@ -62,6 +62,7 @@ exports[`geo-search recipe App renders without crashing 1`] = `
       />
       <button
         className="ais-SearchBox__submit"
+        hidden={false}
         title="Submit your search query."
         type="submit"
       >

--- a/packages/react-instantsearch/examples/multi-index/src/__snapshots__/App.test.js.snap
+++ b/packages/react-instantsearch/examples/multi-index/src/__snapshots__/App.test.js.snap
@@ -61,6 +61,7 @@ exports[`Multi index recipe App renders without crashing 1`] = `
       />
       <button
         className="ais-SearchBox__submit"
+        hidden={false}
         title="Submit your search query."
         type="submit"
       >

--- a/packages/react-instantsearch/examples/next-app/tests/__snapshots__/index.test.js.snap
+++ b/packages/react-instantsearch/examples/next-app/tests/__snapshots__/index.test.js.snap
@@ -67,6 +67,7 @@ exports[`Next app recipes App renders without crashing 1`] = `
             />
             <button
               className="ais-SearchBox__submit"
+              hidden={false}
               title="Submit your search query."
               type="submit"
             >

--- a/packages/react-instantsearch/examples/react-router-v3/src/__snapshots__/App.test.js.snap
+++ b/packages/react-instantsearch/examples/react-router-v3/src/__snapshots__/App.test.js.snap
@@ -73,6 +73,7 @@ exports[`react-router recipe App renders without crashing 1`] = `
           />
           <button
             className="ais-SearchBox__submit"
+            hidden={false}
             title="Submit your search query."
             type="submit"
           >

--- a/packages/react-instantsearch/examples/react-router/src/__snapshots__/App.test.js.snap
+++ b/packages/react-instantsearch/examples/react-router/src/__snapshots__/App.test.js.snap
@@ -73,6 +73,7 @@ exports[`react-router recipe App renders without crashing 1`] = `
           />
           <button
             className="ais-SearchBox__submit"
+            hidden={false}
             title="Submit your search query."
             type="submit"
           >

--- a/packages/react-instantsearch/examples/server-side-rendering/src/app/__snapshots__/index.test.js.snap
+++ b/packages/react-instantsearch/examples/server-side-rendering/src/app/__snapshots__/index.test.js.snap
@@ -61,6 +61,7 @@ exports[`Server-side rendering recipes App renders without crashing 1`] = `
       />
       <button
         className="ais-SearchBox__submit"
+        hidden={false}
         title="Submit your search query."
         type="submit"
       >

--- a/packages/react-instantsearch/src/core/__snapshots__/createInstantSearch.test.js.snap
+++ b/packages/react-instantsearch/src/core/__snapshots__/createInstantSearch.test.js.snap
@@ -2,15 +2,6 @@
 
 exports[`createInstantSearch wraps InstantSearch 1`] = `
 Object {
-  "algoliaClient": Object {
-    "addAlgoliaAgent": [MockFunction] {
-      "calls": Array [
-        Array [
-          "react-instantsearch 4.3.0-beta.0",
-        ],
-      ],
-    },
-  },
   "children": undefined,
   "createURL": undefined,
   "indexName": "name",

--- a/packages/react-instantsearch/src/core/createInstantSearch.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearch.test.js
@@ -25,8 +25,12 @@ describe('createInstantSearch', () => {
     const wrapper = shallow(
       <CustomInstantSearch appId="app" apiKey="key" indexName="name" />
     );
+
+    // eslint-disable-next-line no-shadow
+    const { algoliaClient, ...propsWithoutClient } = wrapper.props();
+
     expect(wrapper.is(InstantSearch)).toBe(true);
-    expect(wrapper.props()).toMatchSnapshot();
+    expect(propsWithoutClient).toMatchSnapshot();
     expect(wrapper.props().algoliaClient).toBe(algoliaClient);
   });
 


### PR DESCRIPTION
**Summary**

With `jest@22` the mock function are now print with the snapshot. 

So when we call `createInstantSearch` from the test, we provide a mock client with the current version of the lib. We already test that the instance is called with the correct client (see below). So we don't need to print the client mock in the snapshot. It will avoid that every time we release a new version we have to fix the snapshot, just because the version bump.

> https://github.com/algolia/react-instantsearch/pull/749/files#diff-89fda296b36d39c13ca0e69ebdb33163R34