### PR TITLE
docs: add deprecation warning

### DIFF
--- a/docgen/layouts/common/header.pug
+++ b/docgen/layouts/common/header.pug
@@ -3,4 +3,4 @@ div !{header}
     .banner__description
       a(href='http://react-instantsearch-beta.netlify.com')
         p
-          strong Checkout React InstantSearch V5! Our new and improved React InstantSearch version →
+          strong Check out React InstantSearch V5! Our new and improved React InstantSearch version →

--- a/docgen/layouts/common/header.pug
+++ b/docgen/layouts/common/header.pug
@@ -1,1 +1,6 @@
 div !{header}
+  .marketing-banner
+    .banner__description
+      a(href='http://react-instantsearch-beta.netlify.com')
+        p
+          strong Checkout React InstantSearch V5! Our new and improved React InstantSearch version →

--- a/docgen/src/stylesheets/components/_deprecation-banner.sass
+++ b/docgen/src/stylesheets/components/_deprecation-banner.sass
@@ -1,0 +1,34 @@
+$banner-height: 50px
+
+.marketing-banner
+  height: $banner-height
+  width: 100%
+  position: fixed
+  background: linear-gradient(80deg, #00D8FF, #00A7FF)
+  float: left
+  line-height: $banner-height
+  padding: 0 2em
+  box-sizing: border-box
+  transform: translateY(-#{$banner-height})
+  transition: transform 0.2s ease, background-position 0.2s ease
+  z-index: 999
+  top: 106px
+
+  &:hover
+    background-position: bottom right
+
+  .banner__description
+    color: #FFFFFF
+    text-align: center
+
+    a
+      color: #FFFFFF
+      text-decoration: none
+      display: block
+      width: 100%
+      height: 100%
+
+    p
+      margin: 0
+      padding: 0
+      display: inline-block

--- a/docgen/src/stylesheets/components/_deprecation-banner.sass
+++ b/docgen/src/stylesheets/components/_deprecation-banner.sass
@@ -4,7 +4,7 @@ $banner-height: 50px
   height: $banner-height
   width: 100%
   position: fixed
-  background: linear-gradient(80deg, #00D8FF, #00A7FF)
+  background: linear-gradient(to top left, #FCB43A, #FEDD4E) no-repeat bottom right / 150%
   float: left
   line-height: $banner-height
   padding: 0 2em

--- a/docgen/src/stylesheets/index.sass
+++ b/docgen/src/stylesheets/index.sass
@@ -17,6 +17,7 @@
 @import 'components/sidebar'
 @import 'components/code-snippets'
 @import 'components/code-highlighting'
+@import 'components/deprecation-banner'
 
 
 @import 'pages/home'


### PR DESCRIPTION
**Summary**

Add a deprecation banner for the current documentation with a link on the next version documentation website.

**Result**

![screen shot 2018-01-31 at 09 28 36](https://user-images.githubusercontent.com/6513513/35612465-2649812e-0669-11e8-9ff0-71d70aeed77b.png)
