### PR TITLE
refactor(connectRange): update default precision to 0

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -21,7 +21,7 @@ import createConnector from '../core/createConnector';
  * @propType {{min: number, max: number}} [defaultRefinement] - Default searchState of the widget containing the start and the end of the range.
  * @propType {number} [min] - Minimum value. When this isn't set, the minimum value will be automatically computed by Algolia using the data in the index.
  * @propType {number} [max] - Maximum value. When this isn't set, the maximum value will be automatically computed by Algolia using the data in the index.
- * @propType {number} [precision=2] - Number of digits after decimal point to use.
+ * @propType {number} [precision=0] - Number of digits after decimal point to use.
  * @providedPropType {function} refine - a function to select a range.
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
  * @providedPropType {string} currentRefinement - the refinement currently applied
@@ -186,7 +186,7 @@ export default createConnector({
   },
 
   defaultProps: {
-    precision: 2,
+    precision: 0,
   },
 
   getProvidedProps(props, searchState, searchResults) {

--- a/packages/react-instantsearch/src/widgets/RangeInput.js
+++ b/packages/react-instantsearch/src/widgets/RangeInput.js
@@ -12,7 +12,7 @@ import RangeInput from '../components/RangeInput';
  * @propType {{min: number, max: number}} [defaultRefinement] - Default state of the widget containing the start and the end of the range.
  * @propType {number} [min] - Minimum value. When this isn't set, the minimum value will be automatically computed by Algolia using the data in the index.
  * @propType {number} [max] - Maximum value. When this isn't set, the maximum value will be automatically computed by Algolia using the data in the index.
- * @propType {number} [precision=2] - Number of digits after decimal point to use.
+ * @propType {number} [precision=0] - Number of digits after decimal point to use.
  * @themeKey ais-RangeInput - the root div of the widget
  * @themeKey ais-RangeInput-form - the wrapping form
  * @themeKey ais-RangeInput-label - the label wrapping inputs

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -59,10 +59,10 @@ stories
     }
   )
   .addWithJSX(
-    'with precision of 0',
+    'with precision of 2',
     () => (
       <WrapWithHits linkedStoryGroup="RangeInput">
-        <RangeInput attributeName="price" precision={0} />
+        <RangeInput attributeName="price" precision={2} />
       </WrapWithHits>
     ),
     {


### PR DESCRIPTION
**Summary**

Fix #518 

Set the precision of `connectRange` to 0 by default instead of 2. It means that you don't have floating numbers by default in the `RangeInput` & `RangeSlider` (custom).