### PR TITLE
Update prop name

### DIFF
--- a/packages/react-instantsearch/src/components/Highlight.js
+++ b/packages/react-instantsearch/src/components/Highlight.js
@@ -12,5 +12,5 @@ Highlight.propTypes = {
   highlight: PropTypes.func.isRequired,
   tagName: PropTypes.string,
   nonHighlightedTagName: PropTypes.string,
-  separatorComponent: PropTypes.node,
+  separator: PropTypes.node,
 };

--- a/packages/react-instantsearch/src/widgets/Highlight.js
+++ b/packages/react-instantsearch/src/widgets/Highlight.js
@@ -11,7 +11,7 @@ import HighlightComponent from '../components/Highlight.js';
  * @propType {object} hit - hit object containing the highlighted attribute
  * @propType {string} [tagName='em'] - tag to be used for highlighted parts of the hit
  * @propType {string} [nonHighlightedTagName='span'] - tag to be used for the parts of the hit that are not highlighted
- * @propType {React.Element} [separatorComponent=',<space>'] - symbol used to separate the elements of the array in case the attributeName points to an array of strings.
+ * @propType {React.Element} [separator=',<space>'] - symbol used to separate the elements of the array in case the attributeName points to an array of strings.
  * @themeKey ais-Highlight - root of the component
  * @themeKey ais-Highlight__highlighted - part of the text that is highlighted
  * @themeKey ais-Highlight__nonHighlighted - part of the text that is non highlighted


### PR DESCRIPTION
**Summary**

Amending the Highlight.js widget documentation to correct prop name for `separator`. The rationale for changing documentation rather than change to actual prop is because the single word `separator` is more in keeping with the other props.  Issue from  https://github.com/algolia/react-instantsearch/issues/803
