### PR TITLE
chore: remove deprecation

### DIFF
--- a/docgen/src/guide/Migration_guide_v5.md
+++ b/docgen/src/guide/Migration_guide_v5.md
@@ -76,16 +76,16 @@ Complete list of changes:
 
 Some of the props has been renamed for a better consistency across the library. See below the list of all of them:
 
-* `attributeName` &rarr; `attribute` (multiple widgets)
-* `limitMin` &rarr; `limit` (HierarchicalMenu, Menu, RefinementList)
-* `limitMax` &rarr; `showMoreLimit` (HierarchicalMenu, Menu, RefinementList)
-* `maxPages` &rarr; `totalPages` (Pagination)
-* `pagesPadding` &rarr; `padding` (Pagination)
-* `title` &rarr; `header` (Panel)
-* `submitComponent` &rarr; `submit` (SearchBox)
-* `resetComponent` &rarr; `reset` (SearchBox)
-* `loadingIndicatorComponent` &rarr; `loadingIndicator` (SearchBox)
-* `withSearchBox` &rarr; `searchable` (Menu, RefinementList)
+* `attributeName` → `attribute` (multiple widgets)
+* `limitMin` → `limit` (HierarchicalMenu, Menu, RefinementList)
+* `limitMax` → `showMoreLimit` (HierarchicalMenu, Menu, RefinementList)
+* `maxPages` → `totalPages` (Pagination)
+* `pagesPadding` → `padding` (Pagination)
+* `title` → `header` (Panel)
+* `submitComponent` → `submit` (SearchBox)
+* `resetComponent` → `reset` (SearchBox)
+* `loadingIndicatorComponent` → `loadingIndicator` (SearchBox)
+* `withSearchBox` → `searchable` (Menu, RefinementList)
 
 Please refer to [Widgets changes](guide/Migration_guide_v5.html#widgets-changes) & [Connectors changes](guide/Migration_guide_v5.html#connectors-changes) sections for more detail informations.
 
@@ -93,9 +93,9 @@ Please refer to [Widgets changes](guide/Migration_guide_v5.html#widgets-changes)
 
 We introduced a couple of months ago [a warning](https://github.com/algolia/react-instantsearch/commit/59d1cc41f0dc739c658c413a4310d72e64b6832e) about the usage of `searchForFacetValues` in favour of `searchForItems` & `withSearchBox` (now renamed `searchable`). This warning has been removed and so is the legacy API.Update your code if it's not already the case. See below for the list of changes:
 
-* `searchForFacetValues` &rarr; `withSearchBox` &rarr; `searchable` (RefinementList, Menu)
-* `searchForFacetValues` &rarr; `searchForItems` (createConnector, connectRefinementList, connectMenu)
-* `searchParameters` &rarr; **removed** on `<InstantSearch>` in favour of `<Configure />`
+* `searchForFacetValues` → `withSearchBox` → `searchable` (RefinementList, Menu)
+* `searchForFacetValues` → `searchForItems` (createConnector, connectRefinementList, connectMenu)
+* `searchParameters` → **removed** on `<InstantSearch>` in favour of `<Configure />`
 
 Please refer to [Widgets changes](guide/Migration_guide_v5.html#widgets-changes) & [Connectors changes](guide/Migration_guide_v5.html#connectors-changes) sections for more detail informations.
 
@@ -156,7 +156,7 @@ No change.
 
 #### Behaviour
 
-* `searchParameters` &rarr; **removed** in favour of `<Configure />`
+* `searchParameters` → **removed** in favour of `<Configure />`
 
 #### CSS classes equivalency table
 
@@ -235,8 +235,8 @@ See [the widget](widgets/HierarchicalMenu.html) documentation page.
 
 #### Naming
 
-* `limitMin` &rarr; `limit`
-* `limitMax` &rarr; `showMoreLimit`
+* `limitMin` → `limit`
+* `limitMax` → `showMoreLimit`
 
 #### Behaviour
 
@@ -265,7 +265,7 @@ See [the widget](widgets/Highlight.html) documentation page.
 
 #### Naming
 
-* `attributeName` &rarr; `attribute`
+* `attributeName` → `attribute`
 
 #### Behaviour
 
@@ -339,10 +339,10 @@ See [the widget](widgets/Menu.html) documentation page.
 
 #### Naming
 
-* `attributeName` &rarr; `attribute`
-* `limitMin` &rarr; `limit`
-* `limitMax` &rarr; `showMoreLimit`
-* `withSearchBox` &rarr; `searchable`
+* `attributeName` → `attribute`
+* `limitMin` → `limit`
+* `limitMax` → `showMoreLimit`
+* `withSearchBox` → `searchable`
 
 #### Behaviour
 
@@ -371,7 +371,7 @@ See [the widget](widgets/MenuSelect.html) documentation page.
 
 #### Naming
 
-* `attributeName` &rarr; `attribute`
+* `attributeName` → `attribute`
 
 #### Behaviour
 
@@ -392,7 +392,7 @@ See [the widget](widgets/NumericMenu.html) documentation page.
 
 Renamed to **NumericMenu**.
 
-* `attributeName` &rarr; `attribute`
+* `attributeName` → `attribute`
 
 #### Behaviour
 
@@ -420,8 +420,8 @@ See [the widget](widgets/Pagination.html) documentation page.
 
 #### Naming
 
-* `maxPages` &rarr; `totalPages`
-* `pagesPadding` &rarr; `padding`
+* `maxPages` → `totalPages`
+* `pagesPadding` → `padding`
 
 #### Behaviour
 
@@ -449,7 +449,7 @@ See [the widget](widgets/Panel.html) documentation page.
 
 #### Naming
 
-* `title` &rarr; `header`
+* `title` → `header`
 
 #### Behaviour
 
@@ -489,7 +489,7 @@ See [the widget](widgets/RangeInput.html) documentation page.
 
 #### Naming
 
-* `attributeName` &rarr; `attribute`
+* `attributeName` → `attribute`
 
 #### Behaviour
 
@@ -514,10 +514,10 @@ See [the widget](widgets/RefinementList.html) documentation page.
 
 #### Naming
 
-* `attributeName` &rarr; `attribute`
-* `limitMin` &rarr; `limit`
-* `limitMax` &rarr; `showMoreLimit`
-* `withSearchBox` &rarr; `searchable`
+* `attributeName` → `attribute`
+* `limitMin` → `limit`
+* `limitMax` → `showMoreLimit`
+* `withSearchBox` → `searchable`
 
 #### Behaviour
 
@@ -550,9 +550,9 @@ See [the widget](widgets/SearchBox.html) documentation page.
 
 #### Naming
 
-* `submitComponent` &rarr; `submit`
-* `resetComponent` &rarr; `reset`
-* `loadingIndicatorComponent` &rarr; `loadingIndicator`
+* `submitComponent` → `submit`
+* `resetComponent` → `reset`
+* `loadingIndicatorComponent` → `loadingIndicator`
 
 #### Behaviour
 
@@ -595,7 +595,7 @@ See [the widget](widgets/RatingMenu.html) documentation page.
 
 Renamed to **RatingMenu**.
 
-* `attributeName` &rarr; `attribute`
+* `attributeName` → `attribute`
 
 #### Behaviour
 
@@ -648,7 +648,7 @@ See [the widget](widgets/ToggleRefinement.html) documentation page.
 
 Renamed to **ToggleRefinement**.
 
-* `attributeName` &rarr; `attribute`
+* `attributeName` → `attribute`
 
 #### Behaviour
 
@@ -670,7 +670,7 @@ See [the connector](guide/Custom_connectors.html) documentation page.
 
 #### Naming
 
-* `searchForFacetValues` &rarr; `searchForItems`
+* `searchForFacetValues` → `searchForItems`
 
 #### Behaviour
 
@@ -694,8 +694,8 @@ See [the connector](connectors/connectHierarchicalMenu.html) documentation page.
 
 #### Naming
 
-* `limitMin` &rarr; `limit`
-* `limitMax` &rarr; `showMoreLimit`
+* `limitMin` → `limit`
+* `limitMax` → `showMoreLimit`
 
 #### Behaviour
 
@@ -719,11 +719,11 @@ See [the connector](connectors/connectMenu.html) documentation page.
 
 #### Naming
 
-* `attributeName` &rarr; `attribute`
-* `limitMin` &rarr; `limit`
-* `limitMax` &rarr; `showMoreLimit`
-* `withSearchBox` &rarr; `searchable`
-* `searchForFacetValues` &rarr; `searchForItems`
+* `attributeName` → `attribute`
+* `limitMin` → `limit`
+* `limitMax` → `showMoreLimit`
+* `withSearchBox` → `searchable`
+* `searchForFacetValues` → `searchForItems`
 
 #### Behaviour
 
@@ -737,7 +737,7 @@ See [the connector](connectors/connectNumericMenu.html) documentation page.
 
 Renamed to **connectNumericMenu**.
 
-* `attributeName` &rarr; `attribute`
+* `attributeName` → `attribute`
 
 #### Behaviour
 
@@ -749,8 +749,8 @@ See [the connector](connectors/connectPagination.html) documentation page.
 
 #### Naming
 
-* `maxPages` &rarr; `totalPages`
-* `pagesPadding` &rarr; `padding`
+* `maxPages` → `totalPages`
+* `pagesPadding` → `padding`
 
 #### Behaviour
 
@@ -762,7 +762,7 @@ See [the connector](connectors/connectRange.html) documentation page.
 
 #### Naming
 
-* `attributeName` &rarr; `attribute`
+* `attributeName` → `attribute`
 
 #### Behaviour
 
@@ -774,11 +774,11 @@ See [the connector](connectors/connectRefinementList.html) documentation page.
 
 #### Naming
 
-* `attributeName` &rarr; `attribute`
-* `limitMin` &rarr; `limit`
-* `limitMax` &rarr; `showMoreLimit`
-* `withSearchBox` &rarr; `searchable`
-* `searchForFacetValues` &rarr; `searchForItems`
+* `attributeName` → `attribute`
+* `limitMin` → `limit`
+* `limitMax` → `showMoreLimit`
+* `withSearchBox` → `searchable`
+* `searchForFacetValues` → `searchForItems`
 
 #### Behaviour
 
@@ -792,7 +792,7 @@ See [the connector](connectors/connectToggleRefinement.html) documentation page.
 
 Renamed to **connectToggleRefinement**.
 
-* `attributeName` &rarr; `attribute`
+* `attributeName` → `attribute`
 
 #### Behaviour
 

--- a/docgen/src/guide/Migration_guide_v5.md
+++ b/docgen/src/guide/Migration_guide_v5.md
@@ -21,6 +21,7 @@ This guide will provide step-by-step migration information for each widget & con
   * [Updating styles](guide/Migration_guide_v5.html#updating-styles)
   * [Adding className](guide/Migration_guide_v5.html#adding-classname)
 * [Widgets changes](guide/Migration_guide_v5.html#widgets-changes)
+  * [InstantSearch](guide/Migration_guide_v5.html#instantsearch)
   * [Breadcrumb](guide/Migration_guide_v5.html#breadcrumb)
   * [ClearAll](guide/Migration_guide_v5.html#clearall)
   * [CurrentRefinements](guide/Migration_guide_v5.html#currentrefinements)
@@ -94,6 +95,7 @@ We introduced a couple of months ago [a warning](https://github.com/algolia/reac
 
 * `searchForFacetValues` &rarr; `withSearchBox` &rarr; `searchable` (RefinementList, Menu)
 * `searchForFacetValues` &rarr; `searchForItems` (createConnector, connectRefinementList, connectMenu)
+* `searchParameters` &rarr; **removed** on `<InstantSearch>` in favour of `<Configure />`
 
 Please refer to [Widgets changes](guide/Migration_guide_v5.html#widgets-changes) & [Connectors changes](guide/Migration_guide_v5.html#connectors-changes) sections for more detail informations.
 
@@ -143,6 +145,22 @@ All the built-in widgets now accept a prop `className` that will be forwarded to
 ## Widgets changes
 
 **Note**: the equivalency table only shows the replacement classes for existing classes. New CSS classes are also available. For more details, please refer to the [Widgets guide](widgets).
+
+### InstantSearch
+
+See [the widget](widgets/<InstantSearch>.html) documentation page.
+
+#### Naming
+
+No change.
+
+#### Behaviour
+
+* `searchParameters` &rarr; **removed** in favour of `<Configure />`
+
+#### CSS classes equivalency table
+
+No change.
 
 ### Breadcrumb
 

--- a/docgen/src/guide/Migration_guide_v5.md
+++ b/docgen/src/guide/Migration_guide_v5.md
@@ -90,7 +90,7 @@ Please refer to [Widgets changes](guide/Migration_guide_v5.html#widgets-changes)
 
 ### Removing deprecation
 
-We introduce a couple of months ago [a warning](https://github.com/algolia/react-instantsearch/commit/59d1cc41f0dc739c658c413a4310d72e64b6832e) about the usage of `searchForFacetValues` in favour of `searchForItems` & `withSearchBox` (now renamed `searchable`). This warning has been removed and so the legacy API, so please update your code if it's not already the case. See below the list of changes:
+We introduced a couple of months ago [a warning](https://github.com/algolia/react-instantsearch/commit/59d1cc41f0dc739c658c413a4310d72e64b6832e) about the usage of `searchForFacetValues` in favour of `searchForItems` & `withSearchBox` (now renamed `searchable`). This warning has been removed and so is the legacy API.Update your code if it's not already the case. See below for the list of changes:
 
 * `searchForFacetValues` &rarr; `withSearchBox` &rarr; `searchable` (RefinementList, Menu)
 * `searchForFacetValues` &rarr; `searchForItems` (createConnector, connectRefinementList, connectMenu)

--- a/docgen/src/guide/Migration_guide_v5.md
+++ b/docgen/src/guide/Migration_guide_v5.md
@@ -17,6 +17,7 @@ This guide will provide step-by-step migration information for each widget & con
 * [Migration steps](guide/Migration_guide_v5.html#migration-steps)
   * [Updating widget & connector names](guide/Migration_guide_v5.html#updating-widget-connector-names)
   * [Updating prop names](guide/Migration_guide_v5.html#updating-prop-names)
+  * [Removing deprecation](guide/Migration_guide_v5.html#removing-deprecation)
   * [Updating styles](guide/Migration_guide_v5.html#updating-styles)
   * [Adding className](guide/Migration_guide_v5.html#adding-classname)
 * [Widgets changes](guide/Migration_guide_v5.html#widgets-changes)
@@ -42,6 +43,7 @@ This guide will provide step-by-step migration information for each widget & con
   * [Stats](guide/Migration_guide_v5.html#stats)
   * [Toggle](guide/Migration_guide_v5.html#toggle)
 * [Connectors changes](guide/Migration_guide_v5.html#connectors-changes)
+  * [createConnector](guide/Migration_guide_v5.html#createconnector)
   * [connectCurrentRefinements](guide/Migration_guide_v5.html#connectcurrentrefinements)
   * [connectHierarchicalMenu](guide/Migration_guide_v5.html#connecthierarchicalmenu)
   * [connectHighlight](guide/Migration_guide_v5.html#connecthighlight)
@@ -83,6 +85,15 @@ Some of the props has been renamed for a better consistency across the library. 
 * `resetComponent` &rarr; `reset` (SearchBox)
 * `loadingIndicatorComponent` &rarr; `loadingIndicator` (SearchBox)
 * `withSearchBox` &rarr; `searchable` (Menu, RefinementList)
+
+Please refer to [Widgets changes](guide/Migration_guide_v5.html#widgets-changes) & [Connectors changes](guide/Migration_guide_v5.html#connectors-changes) sections for more detail informations.
+
+### Removing deprecation
+
+We introduce a couple of months ago [a warning](https://github.com/algolia/react-instantsearch/commit/59d1cc41f0dc739c658c413a4310d72e64b6832e) about the usage of `searchForFacetValues` in favour of `searchForItems` & `withSearchBox` (now renamed `searchable`). This warning has been removed and so the legacy API, so please update your code if it's not already the case. See below the list of changes:
+
+* `searchForFacetValues` &rarr; `withSearchBox` &rarr; `searchable` (RefinementList, Menu)
+* `searchForFacetValues` &rarr; `searchForItems` (createConnector, connectRefinementList, connectMenu)
 
 Please refer to [Widgets changes](guide/Migration_guide_v5.html#widgets-changes) & [Connectors changes](guide/Migration_guide_v5.html#connectors-changes) sections for more detail informations.
 
@@ -635,6 +646,18 @@ No change.
 
 ## Connectors changes
 
+### createConnector
+
+See [the connector](guide/Custom_connectors.html) documentation page.
+
+#### Naming
+
+* `searchForFacetValues` &rarr; `searchForItems`
+
+#### Behaviour
+
+No change.
+
 ### connectCurrentRefinements
 
 See [the connector](connectors/connectCurrentRefinements.html) documentation page.
@@ -682,6 +705,7 @@ See [the connector](connectors/connectMenu.html) documentation page.
 * `limitMin` &rarr; `limit`
 * `limitMax` &rarr; `showMoreLimit`
 * `withSearchBox` &rarr; `searchable`
+* `searchForFacetValues` &rarr; `searchForItems`
 
 #### Behaviour
 
@@ -736,6 +760,7 @@ See [the connector](connectors/connectRefinementList.html) documentation page.
 * `limitMin` &rarr; `limit`
 * `limitMax` &rarr; `showMoreLimit`
 * `withSearchBox` &rarr; `searchable`
+* `searchForFacetValues` &rarr; `searchForItems`
 
 #### Behaviour
 

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -81,7 +81,6 @@ export default createConnector({
     defaultRefinement: PropTypes.string,
     transformItems: PropTypes.func,
     searchable: PropTypes.bool,
-    searchForFacetValues: PropTypes.bool, // @deprecated
   },
 
   defaultProps: {
@@ -97,7 +96,7 @@ export default createConnector({
     meta,
     searchForFacetValuesResults
   ) {
-    const { attribute, showMore, limit, showMoreLimit } = props;
+    const { attribute, showMore, limit, showMoreLimit, searchable } = props;
     const itemsLimit = showMore ? showMoreLimit : limit;
     const results = getResults(searchResults, this.context);
 
@@ -109,16 +108,6 @@ export default createConnector({
         searchForFacetValuesResults[attribute] &&
         searchForFacetValuesResults.query !== ''
     );
-
-    const searchable = props.searchable || props.searchForFacetValues;
-
-    if (process.env.NODE_ENV === 'development' && props.searchForFacetValues) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'react-instantsearch: `searchForFacetValues` has been renamed to' +
-          '`searchable`, this will break in the next major version.'
-      );
-    }
 
     // Search For Facet Values is not available with derived helper (used for multi index search)
     if (props.searchable && this.context.multiIndexContext) {

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -413,28 +413,6 @@ describe('connectMenu', () => {
           count: 20,
         },
       ]);
-
-      // searchForFacetValues is @deprecated. This test should be removed when searchForFacetValues is removed
-      props = getProvidedProps(
-        { attribute: 'ok', searchForFacetValues: true },
-        {},
-        { results }
-      );
-
-      expect(props.items).toEqual([
-        {
-          value: 'oy',
-          label: 'oy',
-          isRefined: true,
-          count: 10,
-        },
-        {
-          value: 'wat',
-          label: 'wat',
-          isRefined: false,
-          count: 20,
-        },
-      ]);
     });
   });
   describe('multi index', () => {

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -101,7 +101,6 @@ export default createConnector({
       PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     ),
     searchable: PropTypes.bool,
-    searchForFacetValues: PropTypes.bool, // @deprecated
     transformItems: PropTypes.func,
   },
 
@@ -119,7 +118,7 @@ export default createConnector({
     metadata,
     searchForFacetValuesResults
   ) {
-    const { attribute, showMore, limit, showMoreLimit } = props;
+    const { attribute, showMore, limit, showMoreLimit, searchable } = props;
     const itemsLimit = showMore ? showMoreLimit : limit;
     const results = getResults(searchResults, this.context);
 
@@ -131,14 +130,7 @@ export default createConnector({
         searchForFacetValuesResults[attribute] &&
         searchForFacetValuesResults.query !== ''
     );
-    const searchable = props.searchable || props.searchForFacetValues;
-    if (process.env.NODE_ENV === 'development' && props.searchForFacetValues) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'react-instantsearch: `searchForFacetValues` has been renamed to' +
-          '`searchable`, this will break in the next major version.'
-      );
-    }
+
     // Search For Facet Values is not available with derived helper (used for multi index search)
     if (props.searchable && this.context.multiIndexContext) {
       throw new Error(

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -80,20 +80,6 @@ describe('connectRefinementList', () => {
         searchable: true,
       });
 
-      // searchForFacetValues is @deprecated. This test should be removed when searchForFacetValues is removed
-      props = getProvidedProps(
-        { attribute: 'ok', searchForFacetValues: true },
-        {},
-        { results }
-      );
-      expect(props).toEqual({
-        items: [],
-        currentRefinement: [],
-        isFromSearch: false,
-        canRefine: false,
-        searchable: true,
-      });
-
       results.getFacetValues.mockClear();
       results.getFacetValues.mockImplementation(() => [
         {

--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -60,7 +60,6 @@ class InstantSearch extends Component {
 
     this.aisManager = createInstantSearchManager({
       indexName: props.indexName,
-      searchParameters: props.searchParameters,
       algoliaClient: props.algoliaClient,
       initialState,
       resultsState: props.resultsState,
@@ -180,8 +179,6 @@ InstantSearch.propTypes = {
   indexName: PropTypes.string.isRequired,
 
   algoliaClient: PropTypes.object.isRequired,
-
-  searchParameters: PropTypes.object,
 
   createURL: PropTypes.func,
 

--- a/packages/react-instantsearch/src/core/InstantSearch.test.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.test.js
@@ -21,7 +21,6 @@ const DEFAULT_PROPS = {
   apiKey: 'bar',
   indexName: 'foobar',
   algoliaClient: {},
-  searchParameters: {},
   root: {
     Root: 'div',
   },
@@ -119,7 +118,6 @@ describe('InstantSearch', () => {
     expect(createInstantSearchManager.mock.calls[0][0]).toEqual({
       indexName: DEFAULT_PROPS.indexName,
       initialState: {},
-      searchParameters: {},
       algoliaClient: {},
       stalledSearchDelay: 200,
     });

--- a/packages/react-instantsearch/src/core/__snapshots__/createInstantSearch.test.js.snap
+++ b/packages/react-instantsearch/src/core/__snapshots__/createInstantSearch.test.js.snap
@@ -17,7 +17,6 @@ Object {
       },
     },
   },
-  "searchParameters": undefined,
   "searchState": undefined,
   "stalledSearchDelay": 200,
 }
@@ -35,7 +34,6 @@ Object {
   "root": Object {
     "Root": "div",
   },
-  "searchParameters": undefined,
   "searchState": undefined,
   "stalledSearchDelay": 200,
 }

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -287,20 +287,9 @@ export default function createConnector(connectorDesc) {
         const refineProps = hasRefine
           ? { refine: this.refine, createURL: this.createURL }
           : {};
+
         const searchForFacetValuesProps = hasSearchForFacetValues
-          ? {
-              searchForItems: this.searchForFacetValues,
-              searchForFacetValues: (facetName, query) => {
-                if (process.env.NODE_ENV === 'development') {
-                  // eslint-disable-next-line no-console
-                  console.warn(
-                    'react-instantsearch: `searchForFacetValues` has been renamed to' +
-                      '`searchForItems`, this will break in the next major version.'
-                  );
-                }
-                this.searchForFacetValues(facetName, query);
-              },
-            }
+          ? { searchForItems: this.searchForFacetValues }
           : {};
 
         return (

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -714,20 +714,13 @@ describe('createConnector', () => {
       const passedProps = wrapper.find(Dummy).props();
       const facetName = 'facetName';
       const query = 'query';
+
       passedProps.searchForItems(facetName, query);
       expect(searchForFacetValues.mock.calls[0][0]).toEqual(props);
       expect(searchForFacetValues.mock.calls[0][1]).toBe(widgets);
       expect(searchForFacetValues.mock.calls[0][2]).toBe(facetName);
       expect(searchForFacetValues.mock.calls[0][3]).toBe(query);
       expect(onSearchForFacetValues.mock.calls[0][0]).toBe(searchState);
-
-      // searchForFacetValues is @deprecated. This test should be removed when searchForFacetValues is removed
-      passedProps.searchForFacetValues(facetName, query);
-      expect(searchForFacetValues.mock.calls[1][0]).toEqual(props);
-      expect(searchForFacetValues.mock.calls[1][1]).toBe(widgets);
-      expect(searchForFacetValues.mock.calls[1][2]).toBe(facetName);
-      expect(searchForFacetValues.mock.calls[1][3]).toBe(query);
-      expect(onSearchForFacetValues.mock.calls[1][0]).toBe(searchState);
     });
   });
 });

--- a/packages/react-instantsearch/src/core/createInstantSearch.js
+++ b/packages/react-instantsearch/src/core/createInstantSearch.js
@@ -21,7 +21,6 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
         PropTypes.node,
       ]),
       indexName: PropTypes.string.isRequired,
-      searchParameters: PropTypes.object,
       createURL: PropTypes.func,
       searchState: PropTypes.object,
       refresh: PropTypes.bool.isRequired,
@@ -68,7 +67,6 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
         <InstantSearch
           createURL={this.props.createURL}
           indexName={this.props.indexName}
-          searchParameters={this.props.searchParameters}
           searchState={this.props.searchState}
           onSearchStateChange={this.props.onSearchStateChange}
           onSearchParameters={this.props.onSearchParameters}

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -18,12 +18,10 @@ export default function createInstantSearchManager({
   indexName,
   initialState = {},
   algoliaClient,
-  searchParameters = {},
   resultsState,
   stalledSearchDelay,
 }) {
   const baseSP = new SearchParameters({
-    ...searchParameters,
     index: indexName,
     ...highlightTags,
   });


### PR DESCRIPTION
**Summary**

In 3.3.1 we introduce a warning about the usage of `searchForFacetValues` in favour of `searchForItems` + `withSearchBox` (now renamed `searchable`). Since it's almost a year this PR remove those warnings. Also remove the `searchParameters` on `<InstantSearch>` in favour of `<Configure />`.
