### PR TITLE
Update prop name

### DIFF
--- a/packages/react-instantsearch/src/components/Snippet.js
+++ b/packages/react-instantsearch/src/components/Snippet.js
@@ -13,5 +13,5 @@ Snippet.propTypes = {
   highlight: PropTypes.func.isRequired,
   tagName: PropTypes.string,
   nonHighlightedTagName: PropTypes.string,
-  separatorComponent: PropTypes.node,
+  separator: PropTypes.node,
 };

--- a/packages/react-instantsearch/src/widgets/Snippet.js
+++ b/packages/react-instantsearch/src/widgets/Snippet.js
@@ -14,7 +14,7 @@ import SnippetComponent from '../components/Snippet.js';
  * @propType {object} hit - hit object containing the highlighted snippet attribute
  * @propType {string} [tagName='em'] - tag to be used for highlighted parts of the attribute
  * @propType {string} [nonHighlightedTagName='span'] - tag to be used for the parts of the hit that are not highlighted
- * @propType {React.Element} [separatorComponent=',<space>'] - symbol used to separate the elements of the array in case the attributeName points to an array of strings.
+ * @propType {React.Element} [separator=',<space>'] - symbol used to separate the elements of the array in case the attributeName points to an array of strings.
  * @example
  * import React from 'react';
  * import { Snippet, InstantSearch, Hits } from 'react-instantsearch/dom';


### PR DESCRIPTION
**Summary**

Amending the Snippet.js widget documentation to correct prop name for `separator`. The rationale for changing documentation rather than change to actual prop is because the single word `separator` is more in keeping with the other props.  Issue from  https://github.com/algolia/react-instantsearch/issues/803