### PR TITLE
fix(StarRatings): always show the stars below

### DIFF
--- a/packages/react-instantsearch/src/components/StarRating.js
+++ b/packages/react-instantsearch/src/components/StarRating.js
@@ -131,15 +131,16 @@ class StarRating extends Component {
 
     // min & max are always set when there is a results, otherwise it means
     // that we don't want to render anything since we don't have any values.
-    const limitMin = min !== undefined ? min : 1;
-    const limitMax = max !== undefined ? max : limitMin - 1;
-    const inclusivePlaceholderLength = limitMax - (limitMin - 1);
+    const limitMin = min !== undefined && min >= 0 ? min : 0;
+    const limitMax = max !== undefined && max >= 0 ? max : -1;
+    const inclusiveLength = limitMax - limitMin + 1;
+    const safeInclusiveLength = Math.max(inclusiveLength, 0);
 
     const values = count
       .map(item => ({ ...item, value: parseFloat(item.value) }))
       .filter(item => item.value >= limitMin && item.value <= limitMax);
 
-    const range = new Array(inclusivePlaceholderLength)
+    const range = new Array(safeInclusiveLength)
       .fill(null)
       .map((_, index) => {
         const element = values.find(item => item.value === limitMax - index);

--- a/packages/react-instantsearch/src/components/StarRating.js
+++ b/packages/react-instantsearch/src/components/StarRating.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import translatable from '../core/translatable';
 import classNames from './classNames.js';
-import { isEmpty } from 'lodash';
 const cx = classNames('StarRating');
 
 class StarRating extends Component {
@@ -129,38 +128,46 @@ class StarRating extends Component {
 
   render() {
     const {
+      min = 1,
+      max = 0,
       translate,
-      refine,
-      min,
-      max,
       count,
       createURL,
       canRefine,
     } = this.props;
-    const items = [];
-    for (let i = max; i >= min; i--) {
-      const hasCount = !isEmpty(count.filter(item => Number(item.value) === i));
-      const lastSelectableItem = count.reduce(
-        (acc, item) =>
-          item.value < acc.value || (!acc.value && hasCount) ? item : acc,
-        {}
+
+    const values = count
+      .map(item => ({ ...item, value: parseFloat(item.value) }))
+      .filter(item => item.value >= min && item.value <= max);
+
+    const range = new Array(max - (min - 1))
+      .fill(null)
+      .map((_, index) => {
+        const element = values.find(item => item.value === max - index);
+        const placeholder = { value: max - index, count: 0, total: 0 };
+
+        return element || placeholder;
+      })
+      .reduce(
+        (acc, item, index) =>
+          acc.concat({
+            ...item,
+            total: index === 0 ? item.count : acc[index - 1].total + item.count,
+          }),
+        []
       );
-      const itemCount = count.reduce(
-        (acc, item) => (item.value >= i && hasCount ? acc + item.count : acc),
-        0
-      );
-      items.push(
-        this.buildItem({
-          lowerBound: i,
-          max,
-          refine,
-          count: itemCount,
-          translate,
-          createURL,
-          isLastSelectableItem: i === Number(lastSelectableItem.value),
-        })
-      );
-    }
+
+    const items = range.map((item, index) =>
+      this.buildItem({
+        lowerBound: item.value,
+        count: item.total,
+        isLastSelectableItem: range.length - 1 === index,
+        max,
+        translate,
+        createURL,
+      })
+    );
+
     return <div {...cx('root', !canRefine && 'noRefinement')}>{items}</div>;
   }
 }

--- a/packages/react-instantsearch/src/components/StarRating.js
+++ b/packages/react-instantsearch/src/components/StarRating.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import translatable from '../core/translatable';
 import classNames from './classNames.js';
 const cx = classNames('StarRating');
@@ -127,24 +127,23 @@ class StarRating extends Component {
   }
 
   render() {
-    const {
-      min = 1,
-      max = 0,
-      translate,
-      count,
-      createURL,
-      canRefine,
-    } = this.props;
+    const { min, max, translate, count, createURL, canRefine } = this.props;
+
+    // min & max are always set when there is a results, otherwise it means
+    // that we don't want to render anything since we don't have any values.
+    const limitMin = min !== undefined ? min : 1;
+    const limitMax = max !== undefined ? max : limitMin - 1;
+    const inclusivePlaceholderLength = limitMax - (limitMin - 1);
 
     const values = count
       .map(item => ({ ...item, value: parseFloat(item.value) }))
-      .filter(item => item.value >= min && item.value <= max);
+      .filter(item => item.value >= limitMin && item.value <= limitMax);
 
-    const range = new Array(max - (min - 1))
+    const range = new Array(inclusivePlaceholderLength)
       .fill(null)
       .map((_, index) => {
-        const element = values.find(item => item.value === max - index);
-        const placeholder = { value: max - index, count: 0, total: 0 };
+        const element = values.find(item => item.value === limitMax - index);
+        const placeholder = { value: limitMax - index, count: 0, total: 0 };
 
         return element || placeholder;
       })
@@ -162,7 +161,7 @@ class StarRating extends Component {
         lowerBound: item.value,
         count: item.total,
         isLastSelectableItem: range.length - 1 === index,
-        max,
+        max: limitMax,
         translate,
         createURL,
       })

--- a/packages/react-instantsearch/src/components/StarRating.test.js
+++ b/packages/react-instantsearch/src/components/StarRating.test.js
@@ -31,6 +31,29 @@ describe('StarRating', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('supports passing max/min values smaller than count max & min', () => {
+    const tree = renderer
+      .create(
+        <StarRating
+          createURL={() => '#'}
+          refine={() => null}
+          min={2}
+          max={4}
+          currentRefinement={{}}
+          count={[
+            { value: '1', count: 1 },
+            { value: '2', count: 2 },
+            { value: '3', count: 3 },
+            { value: '4', count: 4 },
+            { value: '5', count: 5 },
+          ]}
+          canRefine={true}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('applies translations', () => {
     const tree = renderer
       .create(

--- a/packages/react-instantsearch/src/components/StarRating.test.js
+++ b/packages/react-instantsearch/src/components/StarRating.test.js
@@ -1,13 +1,11 @@
-import PropTypes from 'prop-types';
-/* eslint-env jest, jasmine */
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import renderer from 'react-test-renderer';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-Enzyme.configure({ adapter: new Adapter() });
-
 import StarRating from './StarRating';
+
+Enzyme.configure({ adapter: new Adapter() });
 
 describe('StarRating', () => {
   it('supports passing max/min values', () => {
@@ -150,29 +148,6 @@ describe('StarRating', () => {
 
     expect(refine.mock.calls).toHaveLength(1);
     expect(refine.mock.calls[0][0]).toEqual({ min: 1, max: 5 });
-    wrapper.unmount();
-  });
-
-  it('the default selected range should be the lowest one with count', () => {
-    const wrapper = mount(starRating);
-    wrapper.setProps({
-      count: [
-        { value: '2', count: 2 },
-        { value: '3', count: 3 },
-        { value: '4', count: 3 },
-      ],
-    });
-
-    const links = wrapper.find('.ais-StarRating__ratingLink');
-    expect(links.first().hasClass('ais-StarRating__ratingLinkSelected')).toBe(
-      false
-    );
-
-    const selected = wrapper.find('.ais-StarRating__ratingLinkSelected');
-    expect(selected.find('.ais-StarRating__ratingIconEmpty')).toHaveLength(3);
-    expect(selected.find('.ais-StarRating__ratingIcon')).toHaveLength(2);
-    expect(selected.text()).toContain('8');
-
     wrapper.unmount();
   });
 

--- a/packages/react-instantsearch/src/components/StarRating.test.js
+++ b/packages/react-instantsearch/src/components/StarRating.test.js
@@ -57,6 +57,54 @@ describe('StarRating', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('expect to not throw when only min is defined', () => {
+    expect(() => {
+      renderer.create(
+        <StarRating
+          createURL={() => '#'}
+          refine={() => null}
+          translations={{
+            ratingLabel: ' & Up',
+          }}
+          min={3}
+          currentRefinement={{ min: 1, max: 5 }}
+          count={[
+            { value: '1', count: 1 },
+            { value: '2', count: 2 },
+            { value: '3', count: 3 },
+            { value: '4', count: 4 },
+            { value: '5', count: 5 },
+          ]}
+          canRefine={true}
+        />
+      );
+    }).not.toThrow();
+  });
+
+  it('expect to not throw when only max is defined', () => {
+    expect(() => {
+      renderer.create(
+        <StarRating
+          createURL={() => '#'}
+          refine={() => null}
+          translations={{
+            ratingLabel: ' & Up',
+          }}
+          max={3}
+          currentRefinement={{ min: 1, max: 5 }}
+          count={[
+            { value: '1', count: 1 },
+            { value: '2', count: 2 },
+            { value: '3', count: 3 },
+            { value: '4', count: 4 },
+            { value: '5', count: 5 },
+          ]}
+          canRefine={true}
+        />
+      );
+    }).not.toThrow();
+  });
+
   const refine = jest.fn();
   const createURL = jest.fn();
   const starRating = (

--- a/packages/react-instantsearch/src/components/StarRating.test.js
+++ b/packages/react-instantsearch/src/components/StarRating.test.js
@@ -128,6 +128,58 @@ describe('StarRating', () => {
     }).not.toThrow();
   });
 
+  it('expect to render from from 0 when min is negative', () => {
+    const tree = renderer
+      .create(
+        <StarRating
+          createURL={() => '#'}
+          refine={() => null}
+          translations={{
+            ratingLabel: ' & Up',
+          }}
+          min={-5}
+          max={5}
+          currentRefinement={{ min: 1, max: 5 }}
+          count={[
+            { value: '1', count: 1 },
+            { value: '2', count: 2 },
+            { value: '3', count: 3 },
+            { value: '4', count: 4 },
+            { value: '5', count: 5 },
+          ]}
+          canRefine={true}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('expect to render nothing when min is higher than max', () => {
+    const tree = renderer
+      .create(
+        <StarRating
+          createURL={() => '#'}
+          refine={() => null}
+          translations={{
+            ratingLabel: ' & Up',
+          }}
+          min={5}
+          max={3}
+          currentRefinement={{ min: 1, max: 5 }}
+          count={[
+            { value: '1', count: 1 },
+            { value: '2', count: 2 },
+            { value: '3', count: 3 },
+            { value: '4', count: 4 },
+            { value: '5', count: 5 },
+          ]}
+          canRefine={true}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   const refine = jest.fn();
   const createURL = jest.fn();
   const starRating = (

--- a/packages/react-instantsearch/src/components/__snapshots__/StarRating.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/StarRating.test.js.snap
@@ -180,6 +180,229 @@ exports[`StarRating applies translations 1`] = `
 </div>
 `;
 
+exports[`StarRating expect to render from from 0 when min is negative 1`] = `
+<div
+  className="ais-StarRating__root"
+>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      5
+    </span>
+  </a>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      9
+    </span>
+  </a>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      12
+    </span>
+  </a>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      14
+    </span>
+  </a>
+  <a
+    className="ais-StarRating__ratingLink ais-StarRating__ratingLinkSelected"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon ais-StarRating__ratingIconSelected"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty ais-StarRating__ratingIconEmptySelected"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty ais-StarRating__ratingIconEmptySelected"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty ais-StarRating__ratingIconEmptySelected"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty ais-StarRating__ratingIconEmptySelected"
+    />
+    <span
+      className="ais-StarRating__ratingLabel ais-StarRating__ratingLabelSelected"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount ais-StarRating__ratingCountSelected"
+    >
+      15
+    </span>
+  </a>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      15
+    </span>
+  </a>
+</div>
+`;
+
+exports[`StarRating expect to render nothing when min is higher than max 1`] = `
+<div
+  className="ais-StarRating__root"
+/>
+`;
+
 exports[`StarRating supports passing max/min values 1`] = `
 <div
   className="ais-StarRating__root"

--- a/packages/react-instantsearch/src/components/__snapshots__/StarRating.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/StarRating.test.js.snap
@@ -359,3 +359,106 @@ exports[`StarRating supports passing max/min values 1`] = `
   </div>
 </div>
 `;
+
+exports[`StarRating supports passing max/min values smaller than count max & min 1`] = `
+<div
+  className="ais-StarRating__root"
+>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      4
+    </span>
+  </a>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      7
+    </span>
+  </a>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingIconEmpty"
+    />
+    <span
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      9
+    </span>
+  </a>
+</div>
+`;

--- a/stories/StarRating.stories.js
+++ b/stories/StarRating.stories.js
@@ -19,7 +19,71 @@ stories
     'default',
     () => (
       <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
-        <StarRating attributeName="rating" max={6} min={1} />
+        <StarRating attributeName="rating" />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with min',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
+        <StarRating attributeName="rating" min={3} />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with max',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
+        <StarRating attributeName="rating" max={3} />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with min & max',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
+        <StarRating attributeName="rating" min={2} max={4} />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with only one value available',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
+        <Configure filters="rating>=4" />
+
+        <StarRating attributeName="rating" />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with only one value available & min & max',
+    () => (
+      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
+        <Configure filters="rating>=4" />
+
+        <StarRating attributeName="rating" min={1} max={5} />
       </WrapWithHits>
     ),
     {
@@ -32,22 +96,7 @@ stories
     () => (
       <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
         <Panel title="Ratings">
-          <StarRating attributeName="rating" max={6} min={1} />
-        </Panel>
-      </WrapWithHits>
-    ),
-    {
-      displayName,
-      filterProps,
-    }
-  )
-  .addWithJSX(
-    'with some unavailable refinements',
-    () => (
-      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
-        <Configure filters="rating>=4" />
-        <Panel title="Ratings">
-          <StarRating attributeName="rating" max={6} min={1} />
+          <StarRating attributeName="rating" />
         </Panel>
       </WrapWithHits>
     ),
@@ -65,7 +114,8 @@ stories
         linkedStoryGroup="StarRating"
       >
         <Panel title="Ratings">
-          <StarRating attributeName="rating" max={6} min={1} />
+          <StarRating attributeName="rating" />
+
           <div style={{ display: 'none' }}>
             <SearchBox defaultRefinement="ds" />
           </div>
@@ -78,11 +128,20 @@ stories
     }
   )
   .addWithJSX(
-    'with filter on rating',
+    'with panel but no refinement & min & max',
     () => (
-      <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
-        <Configure filters="rating>2" />
-        <StarRating attributeName="rating" max={6} min={1} />
+      <WrapWithHits
+        searchBox={false}
+        hasPlayground={true}
+        linkedStoryGroup="StarRating"
+      >
+        <Panel title="Ratings">
+          <StarRating attributeName="rating" min={1} max={5} />
+
+          <div style={{ display: 'none' }}>
+            <SearchBox defaultRefinement="ds" />
+          </div>
+        </Panel>
       </WrapWithHits>
     ),
     {
@@ -96,7 +155,8 @@ stories
       <WrapWithHits linkedStoryGroup="StarRating">
         <StarRating
           attributeName="rating"
-          max={number('max', 6)}
+          min={number('min', 1)}
+          max={number('max', 5)}
           translations={object('translations', { ratingLabel: ' & Up' })}
         />
       </WrapWithHits>


### PR DESCRIPTION
**Summary**

Fix #674 

In the current implementation we can have sparse rows when the results only return one facet value or if some numeric filters (ex: rating > 3) are applied. Now all the rows under the highest value are filled. Since the v5 is in `beta` I didn't update the tests for avoid to much conflict at the merge. But we should get rid of the `react-test-renderer` for `enzyme`. Same for the component we could move to a SFC after the merge.

**Before:**

![screen shot 2018-01-31 at 16 24 48](https://user-images.githubusercontent.com/6513513/35639092-526ab322-06b9-11e8-8d77-99d7f9c5cb12.png)

**After:**

![screen shot 2018-01-31 at 16 24 37](https://user-images.githubusercontent.com/6513513/35638973-eb8590f0-06b8-11e8-9d0a-7e26ddb4c233.png)

You can play with the widget on [Storybook](https://deploy-preview-929--react-instantsearch.netlify.com/react-instantsearch/storybook/?selectedKind=StarRating&selectedStory=default&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs).