### PR TITLE
fix: Clear SearchBox without search as you type

### DIFF
--- a/packages/react-instantsearch/src/components/SearchBox.js
+++ b/packages/react-instantsearch/src/components/SearchBox.js
@@ -119,17 +119,6 @@ class SearchBox extends Component {
       ? this.props.currentRefinement
       : this.state.query;
 
-  setQuery = val => {
-    const { refine, searchAsYouType } = this.props;
-    if (searchAsYouType) {
-      refine(val);
-    } else {
-      this.setState({
-        query: val,
-      });
-    }
-  };
-
   onInputMount = input => {
     this.input = input;
     if (this.props.__inputRef) {
@@ -182,20 +171,33 @@ class SearchBox extends Component {
     return false;
   };
 
-  onChange = e => {
-    this.setQuery(e.target.value);
+  onChange = event => {
+    const { searchAsYouType, refine, onChange } = this.props;
+    const value = event.target.value;
 
-    if (this.props.onChange) {
-      this.props.onChange(e);
+    if (searchAsYouType) {
+      refine(value);
+    } else {
+      this.setState({ query: value });
+    }
+
+    if (onChange) {
+      onChange(event);
     }
   };
 
-  onReset = () => {
-    this.setQuery('');
+  onReset = event => {
+    const { searchAsYouType, refine, onReset } = this.props;
+
+    refine('');
     this.input.focus();
 
-    if (this.props.onReset) {
-      this.props.onReset();
+    if (!searchAsYouType) {
+      this.setState({ query: '' });
+    }
+
+    if (onReset) {
+      onReset(event);
     }
   };
 

--- a/packages/react-instantsearch/src/components/SearchBox.test.js
+++ b/packages/react-instantsearch/src/components/SearchBox.test.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
-import Enzyme, { mount } from 'enzyme';
+import Enzyme, { shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import SearchBox from './SearchBox';
 
@@ -250,5 +250,41 @@ describe('SearchBox', () => {
 
     instanceWithoutLoadingIndicator.unmount();
     instanceWithLoadingIndicator.unmount();
+  });
+
+  it('expect to clear the query when the reset button is click with searchAsYouType=true', () => {
+    const refine = jest.fn();
+
+    const wrapper = shallow(
+      <SearchBox refine={refine} searchAsYouType />
+    ).dive();
+
+    // Simulate the ref
+    wrapper.instance().input = { focus: jest.fn() };
+
+    wrapper.find('button[type="reset"]').simulate('click');
+
+    expect(refine).toHaveBeenCalledWith('');
+    expect(wrapper.instance().input.focus).toHaveBeenCalled();
+  });
+
+  it('expect to clear the query when the reset button is click with searchAsYouType=false', () => {
+    const refine = jest.fn();
+
+    const wrapper = shallow(
+      <SearchBox refine={refine} searchAsYouType={false} />
+    ).dive();
+
+    // Simulate the ref
+    wrapper.instance().input = { focus: jest.fn() };
+
+    // Simulate change event
+    wrapper.setState({ query: 'Hello' });
+
+    wrapper.find('button[type="reset"]').simulate('click');
+
+    expect(refine).toHaveBeenCalledWith('');
+    expect(wrapper.instance().input.focus).toHaveBeenCalled();
+    expect(wrapper.state()).toEqual({ query: '' });
   });
 });

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -84,6 +84,18 @@ stories
     }
   )
   .addWithJSX(
+    'without search as you type',
+    () => (
+      <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox">
+        <SearchBox searchAsYouType={false} />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
     'playground',
     () => (
       <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox">


### PR DESCRIPTION
**Summary**

Fix #799 

When the button `reset` is clicked the query should be clear. But it's only works when the `searchAsYouType` is `true` since we are using the same function for the `reset` & `change` event. Now we don't use the same function for both events. 

In a future refactoring we can probably avoid to handle the state of the query with two different cases (control & uncontrol). We could move for a full control input with a copy of the current refinement in the local state. It will avoid to have two sources of truth in the component.

**Before**

![before](https://user-images.githubusercontent.com/6513513/34602430-feda6bf8-f1ff-11e7-9937-b3a3ab5ca6bf.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/34602432-02a525f2-f200-11e7-991b-860f33e4fed5.gif)

You can also play with the example on [Storybook](https://deploy-preview-802--react-instantsearch.netlify.com/react-instantsearch/storybook/?knob-showLoadingIndicator=true&selectedKind=SearchBox&selectedStory=without%20search%20as%20you%20type&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs).