### PR TITLE
refactor: rename xxxComponent props

### DIFF
--- a/packages/react-instantsearch/src/components/Breadcrumb.js
+++ b/packages/react-instantsearch/src/components/Breadcrumb.js
@@ -21,12 +21,14 @@ class Breadcrumb extends Component {
     items: itemsPropType,
     refine: PropTypes.func.isRequired,
     rootURL: PropTypes.string,
-    separator: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    separator: PropTypes.node,
     translate: PropTypes.func.isRequired,
     className: PropTypes.string,
   };
 
   static defaultProps = {
+    rootURL: null,
+    separator: '>',
     className: '',
   };
 

--- a/packages/react-instantsearch/src/components/Breadcrumb.js
+++ b/packages/react-instantsearch/src/components/Breadcrumb.js
@@ -28,7 +28,7 @@ class Breadcrumb extends Component {
 
   static defaultProps = {
     rootURL: null,
-    separator: '>',
+    separator: ' > ',
     className: '',
   };
 

--- a/packages/react-instantsearch/src/components/SearchBox.js
+++ b/packages/react-instantsearch/src/components/SearchBox.js
@@ -6,7 +6,7 @@ import createClassNames from './createClassNames';
 
 const cx = createClassNames('SearchBox');
 
-const DefaultLoadingIndicatorComponent = () => (
+const defaultLoadingIndicator = (
   <svg
     width="18"
     height="18"
@@ -33,7 +33,7 @@ const DefaultLoadingIndicatorComponent = () => (
   </svg>
 );
 
-const DefaultResetComponent = () => (
+const defaultReset = (
   <svg
     className={cx('resetIcon')}
     xmlns="http://www.w3.org/2000/svg"
@@ -45,7 +45,7 @@ const DefaultResetComponent = () => (
   </svg>
 );
 
-const DefaultSubmitComponent = () => (
+const defaultSubmit = (
   <svg
     className={cx('submitIcon')}
     xmlns="http://www.w3.org/2000/svg"
@@ -64,9 +64,9 @@ class SearchBox extends Component {
     refine: PropTypes.func.isRequired,
     translate: PropTypes.func.isRequired,
 
-    loadingIndicatorComponent: PropTypes.node,
-    resetComponent: PropTypes.node,
-    submitComponent: PropTypes.node,
+    loadingIndicator: PropTypes.node,
+    reset: PropTypes.node,
+    submit: PropTypes.node,
 
     focusShortcuts: PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.string, PropTypes.number])
@@ -94,9 +94,9 @@ class SearchBox extends Component {
     searchAsYouType: true,
     showLoadingIndicator: false,
     isSearchStalled: false,
-    loadingIndicatorComponent: <DefaultLoadingIndicatorComponent />,
-    resetComponent: <DefaultResetComponent />,
-    submitComponent: <DefaultSubmitComponent />,
+    loadingIndicator: defaultLoadingIndicator,
+    reset: defaultReset,
+    submit: defaultSubmit,
   };
 
   constructor(props) {
@@ -222,9 +222,9 @@ class SearchBox extends Component {
       className,
       translate,
       autoFocus,
-      loadingIndicatorComponent,
-      submitComponent,
-      resetComponent,
+      loadingIndicator,
+      submit,
+      reset,
     } = this.props;
     const query = this.getQuery();
 
@@ -275,7 +275,7 @@ class SearchBox extends Component {
             title={translate('submitTitle')}
             className={cx('submit')}
           >
-            {submitComponent}
+            {submit}
           </button>
           <button
             type="reset"
@@ -284,11 +284,11 @@ class SearchBox extends Component {
             onClick={this.onReset}
             hidden={!query || isSearchStalled}
           >
-            {resetComponent}
+            {reset}
           </button>
           {this.props.showLoadingIndicator && (
             <span hidden={!isSearchStalled} className={cx('loadingIndicator')}>
-              {loadingIndicatorComponent}
+              {loadingIndicator}
             </span>
           )}
         </form>

--- a/packages/react-instantsearch/src/components/SearchBox.test.js
+++ b/packages/react-instantsearch/src/components/SearchBox.test.js
@@ -74,8 +74,8 @@ describe('SearchBox', () => {
     const instance = renderer.create(
       <SearchBox
         refine={() => null}
-        submitComponent={<span>🔍</span>}
-        resetComponent={
+        submit={<span>🔍</span>}
+        reset={
           <svg viewBox="200 198 108 122">
             <path d="M200.8 220l45 46.7-20 47.4 31.7-34 50.4 39.3-34.3-52.6 30.2-68.3-49.7 51.7" />
           </svg>

--- a/packages/react-instantsearch/src/components/__snapshots__/Breadcrumb.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/Breadcrumb.test.js.snap
@@ -94,7 +94,7 @@ exports[`Breadcrumb has customizable translations 1`] = `
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       <a
         className="ais-Breadcrumb-link"
@@ -110,7 +110,7 @@ exports[`Breadcrumb has customizable translations 1`] = `
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       <a
         className="ais-Breadcrumb-link"
@@ -126,7 +126,7 @@ exports[`Breadcrumb has customizable translations 1`] = `
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       white1.1
     </li>
@@ -158,7 +158,7 @@ exports[`Breadcrumb outputs the default breadcrumb 1`] = `
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       <a
         className="ais-Breadcrumb-link"
@@ -174,7 +174,7 @@ exports[`Breadcrumb outputs the default breadcrumb 1`] = `
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       <a
         className="ais-Breadcrumb-link"
@@ -190,7 +190,7 @@ exports[`Breadcrumb outputs the default breadcrumb 1`] = `
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       white1.1
     </li>
@@ -222,7 +222,7 @@ exports[`Breadcrumb outputs the default breadcrumb with a custom className 1`] =
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       <a
         className="ais-Breadcrumb-link"
@@ -238,7 +238,7 @@ exports[`Breadcrumb outputs the default breadcrumb with a custom className 1`] =
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       <a
         className="ais-Breadcrumb-link"
@@ -254,7 +254,7 @@ exports[`Breadcrumb outputs the default breadcrumb with a custom className 1`] =
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       white1.1
     </li>
@@ -275,7 +275,7 @@ exports[`Breadcrumb outputs the default breadcrumb with no refinement 1`] = `
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       <a
         className="ais-Breadcrumb-link"
@@ -291,7 +291,7 @@ exports[`Breadcrumb outputs the default breadcrumb with no refinement 1`] = `
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       <a
         className="ais-Breadcrumb-link"
@@ -307,7 +307,7 @@ exports[`Breadcrumb outputs the default breadcrumb with no refinement 1`] = `
       <span
         className="ais-Breadcrumb-separator"
       >
-        &gt;
+         &gt; 
       </span>
       white1.1
     </li>

--- a/packages/react-instantsearch/src/components/__snapshots__/Breadcrumb.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/Breadcrumb.test.js.snap
@@ -93,7 +93,9 @@ exports[`Breadcrumb has customizable translations 1`] = `
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       <a
         className="ais-Breadcrumb-link"
         href="#"
@@ -107,7 +109,9 @@ exports[`Breadcrumb has customizable translations 1`] = `
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       <a
         className="ais-Breadcrumb-link"
         href="#"
@@ -121,7 +125,9 @@ exports[`Breadcrumb has customizable translations 1`] = `
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       white1.1
     </li>
   </ul>
@@ -151,7 +157,9 @@ exports[`Breadcrumb outputs the default breadcrumb 1`] = `
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       <a
         className="ais-Breadcrumb-link"
         href="#"
@@ -165,7 +173,9 @@ exports[`Breadcrumb outputs the default breadcrumb 1`] = `
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       <a
         className="ais-Breadcrumb-link"
         href="#"
@@ -179,7 +189,9 @@ exports[`Breadcrumb outputs the default breadcrumb 1`] = `
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       white1.1
     </li>
   </ul>
@@ -209,7 +221,9 @@ exports[`Breadcrumb outputs the default breadcrumb with a custom className 1`] =
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       <a
         className="ais-Breadcrumb-link"
         href="#"
@@ -223,7 +237,9 @@ exports[`Breadcrumb outputs the default breadcrumb with a custom className 1`] =
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       <a
         className="ais-Breadcrumb-link"
         href="#"
@@ -237,7 +253,9 @@ exports[`Breadcrumb outputs the default breadcrumb with a custom className 1`] =
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       white1.1
     </li>
   </ul>
@@ -256,7 +274,9 @@ exports[`Breadcrumb outputs the default breadcrumb with no refinement 1`] = `
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       <a
         className="ais-Breadcrumb-link"
         href="#"
@@ -270,7 +290,9 @@ exports[`Breadcrumb outputs the default breadcrumb with no refinement 1`] = `
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       <a
         className="ais-Breadcrumb-link"
         href="#"
@@ -284,7 +306,9 @@ exports[`Breadcrumb outputs the default breadcrumb with no refinement 1`] = `
     >
       <span
         className="ais-Breadcrumb-separator"
-      />
+      >
+        &gt;
+      </span>
       white1.1
     </li>
   </ul>

--- a/packages/react-instantsearch/src/connectors/connectBreadcrumb.js
+++ b/packages/react-instantsearch/src/connectors/connectBreadcrumb.js
@@ -61,9 +61,7 @@ function transformValue(values) {
  * on the Algolia dashboard or configured as `attributesForFaceting` via a set settings call to the Algolia API.
  *
  * @kind connector
- * @propType {string} attributes - List of attributes to use to generate the hierarchy of the menu. See the example for the convention to follow.
- * @propType {string} {React.Element} [separator=' > '] -  Specifies the level separator used in the data.
- * @propType {string} [rootURL=null] - The root element's URL (the originating page).
+ * @propType {array.<string>} attributes - List of attributes to use to generate the hierarchy of the menu. See the example for the convention to follow.
  * @propType {function} [transformItems] - Function to modify the items being displayed, e.g. for filtering or sorting them. Takes an items as parameter and expects it back in return.
  * @providedPropType {function} refine - a function to toggle a refinement
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
@@ -87,14 +85,7 @@ export default createConnector({
       }
       return undefined;
     },
-    rootURL: PropTypes.string,
-    separator: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     transformItems: PropTypes.func,
-  },
-
-  defaultProps: {
-    rootURL: null,
-    separator: '>',
   },
 
   getProvidedProps(props, searchState, searchResults) {

--- a/packages/react-instantsearch/src/widgets/Breadcrumb.js
+++ b/packages/react-instantsearch/src/widgets/Breadcrumb.js
@@ -46,7 +46,7 @@ import Breadcrumb from '../components/Breadcrumb';
  * on the Algolia dashboard or configured as `attributesForFaceting` via a set settings call to the Algolia API.
  *
  * @propType {array.<string>} attributes - List of attributes to use to generate the hierarchy of the menu. See the example for the convention to follow
- * @propType {node} [separator='>'] -  Symbol used for separating hyperlinks
+ * @propType {node} [separator=' > '] -  Symbol used for separating hyperlinks
  * @propType {string} [rootURL=null] - The originating page (homepage)
  * @propType {function} [transformItems] - Function to modify the items being displayed, e.g. for filtering or sorting them. Takes an items as parameter and expects it back in return
  * @themeKey ais-Breadcrumb - the root div of the widget

--- a/packages/react-instantsearch/src/widgets/Breadcrumb.js
+++ b/packages/react-instantsearch/src/widgets/Breadcrumb.js
@@ -45,8 +45,8 @@ import Breadcrumb from '../components/Breadcrumb';
  * All attributes passed to the `attributes` prop must be present in "attributes for faceting"
  * on the Algolia dashboard or configured as `attributesForFaceting` via a set settings call to the Algolia API.
  *
- * @propType {string} attributes - List of attributes to use to generate the hierarchy of the menu. See the example for the convention to follow
- * @propType {string} [separator='>'] -  Symbol used for separating hyperlinks
+ * @propType {array.<string>} attributes - List of attributes to use to generate the hierarchy of the menu. See the example for the convention to follow
+ * @propType {node} [separator='>'] -  Symbol used for separating hyperlinks
  * @propType {string} [rootURL=null] - The originating page (homepage)
  * @propType {function} [transformItems] - Function to modify the items being displayed, e.g. for filtering or sorting them. Takes an items as parameter and expects it back in return
  * @themeKey ais-Breadcrumb - the root div of the widget

--- a/packages/react-instantsearch/src/widgets/Highlight.js
+++ b/packages/react-instantsearch/src/widgets/Highlight.js
@@ -11,7 +11,7 @@ import Highlight from '../components/Highlight';
  * @propType {object} hit - hit object containing the highlighted attribute
  * @propType {string} [tagName='em'] - tag to be used for highlighted parts of the hit
  * @propType {string} [nonHighlightedTagName='span'] - tag to be used for the parts of the hit that are not highlighted
- * @propType {React.Element} [separator=',<space>'] - symbol used to separate the elements of the array in case the attributeName points to an array of strings.
+ * @propType {node} [separator=',<space>'] - symbol used to separate the elements of the array in case the attributeName points to an array of strings.
  * @themeKey ais-Highlight - root of the component
  * @themeKey ais-Highlight-highlighted - part of the text which is highlighted
  * @themeKey ais-Highlight-nonHighlighted - part of the text that is not highlighted

--- a/packages/react-instantsearch/src/widgets/SearchBox.js
+++ b/packages/react-instantsearch/src/widgets/SearchBox.js
@@ -11,9 +11,9 @@ import SearchBox from '../components/SearchBox';
  * @propType {function} [onSubmit] - Intercept submit event sent from the SearchBox form container.
  * @propType {function} [onReset] - Listen to `reset` event sent from the SearchBox form container.
  * @propType {function} [on*] - Listen to any events sent form the search input itself.
- * @propType {React.Element} [submitComponent] - Change the apparence of the default submit button (magnifying glass).
- * @propType {React.Element} [resetComponent] - Change the apparence of the default reset button (cross).
- * @propType {React.Element} [loadingIndicatorComponent] - Change the apparence of the default loading indicator (spinning circle).
+ * @propType {node} [submit] - Change the apparence of the default submit button (magnifying glass).
+ * @propType {node} [reset] - Change the apparence of the default reset button (cross).
+ * @propType {node} [loadingIndicator] - Change the apparence of the default loading indicator (spinning circle).
  * @propType {string} [defaultRefinement] - Provide default refinement value when component is mounted.
  * @propType {boolean} [showLoadingIndicator=false] - Display that the search is loading. This only happens after a certain amount of time to avoid a blinking effect. This timer can be configured with `stalledSearchDelay` props on <InstantSearch>. By default, the value is 200ms.
  * @themeKey ais-SearchBox - the root div of the widget

--- a/packages/react-instantsearch/src/widgets/Snippet.js
+++ b/packages/react-instantsearch/src/widgets/Snippet.js
@@ -14,7 +14,7 @@ import Snippet from '../components/Snippet';
  * @propType {object} hit - hit object containing the highlighted snippet attribute
  * @propType {string} [tagName='em'] - tag to be used for highlighted parts of the attribute
  * @propType {string} [nonHighlightedTagName='span'] - tag to be used for the parts of the hit that are not highlighted
- * @propType {React.Element} [separator=',<space>'] - symbol used to separate the elements of the array in case the attributeName points to an array of strings.
+ * @propType {node} [separator=',<space>'] - symbol used to separate the elements of the array in case the attributeName points to an array of strings.
  * @themeKey ais-Snippet - the root span of the widget
  * @themeKey ais-Snippet-highlighted - the highlighted text
  * @themeKey ais-Snippet-nonHighlighted - the normal text

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -74,7 +74,6 @@ stories
         <Panel header="Breadcrumb" footer="footer">
           <Breadcrumb
             attributes={['category', 'sub_category', 'sub_sub_category']}
-            separator=">"
           />
         </Panel>
         <hr />

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -54,8 +54,8 @@ stories
         linkedStoryGroup="SearchBox"
       >
         <SearchBox
-          submitComponent={<span>🔍</span>}
-          resetComponent={
+          submit={<span>🔍</span>}
+          reset={
             <svg viewBox="200 198 108 122">
               <path d="M200.8 220l45 46.7-20 47.4 31.7-34 50.4 39.3-34.3-52.6 30.2-68.3-49.7 51.7" />
             </svg>
@@ -74,7 +74,7 @@ stories
       <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox">
         <SearchBox
           showLoadingIndicator={true}
-          loadingIndicatorComponent={<span>✨</span>}
+          loadingIndicator={<span>✨</span>}
         />
       </WrapWithHits>
     ),


### PR DESCRIPTION
**Summary**

This PR rename some props from `xxxComponent` to `xxx` because they don't really accept a component. They just accept anything that can be render by React (aka: [`node`](https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes)). Only `Hits` & `InifiniteHits` accept a real component. The principal changes are on the `SearchBox`, otherwise it's mainly docs changes.

I also moved the props related to the rendering from `connectBreadcrumb` to the `Breadcrumb` component since they are unused in the connector.

**SearchBox**:

- `submitComponent` -> `submit`
- `resetComponent` -> `reset`
- `loadingIndicatorComponent` -> `loadingIndicator`
