### PR TITLE
feat: InstantSearch root props

### DIFF
--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -33,6 +33,7 @@ function validateNextProps(props, nextProps) {
  * @propType {func} [createURL] - Function to call when creating links, useful for [URL Routing](guide/Routing.html).
  * @propType {SearchResults|SearchResults[]} [resultsState] - Use this to inject the results that will be used at first rendering. Those results are found by using the `findResultsState` function. Useful for [Server Side Rendering](guide/Server-side_rendering.html).
  * @propType {number} [stalledSearchDelay=200] - The amount of time before considering that the search takes too much time. The time is expressed in milliseconds.
+ * @propType {{ Root: string|function, props: object }} [root] - Use this to customize the root element. Default value: `{ Root: 'div' }`
  * @example
  * import {InstantSearch, SearchBox, Hits} from 'react-instantsearch/dom';
  *

--- a/packages/react-instantsearch/src/core/createInstantSearch.js
+++ b/packages/react-instantsearch/src/core/createInstantSearch.js
@@ -28,16 +28,25 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
       onSearchStateChange: PropTypes.func,
       onSearchParameters: PropTypes.func,
       resultsState: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+      root: PropTypes.shape({
+        Root: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+          .isRequired,
+        props: PropTypes.object,
+      }),
     };
 
     static defaultProps = {
       refresh: false,
+      root,
     };
 
-    constructor(props) {
-      super();
+    constructor(...args) {
+      super(...args);
+
       this.client =
-        props.algoliaClient || defaultAlgoliaClient(props.appId, props.apiKey);
+        this.props.algoliaClient ||
+        defaultAlgoliaClient(this.props.appId, this.props.apiKey);
+
       this.client.addAlgoliaAgent(`react-instantsearch ${version}`);
     }
 
@@ -63,7 +72,7 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
           searchState={this.props.searchState}
           onSearchStateChange={this.props.onSearchStateChange}
           onSearchParameters={this.props.onSearchParameters}
-          root={root}
+          root={this.props.root}
           algoliaClient={this.client}
           refresh={this.props.refresh}
           resultsState={this.props.resultsState}

--- a/stories/InstantSearch.stories.js
+++ b/stories/InstantSearch.stories.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { setAddon, storiesOf } from '@storybook/react';
+import JSXAddon from 'storybook-addon-jsx';
+import {
+  InstantSearch,
+  SearchBox,
+  Hits,
+} from '../packages/react-instantsearch/dom';
+import { displayName, filterProps } from './util';
+
+setAddon(JSXAddon);
+
+const stories = storiesOf('InstantSearch', module);
+
+stories
+  .addWithJSX(
+    'default',
+    () => (
+      <InstantSearch
+        appId="latency"
+        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+        indexName="ikea"
+      >
+        <SearchBox />
+        <Hits />
+      </InstantSearch>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with custom root',
+    () => (
+      <InstantSearch
+        appId="latency"
+        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+        indexName="ikea"
+        root={{
+          Root: 'div',
+          props: {
+            style: {
+              background: 'linear-gradient(80deg, #00D8FF, #00A7FF)',
+            },
+          },
+        }}
+      >
+        <SearchBox />
+        <Hits />
+      </InstantSearch>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  );


### PR DESCRIPTION
**Summary**

Fix #285 

Enable the possibility to pass custom `root` props to InstantSearch. Don't introduce any breaking change, since we use the root of `createInstantSearch` as `defaultProps`.

**Result**

The following example is with React Native, when we don't pass `flex: 1` to InstantSearch the list is crop before the end.

**Before**

![simulator screen shot - iphone x - 2017-12-27 at 12 18 14](https://user-images.githubusercontent.com/6513513/34380209-1c5a10f4-eb00-11e7-8bce-5b40a02f7a07.png)

**After**

![simulator screen shot - iphone x - 2017-12-27 at 12 18 35](https://user-images.githubusercontent.com/6513513/34380210-1f84ada2-eb00-11e7-8d3e-a4ae6ae577d3.png)