### PR TITLE
Use substr instead of startsWith

### DIFF
--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -94,7 +94,7 @@ export default function createConnector(connectorDesc) {
 
           if (
             onlyGetProvidedPropsUsage &&
-            !connectorDesc.displayName.startsWith('Algolia')
+            connectorDesc.displayName.substr(0, 7) !== 'Algolia'
           ) {
             // eslint-disable-next-line no-console
             console.warn(


### PR DESCRIPTION
Necessary for IE 11 compatibility and avoids having to use a polyfill. Fixes #869 