### PR TITLE
fix(connectRange): check if facet exist before access

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -190,8 +190,13 @@ export default createConnector({
   getProvidedProps(props, searchState, searchResults) {
     const { attributeName, precision, min: minBound, max: maxBound } = props;
     const results = getResults(searchResults, this.context);
-    const stats = results ? results.getFacetStats(attributeName) || {} : {};
-    const count = results
+    const isFacetExist = results && results.getFacetByName(attributeName);
+
+    const stats = isFacetExist
+      ? results.getFacetStats(attributeName) || {}
+      : {};
+
+    const count = isFacetExist
       ? results.getFacetValues(attributeName).map(v => ({
           value: v.name,
           count: v.count,

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -190,13 +190,9 @@ export default createConnector({
   getProvidedProps(props, searchState, searchResults) {
     const { attributeName, precision, min: minBound, max: maxBound } = props;
     const results = getResults(searchResults, this.context);
-    const isFacetExist = results && results.getFacetByName(attributeName);
-
-    const stats = isFacetExist
-      ? results.getFacetStats(attributeName) || {}
-      : {};
-
-    const count = isFacetExist
+    const hasFacet = results && results.getFacetByName(attributeName);
+    const stats = hasFacet ? results.getFacetStats(attributeName) || {} : {};
+    const count = hasFacet
       ? results.getFacetValues(attributeName).map(v => ({
           value: v.name,
           count: v.count,

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -192,12 +192,12 @@ export default createConnector({
     const results = getResults(searchResults, this.context);
     const hasFacet = results && results.getFacetByName(attributeName);
     const stats = hasFacet ? results.getFacetStats(attributeName) || {} : {};
-    const count = hasFacet
-      ? results.getFacetValues(attributeName).map(v => ({
-          value: v.name,
-          count: v.count,
-        }))
-      : [];
+    const facetValues = hasFacet ? results.getFacetValues(attributeName) : [];
+
+    const count = facetValues.map(v => ({
+      value: v.name,
+      count: v.count,
+    }));
 
     const { min: rangeMin, max: rangeMax } = getCurrentRange(
       { min: minBound, max: maxBound },

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -1,8 +1,6 @@
-/* eslint-env jest, jasmine */
-
-import { SearchParameters } from 'algoliasearch-helper';
-
+import { SearchParameters, SearchResults } from 'algoliasearch-helper';
 import connect from './connectRange';
+
 jest.mock('../core/createConnector');
 
 let props;
@@ -214,6 +212,7 @@ describe('connectRange', () => {
       });
 
       results = {
+        getFacetByName: () => false,
         getFacetStats: () => {},
         getFacetValues: () => [],
         hits: [],
@@ -312,6 +311,28 @@ describe('connectRange', () => {
         min: 5,
         max: 10,
         currentRefinement: { min: 6, max: 9 },
+        count: [],
+        canRefine: false,
+        precision: 2,
+      });
+
+      props = getProvidedProps(
+        {
+          attributeName: 'ok',
+          precision: 2,
+        },
+        {},
+        {
+          results: new SearchResults(new SearchParameters(), [{ hits: [] }]),
+        }
+      );
+      expect(props).toEqual({
+        min: undefined,
+        max: undefined,
+        currentRefinement: {
+          min: undefined,
+          max: undefined,
+        },
         count: [],
         canRefine: false,
         precision: 2,
@@ -627,6 +648,30 @@ describe('connectRange', () => {
         min: 5,
         max: 10,
         currentRefinement: { min: 6, max: 9 },
+        count: [],
+        canRefine: false,
+        precision: 2,
+      });
+
+      props = getProvidedProps(
+        {
+          attributeName: 'ok',
+          precision: 2,
+        },
+        {},
+        {
+          results: {
+            first: new SearchResults(new SearchParameters(), [{ hits: [] }]),
+          },
+        }
+      );
+      expect(props).toEqual({
+        min: undefined,
+        max: undefined,
+        currentRefinement: {
+          min: undefined,
+          max: undefined,
+        },
         count: [],
         canRefine: false,
         precision: 2,


### PR DESCRIPTION
**Summary**

Fix #630 

In the `connectRange` we need to access the stats & the values of the given facet in order to compute the range. But it may happen that the facet is not yet present on the results so we need to check that the facet is present on results before accessing it.