### PR TITLE
chore(theme): use jsDelivr by default and set alias

### DIFF
--- a/docgen/src/Getting_started.md
+++ b/docgen/src/Getting_started.md
@@ -105,7 +105,7 @@ We provide an Algolia theme that should be a good start.
 Include it in your webpage with this CDN link or copy paste the raw content:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/react-instantsearch-theme-algolia@4.0.0/style.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/react-instantsearch-theme-algolia@4.4.1">
 ```
 
 Read the [styling](guide/Styling_widgets.html) guide for more information.

--- a/docgen/src/guide/Styling_widgets.md
+++ b/docgen/src/guide/Styling_widgets.md
@@ -31,14 +31,14 @@ manually.
 
 ### Via CDN
 
-The theme is available on unpkg.com:
-- unminified: https://unpkg.com/react-instantsearch-theme-algolia@4.0.0/style.css
-- minified: https://unpkg.com/react-instantsearch-theme-algolia@4.0.0/style.min.css
+The theme is available on [jsDelivr](https://www.jsdelivr.com/):
+- minified: https://cdn.jsdelivr.net/npm/react-instantsearch-theme-algolia@4.4.1
+- unminified: https://cdn.jsdelivr.net/npm/react-instantsearch-theme-algolia@4.4.1/style.css
 
-You can either copy paste the content in your own app or use a direct link to unpkg.com:
+You can either copy paste the content in your own app or use a direct link to jsDelivr:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/react-instantsearch-theme-algolia@4.0.0/style.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/react-instantsearch-theme-algolia@4.4.1">
 ```
 
 ### Via npm, Webpack

--- a/packages/react-instantsearch-theme-algolia/package.json
+++ b/packages/react-instantsearch-theme-algolia/package.json
@@ -2,6 +2,7 @@
   "name": "react-instantsearch-theme-algolia",
   "description": "Algolia theme for React InstantSearch",
   "version": "4.4.1",
+  "jsdelivr": "style.min.css",
   "homepage": "https://community.algolia.com/react-instantsearch/",
   "repository": {
     "type": "git",

--- a/packages/react-instantsearch/examples/next-app/components/head.js
+++ b/packages/react-instantsearch/examples/next-app/components/head.js
@@ -33,7 +33,7 @@ export const Head = props => (
     <meta property="og:image:height" content="630" />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/react-instantsearch-theme-algolia@3.0.0/style.min.css"
+      href="https://cdn.jsdelivr.net/npm/react-instantsearch-theme-algolia@4.4.1"
     />
     <link rel="stylesheet" href="../static/instantsearch.css" />
   </NextHead>


### PR DESCRIPTION
We recommended unpkg at the begining, it was the only one serving other
files than JS from npm.

Now jsDelivr supports it by default since a long time, and we can inform
jsDelivr whats the default file to serve (to avoid style.min.css).

This will only work on the new release of the lib.

Also I updated the versions of the theme in the docs, might be worth
automating it or you'll have to do it next time too.