### PR TITLE
fix: pass maxFacetHits to SFFV

### DIFF
--- a/docgen/src/guide/Custom_connectors.md
+++ b/docgen/src/guide/Custom_connectors.md
@@ -203,7 +203,7 @@ const CoolWidget = createConnector({
 This method needs to be implemented if you want to have the ability to perform a search for facet values inside your widget.
 
 It takes in the current props of the higher-order component, the [search state](guide/Search_state.html) of all widgets, as well as all arguments passed to the `searchForFacetValues` props of stateful widgets, and returns an
-object of the shape: `{facetName: string, query: string}`
+object of the shape: `{facetName: string, query: string, maxFacetHits?: number}`. The default value for the `maxFacetHits` is the one set by [the API](https://www.algolia.com/doc/api-reference/api-parameters/maxFacetHits) which is `10`.
 
 ```jsx
 import {createConnector} from 'react-instantsearch';

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -179,7 +179,14 @@ export default createConnector({
   },
 
   searchForFacetValues(props, searchState, nextRefinement) {
-    return { facetName: props.attributeName, query: nextRefinement };
+    const { showMore, limitMin, limitMax } = props;
+    const maxFacetHits = showMore ? limitMax : limitMin;
+
+    return {
+      facetName: props.attributeName,
+      query: nextRefinement,
+      maxFacetHits,
+    };
   },
 
   cleanUp(props, searchState) {

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -37,6 +37,10 @@ function getValue(name, props, searchState, context) {
   return name === currentRefinement ? '' : name;
 }
 
+function getLimit({ showMore, limitMin, limitMax }) {
+  return showMore ? limitMax : limitMin;
+}
+
 function refine(props, searchState, nextRefinement, context) {
   const id = getId(props);
   const nextValue = { [id]: nextRefinement ? nextRefinement : '' };
@@ -97,8 +101,7 @@ export default createConnector({
     meta,
     searchForFacetValuesResults
   ) {
-    const { attributeName, showMore, limitMin, limitMax } = props;
-    const limit = showMore ? limitMax : limitMin;
+    const { attributeName } = props;
     const results = getResults(searchResults, this.context);
 
     const canRefine =
@@ -166,7 +169,7 @@ export default createConnector({
       ? props.transformItems(sortedItems)
       : sortedItems;
     return {
-      items: transformedItems.slice(0, limit),
+      items: transformedItems.slice(0, getLimit(props)),
       currentRefinement: getCurrentRefinement(props, searchState, this.context),
       isFromSearch,
       withSearchBox,
@@ -179,13 +182,10 @@ export default createConnector({
   },
 
   searchForFacetValues(props, searchState, nextRefinement) {
-    const { showMore, limitMin, limitMax } = props;
-    const maxFacetHits = showMore ? limitMax : limitMin;
-
     return {
       facetName: props.attributeName,
       query: nextRefinement,
-      maxFacetHits,
+      maxFacetHits: getLimit(props),
     };
   },
 
@@ -194,13 +194,12 @@ export default createConnector({
   },
 
   getSearchParameters(searchParameters, props, searchState) {
-    const { attributeName, showMore, limitMin, limitMax } = props;
-    const limit = showMore ? limitMax : limitMin;
+    const { attributeName } = props;
 
     searchParameters = searchParameters.setQueryParameters({
       maxValuesPerFacet: Math.max(
         searchParameters.maxValuesPerFacet || 0,
-        limit
+        getLimit(props)
       ),
     });
 

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -369,15 +369,31 @@ describe('connectMenu', () => {
       });
     });
 
-    it('calling searchForItems return the right searchForItems parameters', () => {
+    it('calling searchForItems return the right searchForItems parameters with limitMin', () => {
       const parameters = searchForFacetValues(
-        { attributeName: 'ok' },
+        { attributeName: 'ok', limitMin: 15, limitMax: 25, showMore: false },
         {},
         'yep'
       );
+
       expect(parameters).toEqual({
         facetName: 'ok',
         query: 'yep',
+        maxFacetHits: 15,
+      });
+    });
+
+    it('calling searchForItems return the right searchForItems parameters with limitMax', () => {
+      const parameters = searchForFacetValues(
+        { attributeName: 'ok', limitMin: 15, limitMax: 25, showMore: true },
+        {},
+        'yep'
+      );
+
+      expect(parameters).toEqual({
+        facetName: 'ok',
+        query: 'yep',
+        maxFacetHits: 25,
       });
     });
 

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -194,7 +194,14 @@ export default createConnector({
   },
 
   searchForFacetValues(props, searchState, nextRefinement) {
-    return { facetName: props.attributeName, query: nextRefinement };
+    const { showMore, limitMin, limitMax } = props;
+    const maxFacetHits = showMore ? limitMax : limitMin;
+
+    return {
+      facetName: props.attributeName,
+      query: nextRefinement,
+      maxFacetHits,
+    };
   },
 
   cleanUp(props, searchState) {

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -46,6 +46,10 @@ function getValue(name, props, searchState, context) {
   return nextRefinement;
 }
 
+function getLimit({ showMore, limitMin, limitMax }) {
+  return showMore ? limitMax : limitMin;
+}
+
 function refine(props, searchState, nextRefinement, context) {
   const id = getId(props);
   // Setting the value to an empty string ensures that it is persisted in
@@ -119,8 +123,7 @@ export default createConnector({
     metadata,
     searchForFacetValuesResults
   ) {
-    const { attributeName, showMore, limitMin, limitMax } = props;
-    const limit = showMore ? limitMax : limitMin;
+    const { attributeName } = props;
     const results = getResults(searchResults, this.context);
 
     const canRefine =
@@ -181,7 +184,7 @@ export default createConnector({
       : items;
 
     return {
-      items: transformedItems.slice(0, limit),
+      items: transformedItems.slice(0, getLimit(props)),
       currentRefinement: getCurrentRefinement(props, searchState, this.context),
       isFromSearch,
       withSearchBox,
@@ -194,13 +197,10 @@ export default createConnector({
   },
 
   searchForFacetValues(props, searchState, nextRefinement) {
-    const { showMore, limitMin, limitMax } = props;
-    const maxFacetHits = showMore ? limitMax : limitMin;
-
     return {
       facetName: props.attributeName,
       query: nextRefinement,
-      maxFacetHits,
+      maxFacetHits: getLimit(props),
     };
   },
 
@@ -209,8 +209,7 @@ export default createConnector({
   },
 
   getSearchParameters(searchParameters, props, searchState) {
-    const { attributeName, operator, showMore, limitMin, limitMax } = props;
-    const limit = showMore ? limitMax : limitMin;
+    const { attributeName, operator } = props;
 
     const addKey = operator === 'and' ? 'addFacet' : 'addDisjunctiveFacet';
     const addRefinementKey = `${addKey}Refinement`;
@@ -218,7 +217,7 @@ export default createConnector({
     searchParameters = searchParameters.setQueryParameters({
       maxValuesPerFacet: Math.max(
         searchParameters.maxValuesPerFacet || 0,
-        limit
+        getLimit(props)
       ),
     });
 

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -416,18 +416,35 @@ describe('connectRefinementList', () => {
       });
     });
 
-    it('calling searchForItems return the right searchForItems parameters', () => {
+    it('calling searchForItems return the right searchForItems parameters with limitMin', () => {
       const parameters = searchForFacetValues(
-        { attributeName: 'ok' },
+        { attributeName: 'ok', limitMin: 15, limitMax: 25, showMore: false },
         {},
         'yep'
       );
+
       expect(parameters).toEqual({
         facetName: 'ok',
         query: 'yep',
+        maxFacetHits: 15,
+      });
+    });
+
+    it('calling searchForItems return the right searchForItems parameters with limitMax', () => {
+      const parameters = searchForFacetValues(
+        { attributeName: 'ok', limitMin: 15, limitMax: 25, showMore: true },
+        {},
+        'yep'
+      );
+
+      expect(parameters).toEqual({
+        facetName: 'ok',
+        query: 'yep',
+        maxFacetHits: 25,
       });
     });
   });
+
   describe('multi index', () => {
     let context = {
       context: {

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -290,7 +290,7 @@ export default function createConnector(connectorDesc) {
         const searchForFacetValuesProps = hasSearchForFacetValues
           ? {
               searchForItems: this.searchForFacetValues,
-              searchForFacetValues: (facetName, query) => {
+              searchForFacetValues: (...args) => {
                 if (process.env.NODE_ENV === 'development') {
                   // eslint-disable-next-line no-console
                   console.warn(
@@ -298,7 +298,7 @@ export default function createConnector(connectorDesc) {
                       '`searchForItems`, this will break in the next major version.'
                   );
                 }
-                this.searchForFacetValues(facetName, query);
+                this.searchForFacetValues(...args);
               },
             }
           : {};

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -1,9 +1,8 @@
+import { omit, isEmpty } from 'lodash';
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
-
 import createWidgetsManager from './createWidgetsManager';
 import createStore from './createStore';
 import highlightTags from './highlightTags.js';
-import { omit, isEmpty } from 'lodash';
 
 /**
  * Creates a new instance of the InstantSearchManager which controls the widgets and
@@ -274,22 +273,22 @@ export default function createInstantSearchManager({
     search();
   }
 
-  function onSearchForFacetValues(nextSearchState) {
+  function onSearchForFacetValues({ facetName, query, maxFacetHits }) {
     store.setState({
       ...store.getState(),
       searchingForFacetValues: true,
     });
 
     helper
-      .searchForFacetValues(nextSearchState.facetName, nextSearchState.query)
+      .searchForFacetValues(facetName, query, maxFacetHits)
       .then(
         content => {
           store.setState({
             ...store.getState(),
             resultsFacetValues: {
               ...store.getState().resultsFacetValues,
-              [nextSearchState.facetName]: content.facetHits,
-              query: nextSearchState.query,
+              [facetName]: content.facetHits,
+              query,
             },
             searchingForFacetValues: false,
           });

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
@@ -171,7 +171,8 @@ describe('createInstantSearchManager', () => {
 
           expect(searchForFacetValues).toHaveBeenCalledWith(
             'facetName',
-            'query'
+            'query',
+            undefined
           );
 
           expect(store.searchingForFacetValues).toBe(false);
@@ -180,6 +181,56 @@ describe('createInstantSearchManager', () => {
             facetName: 'results',
             query: 'query',
           });
+        });
+      });
+
+      it('updates the store and searches with maxFacetHits', () => {
+        const searchForFacetValues = jest.fn(() =>
+          Promise.resolve({
+            facetHits: 'results',
+          })
+        );
+
+        jsHepler.mockImplementationOnce((...args) => {
+          const instance = jsHepler(...args);
+
+          instance.searchForFacetValues = searchForFacetValues;
+
+          return instance;
+        });
+
+        const ism = createInstantSearchManager({
+          indexName: 'index',
+          initialState: {},
+          searchParameters: {},
+          algoliaClient: client,
+        });
+
+        ism.onSearchForFacetValues({
+          facetName: 'facetName',
+          query: 'query',
+          maxFacetHits: 25,
+        });
+
+        expect(ism.store.getState().results).toBe(null);
+
+        jest.runAllTimers();
+
+        return Promise.resolve().then(() => {
+          const store = ism.store.getState();
+
+          expect(searchForFacetValues).toHaveBeenCalledWith(
+            'facetName',
+            'query',
+            25
+          );
+
+          expect(store.resultsFacetValues).toEqual({
+            facetName: 'results',
+            query: 'query',
+          });
+
+          expect(store.searchingForFacetValues).toBe(false);
         });
       });
     });

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
@@ -1,22 +1,22 @@
-/* eslint-env jest, jasmine */
-
-import createInstantSearchManager from './createInstantSearchManager';
-
 import algoliaClient from 'algoliasearch/lite';
+import jsHepler from 'algoliasearch-helper';
+import createInstantSearchManager from './createInstantSearchManager';
 
 jest.useFakeTimers();
 
-jest.mock('algoliasearch-helper/src/algoliasearch.helper.js', () => {
-  let count = 0;
-  const Helper = require.requireActual(
-    'algoliasearch-helper/src/algoliasearch.helper.js'
-  );
-  Helper.prototype._dispatchAlgoliaResponse = function(state) {
-    this.emit('result', { count: count++ }, state);
-  };
-  Helper.prototype.searchForFacetValues = () =>
-    Promise.resolve({ facetHits: 'results' });
-  return Helper;
+// We should avoid to rely on such mock, we do crazy stuff in order to have access
+// to the instance. An easier way is to pass the helper as an argument of the manager
+// with the default implementation as default value. With this change we can easily
+// pass a custom helper (mock or not).
+jest.mock('algoliasearch-helper', () => {
+  const actualJsHelper = require.requireActual('algoliasearch-helper');
+  const proxifyJsHelper = jest.fn((...args) => actualJsHelper(...args));
+
+  Object.keys(actualJsHelper).forEach(key => {
+    proxifyJsHelper[key] = actualJsHelper[key];
+  });
+
+  return proxifyJsHelper;
 });
 
 const client = algoliaClient('latency', '249078a3d4337a8231f1665ec5a44966');
@@ -41,6 +41,18 @@ describe('createInstantSearchManager', () => {
   describe('with correct result from algolia', () => {
     describe('on widget lifecycle', () => {
       it('updates the store and searches', () => {
+        const _dispatchAlgoliaResponse = jest.fn(function(state) {
+          this.emit('result', { value: 'results' }, state);
+        });
+
+        jsHepler.mockImplementationOnce((...args) => {
+          const instance = jsHepler(...args);
+
+          instance._dispatchAlgoliaResponse = _dispatchAlgoliaResponse;
+
+          return instance;
+        });
+
         const ism = createInstantSearchManager({
           indexName: 'index',
           initialState: {},
@@ -56,27 +68,42 @@ describe('createInstantSearchManager', () => {
 
         expect(ism.store.getState().results).toBe(null);
 
-        return Promise.resolve().then(() => {
-          jest.runAllTimers();
-
-          const store = ism.store.getState();
-          expect(store.results).toEqual({ count: 0 });
-          expect(store.error).toBe(null);
-
-          ism.widgetsManager.update();
-
-          return Promise.resolve().then(() => {
+        return Promise.resolve()
+          .then(() => {
             jest.runAllTimers();
 
-            const store1 = ism.store.getState();
-            expect(store1.results).toEqual({ count: 1 });
-            expect(store1.error).toBe(null);
+            const store = ism.store.getState();
+            expect(_dispatchAlgoliaResponse).toHaveBeenCalledTimes(1);
+            expect(store.results).toEqual({ value: 'results' });
+            expect(store.error).toBe(null);
+
+            ism.widgetsManager.update();
+          })
+          .then(() => {
+            jest.runAllTimers();
+
+            const store = ism.store.getState();
+            expect(_dispatchAlgoliaResponse).toHaveBeenCalledTimes(2);
+            expect(store.results).toEqual({ value: 'results' });
+            expect(store.error).toBe(null);
           });
-        });
       });
     });
+
     describe('on external updates', () => {
       it('updates the store and searches', () => {
+        const _dispatchAlgoliaResponse = jest.fn(function(state) {
+          this.emit('result', { value: 'results' }, state);
+        });
+
+        jsHepler.mockImplementationOnce((...args) => {
+          const instance = jsHepler(...args);
+
+          instance._dispatchAlgoliaResponse = _dispatchAlgoliaResponse;
+
+          return instance;
+        });
+
         const ism = createInstantSearchManager({
           indexName: 'index',
           initialState: {},
@@ -88,15 +115,44 @@ describe('createInstantSearchManager', () => {
 
         expect(ism.store.getState().results).toBe(null);
 
-        jest.runAllTimers();
+        return Promise.resolve()
+          .then(() => {
+            jest.runAllTimers();
 
-        const store = ism.store.getState();
-        expect(store.results).toEqual({ count: 2 });
-        expect(store.error).toBe(null);
+            const store = ism.store.getState();
+            expect(_dispatchAlgoliaResponse).toHaveBeenCalledTimes(1);
+            expect(store.results).toEqual({ value: 'results' });
+            expect(store.error).toBe(null);
+
+            ism.widgetsManager.update();
+          })
+          .then(() => {
+            jest.runAllTimers();
+
+            const store = ism.store.getState();
+            expect(_dispatchAlgoliaResponse).toHaveBeenCalledTimes(2);
+            expect(store.results).toEqual({ value: 'results' });
+            expect(store.error).toBe(null);
+          });
       });
     });
+
     describe('on search for facet values', () => {
       it('updates the store and searches', () => {
+        const searchForFacetValues = jest.fn(() =>
+          Promise.resolve({
+            facetHits: 'results',
+          })
+        );
+
+        jsHepler.mockImplementationOnce((...args) => {
+          const instance = jsHepler(...args);
+
+          instance.searchForFacetValues = searchForFacetValues;
+
+          return instance;
+        });
+
         const ism = createInstantSearchManager({
           indexName: 'index',
           initialState: {},
@@ -112,11 +168,18 @@ describe('createInstantSearchManager', () => {
 
         return Promise.resolve().then(() => {
           const store = ism.store.getState();
+
+          expect(searchForFacetValues).toHaveBeenCalledWith(
+            'facetName',
+            'query'
+          );
+
+          expect(store.searchingForFacetValues).toBe(false);
+
           expect(store.resultsFacetValues).toEqual({
             facetName: 'results',
             query: 'query',
           });
-          expect(store.searchingForFacetValues).toBe(false);
         });
       });
     });


### PR DESCRIPTION
**Summary**

Fix #707 

Inside the `RefinementList` & `Menu` we can search through the list of items. On the first render the `maxValuesPerFacet` is correctly set on the `SearchParameters`. But when you trigger a search from the `SearchBox` the limit provided to the widget is ignored and only the default one is applied (which is `10`). It can produce unexpected results like the one linked inside the issue. The `limitMax` is set to `30` but when you search for some facets since the latter is ignored you only have 10 results which is equal to the `limitMin` and so the button is disabled.

In the following example I search for `<space>` so all the results are retrieve until the limit (`15`).

**Before:**

![before](https://user-images.githubusercontent.com/6513513/35040851-fcd38d9e-fb82-11e7-991c-b358e1f0cdf8.gif)

**After:**

![after](https://user-images.githubusercontent.com/6513513/35040856-00eec8c6-fb83-11e7-9ed4-f4a5bd24e0d1.gif)