### PR TITLE
refactor: rename Toggle to ToggleRefinement

### DIFF
--- a/packages/react-instantsearch/connectors.js
+++ b/packages/react-instantsearch/connectors.js
@@ -45,7 +45,9 @@ export {
 } from './src/connectors/connectSearchBox.js';
 export { default as connectSortBy } from './src/connectors/connectSortBy.js';
 export { default as connectStats } from './src/connectors/connectStats.js';
-export { default as connectToggle } from './src/connectors/connectToggle.js';
+export {
+  default as connectToggleRefinement,
+} from './src/connectors/connectToggleRefinement.js';
 export {
   default as connectStateResults,
 } from './src/connectors/connectStateResults.js';

--- a/packages/react-instantsearch/dom.js
+++ b/packages/react-instantsearch/dom.js
@@ -36,6 +36,6 @@ export { default as ScrollTo } from './src/widgets/ScrollTo.js';
 export { default as SearchBox } from './src/widgets/SearchBox.js';
 export { default as SortBy } from './src/widgets/SortBy.js';
 export { default as Stats } from './src/widgets/Stats.js';
-export { default as Toggle } from './src/widgets/Toggle.js';
+export { default as ToggleRefinement } from './src/widgets/ToggleRefinement.js';
 export { default as Panel } from './src/widgets/Panel.js';
 export { default as Breadcrumb } from './src/widgets/Breadcrumb';

--- a/packages/react-instantsearch/src/components/ToggleRefinement.js
+++ b/packages/react-instantsearch/src/components/ToggleRefinement.js
@@ -1,43 +1,33 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import createClassNames from './createClassNames';
 
 const cx = createClassNames('ToggleRefinement');
 
