### PR TITLE
fix(connectRange): use the same behaviour for currentRefinement in getMetadata

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -107,6 +107,13 @@ function getCurrentRefinement(props, searchState, currentRange, context) {
   return refinement;
 }
 
+function getCurrentRefinementWithRange(refinement, range) {
+  return {
+    min: refinement.min !== undefined ? refinement.min : range.min,
+    max: refinement.max !== undefined ? refinement.max : range.max,
+  };
+}
+
 function nextValueForRefinement(hasBound, isReset, range, value) {
   let next;
   if (!hasBound && range === value) {
@@ -217,7 +224,7 @@ export default createConnector({
       max: rangeMax,
     };
 
-    const { min: valueMin, max: valueMax } = getCurrentRefinement(
+    const currentRefinement = getCurrentRefinement(
       props,
       searchState,
       this._currentRange,
@@ -228,10 +235,10 @@ export default createConnector({
       min: rangeMin,
       max: rangeMax,
       canRefine: count.length > 0,
-      currentRefinement: {
-        min: valueMin === undefined ? rangeMin : valueMin,
-        max: valueMax === undefined ? rangeMax : valueMax,
-      },
+      currentRefinement: getCurrentRefinementWithRange(
+        currentRefinement,
+        this._currentRange
+      ),
       count,
       precision,
     };
@@ -300,10 +307,10 @@ export default createConnector({
         attributeName: props.attributeName,
         value: nextState =>
           refine(props, nextState, {}, this._currentRange, this.context),
-        currentRefinement: {
-          min: minValue,
-          max: maxValue,
-        },
+        currentRefinement: getCurrentRefinementWithRange(
+          { min: minValue, max: maxValue },
+          { min: minRange, max: maxRange }
+        ),
       });
     }
 

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -470,7 +470,7 @@ describe('connectRange', () => {
           {
             label: '5 <= wot',
             attributeName: 'wot',
-            currentRefinement: { min: 5, max: undefined },
+            currentRefinement: { min: 5, max: 100 },
             // Ignore clear, we test it later
             value: metadata.items[0].value,
           },
@@ -505,7 +505,7 @@ describe('connectRange', () => {
           {
             label: 'wot <= 10',
             attributeName: 'wot',
-            currentRefinement: { min: undefined, max: 10 },
+            currentRefinement: { min: 0, max: 10 },
             value: metadata.items[0].value,
           },
         ],
@@ -753,7 +753,7 @@ describe('connectRange', () => {
           {
             label: '5 <= wot',
             attributeName: 'wot',
-            currentRefinement: { min: 5, max: undefined },
+            currentRefinement: { min: 5, max: 100 },
             // Ignore clear, we test it later
             value: metadata.items[0].value,
           },
@@ -792,7 +792,7 @@ describe('connectRange', () => {
           {
             label: 'wot <= 10',
             attributeName: 'wot',
-            currentRefinement: { min: undefined, max: 10 },
+            currentRefinement: { min: 0, max: 10 },
             value: metadata.items[0].value,
           },
         ],


### PR DESCRIPTION
**Summary**

Close #920 

We provide two different values for the `currentRefinement` in `getProvidedProps` & `getMetadata`. In the first case we "normalize" the value with the range, in the latter we pass the raw values. It can lead to some issues when the user use the `currentRefinement` from the `connectCurrentRefinement` since the values aren't aligned.

**Edit:** At some point we should avoid to "normalize" the `currentRefinement` with the range from the connector. Passing the raw values to the view and let it decide which value to render is more flexible. It's a bit more work to do in the view but the connector will be more reusable (ex: We can implement a "correct" behaviour for `RatingMenu`).