### PR TITLE
refactor(CurrentRefinements): revert behaviour changes

### DIFF
--- a/docgen/src/guide/Migration_guide_v5.md
+++ b/docgen/src/guide/Migration_guide_v5.md
@@ -216,7 +216,7 @@ No change.
 
 #### Behaviour
 
-Instead of displaying the widget as `category: One ✕ Two ✕`, it now displays like this: `One ✕` `Two ✕`.
+No change.
 
 #### CSS classes equivalency table
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "happo-target-firefox": "5.0.0",
     "happypack": "4.0.0",
     "hasha": "3.0.0",
-    "instantsearch.css": "6.0.1",
+    "instantsearch.css": "7.0.0",
     "jest": "22.0.3",
     "jsdoc-parse": "1.2.7",
     "json": "9.0.6",

--- a/packages/react-instantsearch/src/components/CurrentRefinements.js
+++ b/packages/react-instantsearch/src/components/CurrentRefinements.js
@@ -1,10 +1,50 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import translatable from '../core/translatable';
 import createClassNames from '../components/createClassNames';
 
 const cx = createClassNames('CurrentRefinements');
+
+export const CurrentRefinements = ({
+  items,
+  canRefine,
+  refine,
+  translate,
+  className,
+}) => (
+  <div className={classNames(cx('', !canRefine && '-noRefinement'), className)}>
+    <ul className={cx('list', !canRefine && 'list--noRefinement')}>
+      {items.map(item => (
+        <li key={item.label} className={cx('item')}>
+          <span className={cx('label')}>{item.label}</span>
+          {item.items ? (
+            item.items.map(nest => (
+              <span key={nest.label} className={cx('category')}>
+                <span className={cx('categoryLabel')}>{nest.label}</span>
+                <button
+                  className={cx('delete')}
+                  onClick={() => refine(nest.value)}
+                >
+                  {translate('clearFilter', nest)}
+                </button>
+              </span>
+            ))
+          ) : (
+            <span className={cx('category')}>
+              <button
+                className={cx('delete')}
+                onClick={() => refine(item.value)}
+              >
+                {translate('clearFilter', item)}
+              </button>
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  </div>
+);
 
 const itemPropTypes = PropTypes.arrayOf(
   PropTypes.shape({
@@ -14,58 +54,17 @@ const itemPropTypes = PropTypes.arrayOf(
   })
 );
 
-export class CurrentRefinements extends Component {
-  static propTypes = {
-    items: itemPropTypes.isRequired,
-    canRefine: PropTypes.bool.isRequired,
-    refine: PropTypes.func.isRequired,
-    translate: PropTypes.func.isRequired,
-    className: PropTypes.string,
-  };
+CurrentRefinements.propTypes = {
+  items: itemPropTypes.isRequired,
+  canRefine: PropTypes.bool.isRequired,
+  refine: PropTypes.func.isRequired,
+  translate: PropTypes.func.isRequired,
+  className: PropTypes.string,
+};
 
-  static defaultProps = {
-    className: '',
-  };
-
-  renderItem(item) {
-    const { refine, translate } = this.props;
-
-    return (
-      <span key={item.label} className={cx('category')}>
-        <span className={cx('categoryLabel')}>{item.label}</span>
-        <button className={cx('delete')} onClick={() => refine(item.value)}>
-          {translate('clearFilter', item)}
-        </button>
-      </span>
-    );
-  }
-
-  render() {
-    const { items, canRefine, className } = this.props;
-
-    return (
-      <div
-        className={classNames(cx('', !canRefine && '-noRefinement'), className)}
-      >
-        <ul className={cx('list', !canRefine && 'list--noRefinement')}>
-          {items.map(
-            item =>
-              item.items ? (
-                <li key={item.label} className={cx('item')}>
-                  <span className={cx('label')}>{item.label}</span>
-                  {item.items.map(nest => this.renderItem(nest))}
-                </li>
-              ) : (
-                <li key={item.label} className={cx('item')}>
-                  {this.renderItem(item)}
-                </li>
-              )
-          )}
-        </ul>
-      </div>
-    );
-  }
-}
+CurrentRefinements.defaultProps = {
+  className: '',
+};
 
 export default translatable({
   clearFilter: '✕',

--- a/packages/react-instantsearch/src/components/CurrentRefinements.js
+++ b/packages/react-instantsearch/src/components/CurrentRefinements.js
@@ -6,13 +6,17 @@ import createClassNames from '../components/createClassNames';
 
 const cx = createClassNames('CurrentRefinements');
 
-class CurrentRefinements extends Component {
+const itemPropTypes = PropTypes.arrayOf(
+  PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.func.isRequired,
+    items: (...args) => itemPropTypes(...args),
+  })
+);
+
+export class CurrentRefinements extends Component {
   static propTypes = {
-    items: PropTypes.arrayOf(
-      PropTypes.shape({
-        label: PropTypes.string,
-      })
-    ).isRequired,
+    items: itemPropTypes.isRequired,
     canRefine: PropTypes.bool.isRequired,
     refine: PropTypes.func.isRequired,
     translate: PropTypes.func.isRequired,
@@ -23,32 +27,40 @@ class CurrentRefinements extends Component {
     className: '',
   };
 
-  render() {
-    const { items, canRefine, refine, translate, className } = this.props;
+  renderItem(item) {
+    const { refine, translate } = this.props;
 
-    const flatten = items.reduce(
-      (acc, item) => acc.concat(item.items ? item.items : item),
-      []
+    return (
+      <span key={item.label} className={cx('category')}>
+        <span className={cx('categoryLabel')}>{item.label}</span>
+        <button className={cx('delete')} onClick={() => refine(item.value)}>
+          {translate('clearFilter', item)}
+        </button>
+      </span>
     );
+  }
+
+  render() {
+    const { items, canRefine, className } = this.props;
 
     return (
       <div
         className={classNames(cx('', !canRefine && '-noRefinement'), className)}
       >
         <ul className={cx('list', !canRefine && 'list--noRefinement')}>
-          {flatten.map(item => (
-            <li key={item.label} className={cx('item')}>
-              <button
-                className={cx('button')}
-                onClick={() => refine(item.value)}
-              >
-                <span className={cx('label')}>{item.label}</span>
-                <span className={cx('delete')}>
-                  {translate('clearFilter', item)}
-                </span>
-              </button>
-            </li>
-          ))}
+          {items.map(
+            item =>
+              item.items ? (
+                <li key={item.label} className={cx('item')}>
+                  <span className={cx('label')}>{item.label}</span>
+                  {item.items.map(nest => this.renderItem(nest))}
+                </li>
+              ) : (
+                <li key={item.label} className={cx('item')}>
+                  {this.renderItem(item)}
+                </li>
+              )
+          )}
         </ul>
       </div>
     );

--- a/packages/react-instantsearch/src/components/CurrentRefinements.test.js
+++ b/packages/react-instantsearch/src/components/CurrentRefinements.test.js
@@ -1,85 +1,162 @@
-/* eslint-env jest, jasmine */
-
 import React from 'react';
-import renderer from 'react-test-renderer';
-import Enzyme from 'enzyme';
+import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import CurrentRefinements from './CurrentRefinements';
+import Connected, { CurrentRefinements } from './CurrentRefinements';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('CurrentRefinements', () => {
-  it('renders a list of current refinements', () =>
-    expect(
-      renderer
-        .create(
-          <CurrentRefinements
-            refine={() => null}
-            items={[
-              {
-                label: 'Genre',
-                value: 'clear all genres',
-              },
-            ]}
-            canRefine={true}
-          />
-        )
-        .toJSON()
-    ).toMatchSnapshot());
+  const defaultProps = {
+    items: [],
+    canRefine: true,
+    refine: () => {},
+    translate: x => x,
+  };
 
-  it('renders a list of current refinements with a custom className', () =>
-    expect(
-      renderer
-        .create(
-          <CurrentRefinements
-            className="MyCustomCurrentRefinements"
-            refine={() => null}
-            items={[
-              {
-                label: 'Genre',
-                value: 'clear all genres',
-              },
-            ]}
-            canRefine={true}
-          />
-        )
-        .toJSON()
-    ).toMatchSnapshot());
+  it('expect to render a list of current refinements', () => {
+    const props = {
+      ...defaultProps,
+      items: [
+        { label: 'color: Red', value: () => {} },
+        {
+          label: 'category:',
+          value: () => {},
+          items: [
+            { label: 'iPhone', value: () => {} },
+            { label: 'iPad', value: () => {} },
+          ],
+        },
+      ],
+    };
 
-  it('renders a empty list with no current refinements', () =>
-    expect(
-      renderer
-        .create(
-          <CurrentRefinements
-            refine={() => null}
-            items={[]}
-            canRefine={false}
-          />
-        )
-        .toJSON()
-    ).toMatchSnapshot());
+    const wrapper = shallow(<CurrentRefinements {...props} />);
 
-  it('allows clearing unique items of a refinement', () =>
-    expect(
-      renderer
-        .create(
-          <CurrentRefinements
-            refine={() => null}
-            items={[
-              {
-                label: 'Genre',
-                value: 'clear all genres',
-                items: [
-                  {
-                    label: 'Sci-fi',
-                    value: 'clear sci-fi',
-                  },
-                ],
-              },
-            ]}
-            canRefine={true}
-          />
-        )
-        .toJSON()
-    ).toMatchSnapshot());
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to render a list without refinements', () => {
+    const props = {
+      ...defaultProps,
+      canRefine: false,
+    };
+
+    const wrapper = shallow(<CurrentRefinements {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to render a list with a custom className', () => {
+    const props = {
+      ...defaultProps,
+      className: 'MyCustomCurrentRefinements',
+    };
+
+    const wrapper = shallow(<CurrentRefinements {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to refine the "color" onClick', () => {
+    const value = () => {};
+    const props = {
+      ...defaultProps,
+      items: [
+        { label: 'color: Red', value },
+        {
+          label: 'category:',
+          value: () => {},
+          items: [
+            { label: 'iPhone', value: () => {} },
+            { label: 'iPad', value: () => {} },
+          ],
+        },
+      ],
+      refine: jest.fn(),
+    };
+
+    const wrapper = shallow(<CurrentRefinements {...props} />);
+
+    expect(props.refine).not.toHaveBeenCalled();
+
+    wrapper
+      .find('li')
+      .first()
+      .find('button')
+      .simulate('click');
+
+    expect(props.refine).toHaveBeenCalledWith(value);
+  });
+
+  it('expect to refine the "category: iPad" onClick', () => {
+    const value = () => {};
+    const props = {
+      ...defaultProps,
+      items: [
+        { label: 'color: Red', value: () => {} },
+        {
+          label: 'category:',
+          value: () => {},
+          items: [
+            { label: 'iPhone', value: () => {} },
+            { label: 'iPad', value },
+          ],
+        },
+      ],
+      refine: jest.fn(),
+    };
+
+    const wrapper = shallow(<CurrentRefinements {...props} />);
+
+    expect(props.refine).not.toHaveBeenCalled();
+
+    wrapper
+      .find('li')
+      .last()
+      .find('button')
+      .last()
+      .simulate('click');
+
+    expect(props.refine).toHaveBeenCalledWith(value);
+  });
+});
+
+describe('CurrentRefinements - Connected', () => {
+  const defaultProps = {
+    items: [
+      { label: 'color: Red', value: () => {} },
+      {
+        label: 'category:',
+        value: () => {},
+        items: [
+          { label: 'iPhone', value: () => {} },
+          { label: 'iPad', value: () => {} },
+        ],
+      },
+    ],
+    canRefine: true,
+    refine: () => {},
+  };
+
+  it('expect to render a list of current refinements', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = shallow(<Connected {...props} />).dive();
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to render a list of current refinements with custom translations', () => {
+    const props = {
+      ...defaultProps,
+      translations: {
+        clearFilter: 'DELETE',
+      },
+    };
+
+    const wrapper = shallow(<Connected {...props} />).dive();
+
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/packages/react-instantsearch/src/components/__snapshots__/CurrentRefinements.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/CurrentRefinements.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CurrentRefinements allows clearing unique items of a refinement 1`] = `
+exports[`CurrentRefinements - Connected expect to render a list of current refinements 1`] = `
 <div
   className="ais-CurrentRefinements"
 >
@@ -9,93 +9,235 @@ exports[`CurrentRefinements allows clearing unique items of a refinement 1`] = `
   >
     <li
       className="ais-CurrentRefinements-item"
+      key="color: Red"
     >
-      <button
-        className="ais-CurrentRefinements-button"
-        onClick={[Function]}
+      <span
+        className="ais-CurrentRefinements-category"
+        key="color: Red"
       >
         <span
-          className="ais-CurrentRefinements-label"
+          className="ais-CurrentRefinements-categoryLabel"
         >
-          Sci-fi
+          color: Red
         </span>
-        <span
+        <button
           className="ais-CurrentRefinements-delete"
+          onClick={[Function]}
         >
           ✕
+        </button>
+      </span>
+    </li>
+    <li
+      className="ais-CurrentRefinements-item"
+      key="category:"
+    >
+      <span
+        className="ais-CurrentRefinements-label"
+      >
+        category:
+      </span>
+      <span
+        className="ais-CurrentRefinements-category"
+        key="iPhone"
+      >
+        <span
+          className="ais-CurrentRefinements-categoryLabel"
+        >
+          iPhone
         </span>
-      </button>
+        <button
+          className="ais-CurrentRefinements-delete"
+          onClick={[Function]}
+        >
+          ✕
+        </button>
+      </span>
+      <span
+        className="ais-CurrentRefinements-category"
+        key="iPad"
+      >
+        <span
+          className="ais-CurrentRefinements-categoryLabel"
+        >
+          iPad
+        </span>
+        <button
+          className="ais-CurrentRefinements-delete"
+          onClick={[Function]}
+        >
+          ✕
+        </button>
+      </span>
     </li>
   </ul>
 </div>
 `;
 
-exports[`CurrentRefinements renders a empty list with no current refinements 1`] = `
+exports[`CurrentRefinements - Connected expect to render a list of current refinements with custom translations 1`] = `
+<div
+  className="ais-CurrentRefinements"
+>
+  <ul
+    className="ais-CurrentRefinements-list"
+  >
+    <li
+      className="ais-CurrentRefinements-item"
+      key="color: Red"
+    >
+      <span
+        className="ais-CurrentRefinements-category"
+        key="color: Red"
+      >
+        <span
+          className="ais-CurrentRefinements-categoryLabel"
+        >
+          color: Red
+        </span>
+        <button
+          className="ais-CurrentRefinements-delete"
+          onClick={[Function]}
+        >
+          DELETE
+        </button>
+      </span>
+    </li>
+    <li
+      className="ais-CurrentRefinements-item"
+      key="category:"
+    >
+      <span
+        className="ais-CurrentRefinements-label"
+      >
+        category:
+      </span>
+      <span
+        className="ais-CurrentRefinements-category"
+        key="iPhone"
+      >
+        <span
+          className="ais-CurrentRefinements-categoryLabel"
+        >
+          iPhone
+        </span>
+        <button
+          className="ais-CurrentRefinements-delete"
+          onClick={[Function]}
+        >
+          DELETE
+        </button>
+      </span>
+      <span
+        className="ais-CurrentRefinements-category"
+        key="iPad"
+      >
+        <span
+          className="ais-CurrentRefinements-categoryLabel"
+        >
+          iPad
+        </span>
+        <button
+          className="ais-CurrentRefinements-delete"
+          onClick={[Function]}
+        >
+          DELETE
+        </button>
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`CurrentRefinements expect to render a list of current refinements 1`] = `
+<div
+  className="ais-CurrentRefinements"
+>
+  <ul
+    className="ais-CurrentRefinements-list"
+  >
+    <li
+      className="ais-CurrentRefinements-item"
+      key="color: Red"
+    >
+      <span
+        className="ais-CurrentRefinements-category"
+        key="color: Red"
+      >
+        <span
+          className="ais-CurrentRefinements-categoryLabel"
+        >
+          color: Red
+        </span>
+        <button
+          className="ais-CurrentRefinements-delete"
+          onClick={[Function]}
+        >
+          clearFilter
+        </button>
+      </span>
+    </li>
+    <li
+      className="ais-CurrentRefinements-item"
+      key="category:"
+    >
+      <span
+        className="ais-CurrentRefinements-label"
+      >
+        category:
+      </span>
+      <span
+        className="ais-CurrentRefinements-category"
+        key="iPhone"
+      >
+        <span
+          className="ais-CurrentRefinements-categoryLabel"
+        >
+          iPhone
+        </span>
+        <button
+          className="ais-CurrentRefinements-delete"
+          onClick={[Function]}
+        >
+          clearFilter
+        </button>
+      </span>
+      <span
+        className="ais-CurrentRefinements-category"
+        key="iPad"
+      >
+        <span
+          className="ais-CurrentRefinements-categoryLabel"
+        >
+          iPad
+        </span>
+        <button
+          className="ais-CurrentRefinements-delete"
+          onClick={[Function]}
+        >
+          clearFilter
+        </button>
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`CurrentRefinements expect to render a list with a custom className 1`] = `
+<div
+  className="ais-CurrentRefinements MyCustomCurrentRefinements"
+>
+  <ul
+    className="ais-CurrentRefinements-list"
+  />
+</div>
+`;
+
+exports[`CurrentRefinements expect to render a list without refinements 1`] = `
 <div
   className="ais-CurrentRefinements ais-CurrentRefinements--noRefinement"
 >
   <ul
     className="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
   />
-</div>
-`;
-
-exports[`CurrentRefinements renders a list of current refinements 1`] = `
-<div
-  className="ais-CurrentRefinements"
->
-  <ul
-    className="ais-CurrentRefinements-list"
-  >
-    <li
-      className="ais-CurrentRefinements-item"
-    >
-      <button
-        className="ais-CurrentRefinements-button"
-        onClick={[Function]}
-      >
-        <span
-          className="ais-CurrentRefinements-label"
-        >
-          Genre
-        </span>
-        <span
-          className="ais-CurrentRefinements-delete"
-        >
-          ✕
-        </span>
-      </button>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`CurrentRefinements renders a list of current refinements with a custom className 1`] = `
-<div
-  className="ais-CurrentRefinements MyCustomCurrentRefinements"
->
-  <ul
-    className="ais-CurrentRefinements-list"
-  >
-    <li
-      className="ais-CurrentRefinements-item"
-    >
-      <button
-        className="ais-CurrentRefinements-button"
-        onClick={[Function]}
-      >
-        <span
-          className="ais-CurrentRefinements-label"
-        >
-          Genre
-        </span>
-        <span
-          className="ais-CurrentRefinements-delete"
-        >
-          ✕
-        </span>
-      </button>
-    </li>
-  </ul>
 </div>
 `;

--- a/packages/react-instantsearch/src/components/__snapshots__/CurrentRefinements.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/CurrentRefinements.test.js.snap
@@ -12,14 +12,13 @@ exports[`CurrentRefinements - Connected expect to render a list of current refin
       key="color: Red"
     >
       <span
-        className="ais-CurrentRefinements-category"
-        key="color: Red"
+        className="ais-CurrentRefinements-label"
       >
-        <span
-          className="ais-CurrentRefinements-categoryLabel"
-        >
-          color: Red
-        </span>
+        color: Red
+      </span>
+      <span
+        className="ais-CurrentRefinements-category"
+      >
         <button
           className="ais-CurrentRefinements-delete"
           onClick={[Function]}
@@ -86,14 +85,13 @@ exports[`CurrentRefinements - Connected expect to render a list of current refin
       key="color: Red"
     >
       <span
-        className="ais-CurrentRefinements-category"
-        key="color: Red"
+        className="ais-CurrentRefinements-label"
       >
-        <span
-          className="ais-CurrentRefinements-categoryLabel"
-        >
-          color: Red
-        </span>
+        color: Red
+      </span>
+      <span
+        className="ais-CurrentRefinements-category"
+      >
         <button
           className="ais-CurrentRefinements-delete"
           onClick={[Function]}
@@ -160,14 +158,13 @@ exports[`CurrentRefinements expect to render a list of current refinements 1`] =
       key="color: Red"
     >
       <span
-        className="ais-CurrentRefinements-category"
-        key="color: Red"
+        className="ais-CurrentRefinements-label"
       >
-        <span
-          className="ais-CurrentRefinements-categoryLabel"
-        >
-          color: Red
-        </span>
+        color: Red
+      </span>
+      <span
+        className="ais-CurrentRefinements-category"
+      >
         <button
           className="ais-CurrentRefinements-delete"
           onClick={[Function]}

--- a/packages/react-instantsearch/src/widgets/CurrentRefinements.js
+++ b/packages/react-instantsearch/src/widgets/CurrentRefinements.js
@@ -17,6 +17,8 @@ import CurrentRefinements from '../components/CurrentRefinements';
  * @themeKey ais-CurrentRefinements-item - the refined list item
  * @themeKey ais-CurrentRefinements-button - the button of each refined list item
  * @themeKey ais-CurrentRefinements-label - the refined list label
+ * @themeKey ais-CurrentRefinements-category - the category of each item
+ * @themeKey ais-CurrentRefinements-categoryLabel - the label of each catgory
  * @themeKey ais-CurrentRefinements-delete - the delete button of each label
  * @translationKey clearFilter - the remove filter button label
  * @example

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,9 +6626,9 @@ insert-css@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
 
-instantsearch.css@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-6.0.1.tgz#00063ba3653c5c78772e35a7eb084acd9b6b5cd4"
+instantsearch.css@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.0.0.tgz#74fb9aa25ce64c80effc663fe92bc9ec785cc5e3"
 
 internal-ip@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
**Summary**

This PR restore the previous behaviour of `CurrentRefinements`. The component also move for a SFC since we didn't use state & hooks.

**Result**

You can play with the widget on [Storybook](https://deploy-preview-906--react-instantsearch.netlify.com/react-instantsearch/storybook/?selectedKind=CurrentRefinements&selectedStory=with%20RefinementList&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs).