-class ToggleRefinement extends Component {
-  static propTypes = {
-    currentRefinement: PropTypes.bool.isRequired,
-    refine: PropTypes.func.isRequired,
-    label: PropTypes.string.isRequired,
-    className: PropTypes.string,
-  };
+const ToggleRefinement = ({ currentRefinement, label, refine, className }) => (
+  <div className={classNames(cx(''), className)}>
+    <label className={cx('label')}>
+      <input
+        className={cx('checkbox')}
+        type="checkbox"
+        checked={currentRefinement}
+        onChange={event => refine(event.target.checked)}
+      />
+      <span className={cx('labelText')}>{label}</span>
+    </label>
+  </div>
+);
 
-  static defaultProps = {
-    className: '',
-  };
-
-  onChange = e => {
-    this.props.refine(e.target.checked);
-  };
-
-  render() {
-    const { currentRefinement, label, className } = this.props;
-
-    return (
-      <div className={classNames(cx(''), className)}>
-        <label className={cx('label')}>
-          <input
-            className={cx('checkbox')}
-            type="checkbox"
-            checked={currentRefinement}
-            onChange={this.onChange}
-          />
-          <span className={cx('labelText')}>{label}</span>
-        </label>
-      </div>
-    );
-  }
+ToggleRefinement.propTypes = {
+  currentRefinement: PropTypes.bool.isRequired,
+  label: PropTypes.string.isRequired,
+  refine: PropTypes.func.isRequired,
+  className: PropTypes.string,
 }
+
+ToggleRefinement.defaultProps = {
+  className: '',
+};
 
 export default ToggleRefinement;

--- a/packages/react-instantsearch/src/components/ToggleRefinement.js
+++ b/packages/react-instantsearch/src/components/ToggleRefinement.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import createClassNames from './createClassNames';
 
-const cx = createClassNames('Toggle');
+const cx = createClassNames('ToggleRefinement');
 
-class Toggle extends Component {
+class ToggleRefinement extends Component {
   static propTypes = {
     currentRefinement: PropTypes.bool.isRequired,
     refine: PropTypes.func.isRequired,
@@ -40,4 +40,4 @@ class Toggle extends Component {
   }
 }
 
-export default Toggle;
+export default ToggleRefinement;

--- a/packages/react-instantsearch/src/components/ToggleRefinement.test.js
+++ b/packages/react-instantsearch/src/components/ToggleRefinement.test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import ToggleRefinement from './ToggleRefinement';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('ToggleRefinement', () => {
+  const defaultProps = {
+    currentRefinement: true,
+    label: 'toggle the refinement',
+    refine: () => {},
+  };
+
+  it('expect to render with a positive currentRefinement', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = shallow(<ToggleRefinement {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to render with a negative currentRefinement', () => {
+    const props = {
+      ...defaultProps,
+      currentRefinement: false,
+    };
+
+    const wrapper = shallow(<ToggleRefinement {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to render with custom className', () => {
+    const props = {
+      ...defaultProps,
+      className: 'MyCustomToggleRefinement'
+    };
+
+    const wrapper = shallow(<ToggleRefinement {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to call refine onChange', () => {
+    const props = {
+      ...defaultProps,
+      refine: jest.fn(),
+    };
+
+    const wrapper = shallow(<ToggleRefinement {...props} />);
+
+    expect(props.refine).not.toHaveBeenCalled();
+
+    wrapper.find('input[type="checkbox"]').simulate('change', {
+      target: {
+        checked: false,
+      },
+    });
+
+    expect(props.refine).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/react-instantsearch/src/components/__snapshots__/ToggleRefinement.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/ToggleRefinement.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ToggleRefinement expect to render with a negative currentRefinement 1`] = `
+<div
+  className="ais-ToggleRefinement"
+>
+  <label
+    className="ais-ToggleRefinement-label"
+  >
+    <input
+      checked={false}
+      className="ais-ToggleRefinement-checkbox"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <span
+      className="ais-ToggleRefinement-labelText"
+    >
+      toggle the refinement
+    </span>
+  </label>
+</div>
+`;
+
+exports[`ToggleRefinement expect to render with a positive currentRefinement 1`] = `
+<div
+  className="ais-ToggleRefinement"
+>
+  <label
+    className="ais-ToggleRefinement-label"
+  >
+    <input
+      checked={true}
+      className="ais-ToggleRefinement-checkbox"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <span
+      className="ais-ToggleRefinement-labelText"
+    >
+      toggle the refinement
+    </span>
+  </label>
+</div>
+`;
+
+exports[`ToggleRefinement expect to render with custom className 1`] = `
+<div
+  className="ais-ToggleRefinement MyCustomToggleRefinement"
+>
+  <label
+    className="ais-ToggleRefinement-label"
+  >
+    <input
+      checked={true}
+      className="ais-ToggleRefinement-checkbox"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <span
+      className="ais-ToggleRefinement-labelText"
+    >
+      toggle the refinement
+    </span>
+  </label>
+</div>
+`;

--- a/packages/react-instantsearch/src/components/index.js
+++ b/packages/react-instantsearch/src/components/index.js
@@ -14,4 +14,4 @@ export { default as ScrollTo } from './ScrollTo.js';
 export { default as SearchBox } from './SearchBox.js';
 export { default as SortBy } from './SortBy.js';
 export { default as Stats } from './Stats.js';
-export { default as Toggle } from './Toggle.js';
+export { default as ToggleRefinement } from './ToggleRefinement.js';

--- a/packages/react-instantsearch/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch/src/connectors/connectToggleRefinement.js
@@ -41,9 +41,9 @@ function cleanUp(props, searchState, context) {
 }
 
 /**
- * connectToggle connector provides the logic to build a widget that will
+ * connectToggleRefinement connector provides the logic to build a widget that will
  *  provides an on/off filtering feature based on an attribute value. Note that if you provide an “off” option, it will be refined at initialization.
- * @name connectToggle
+ * @name connectToggleRefinement
  * @kind connector
  * @requirements To use this widget, you'll need an attribute to toggle on.
  *

--- a/packages/react-instantsearch/src/connectors/connectToggleRefinement.test.js
+++ b/packages/react-instantsearch/src/connectors/connectToggleRefinement.test.js
@@ -2,13 +2,14 @@
 
 import { SearchParameters } from 'algoliasearch-helper';
 
-import connect from './connectToggle';
+import connect from './connectToggleRefinement';
+
 jest.mock('../core/createConnector');
 
 let props;
 let params;
 
-describe('connectToggle', () => {
+describe('connectToggleRefinement', () => {
   describe('single index', () => {
     const context = { context: { ais: { mainTargetedIndex: 'index' } } };
     const getProvidedProps = connect.getProvidedProps.bind(context);
@@ -23,10 +24,7 @@ describe('connectToggle', () => {
       props = getProvidedProps({ attribute: 't' }, { toggle: { t: true } });
       expect(props).toEqual({ currentRefinement: true });
 
-      props = getProvidedProps(
-        { defaultRefinement: true, attribute: 't' },
-        {}
-      );
+      props = getProvidedProps({ defaultRefinement: true, attribute: 't' }, {});
       expect(props).toEqual({ currentRefinement: true });
     });
 

--- a/packages/react-instantsearch/src/widgets/ToggleRefinement.js
+++ b/packages/react-instantsearch/src/widgets/ToggleRefinement.js
@@ -1,9 +1,9 @@
-import connectToggle from '../connectors/connectToggle';
-import Toggle from '../components/Toggle';
+import connectToggleRefinement from '../connectors/connectToggleRefinement';
+import ToggleRefinement from '../components/ToggleRefinement';
 
 /**
- * The Toggle provides an on/off filtering feature based on an attribute value. Note that if you provide an “off” option, it will be refined at initialization.
- * @name Toggle
+ * The ToggleRefinement provides an on/off filtering feature based on an attribute value. Note that if you provide an “off” option, it will be refined at initialization.
+ * @name ToggleRefinement
  * @kind widget
  * @requirements To use this widget, you'll need an attribute to toggle on.
  *
@@ -14,17 +14,17 @@ import Toggle from '../components/Toggle';
  * @propType {string} label - Label for the toggle.
  * @propType {any} value - Value of the refinement to apply on `attribute` when checked.
  * @propType {boolean} [defaultRefinement=false] - Default state of the widget. Should the toggle be checked by default?
- * @themeKey ais-Toggle - the root div of the widget
- * @themeKey ais-Toggle-list - the list of toggles
- * @themeKey ais-Toggle-item - the toggle list item
- * @themeKey ais-Toggle-label - the label of each toggle item
- * @themeKey ais-Toggle-checkbox - the checkbox input of each toggle item
- * @themeKey ais-Toggle-labelText - the label text of each toggle item
- * @themeKey ais-Toggle-count - the count of items for each item
+ * @themeKey ais-ToggleRefinement - the root div of the widget
+ * @themeKey ais-ToggleRefinement-list - the list of toggles
+ * @themeKey ais-ToggleRefinement-item - the toggle list item
+ * @themeKey ais-ToggleRefinement-label - the label of each toggle item
+ * @themeKey ais-ToggleRefinement-checkbox - the checkbox input of each toggle item
+ * @themeKey ais-ToggleRefinement-labelText - the label text of each toggle item
+ * @themeKey ais-ToggleRefinement-count - the count of items for each item
  * @example
  * import React from 'react';
  *
- * import { Toggle, InstantSearch } from 'react-instantsearch/dom';
+ * import { ToggleRefinement, InstantSearch } from 'react-instantsearch/dom';
  *
  * export default function App() {
  *   return (
@@ -33,7 +33,7 @@ import Toggle from '../components/Toggle';
  *       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
  *       indexName="ikea"
  *     >
- *       <Toggle
+ *       <ToggleRefinement
  *         attribute="materials"
  *         label="Made with solid pine"
  *         value="Solid pine"
@@ -43,4 +43,4 @@ import Toggle from '../components/Toggle';
  * }
  */
 
-export default connectToggle(Toggle);
+export default connectToggleRefinement(ToggleRefinement);

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -6,7 +6,7 @@ import {
   HierarchicalMenu,
   Panel,
   RefinementList,
-  Toggle,
+  ToggleRefinement,
 } from '../packages/react-instantsearch/dom';
 import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
@@ -65,12 +65,12 @@ stories
   )
 
   .addWithJSX(
-    'with Toggle',
+    'with ToggleRefinement',
     () => (
       <WrapWithHits linkedStoryGroup="CurrentRefinements">
         <CurrentRefinements />
         <hr />
-        <Toggle
+        <ToggleRefinement
           attribute="materials"
           label="Made with solid pine"
           value={'Solid pine'}

--- a/stories/ToggleRefinement.stories.js
+++ b/stories/ToggleRefinement.stories.js
@@ -1,19 +1,19 @@
 import React from 'react';
 import { setAddon, storiesOf } from '@storybook/react';
-import { Panel, Toggle } from '../packages/react-instantsearch/dom';
+import { Panel, ToggleRefinement } from '../packages/react-instantsearch/dom';
 import { displayName, filterProps, WrapWithHits } from './util';
 import JSXAddon from 'storybook-addon-jsx';
 
 setAddon(JSXAddon);
 
-const stories = storiesOf('Toggle', module);
+const stories = storiesOf('ToggleRefinement', module);
 
 stories
   .addWithJSX(
     'default',
     () => (
-      <WrapWithHits linkedStoryGroup="Toggle">
-        <Toggle
+      <WrapWithHits linkedStoryGroup="ToggleRefinement">
+        <ToggleRefinement
           attribute="materials"
           label="Made with solid pine"
           value={'Solid pine'}
@@ -28,8 +28,8 @@ stories
   .addWithJSX(
     'checked by default',
     () => (
-      <WrapWithHits linkedStoryGroup="Toggle">
-        <Toggle
+      <WrapWithHits linkedStoryGroup="ToggleRefinement">
+        <ToggleRefinement
           attribute="materials"
           label="Made with solid pine"
           value="Solid pine"
@@ -45,9 +45,9 @@ stories
   .addWithJSX(
     'with Panel',
     () => (
-      <WrapWithHits linkedStoryGroup="Toggle">
-        <Panel header="Toggle" footer="Footer">
-          <Toggle
+      <WrapWithHits linkedStoryGroup="ToggleRefinement">
+        <Panel header="Toggle Refinement" footer="Footer">
+          <ToggleRefinement
             attribute="materials"
             label="Made with solid pine"
             value="Solid pine"


### PR DESCRIPTION
**Summary**

Finally close #519 

This PR rename the widget Toggle for ToggleRefinement. 
IS.css doesn't have migrate the widget yet but it's tracked.
