### PR TITLE
fix: update CSS import

### DIFF
--- a/docgen/src/Getting_started.md
+++ b/docgen/src/Getting_started.md
@@ -107,10 +107,6 @@ We provide an Algolia theme that should be a good start.
 Include it in your webpage with this CDN link or copy paste the raw content:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/reset-min.css">
-
-<!-- or -->
-
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/algolia-min.css">
 ```
 

--- a/docgen/src/Getting_started.md
+++ b/docgen/src/Getting_started.md
@@ -108,6 +108,9 @@ Include it in your webpage with this CDN link or copy paste the raw content:
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/reset-min.css">
+
+<!-- or -->
+
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/algolia-min.css">
 ```
 

--- a/docgen/src/examples/default-theme/App.js
+++ b/docgen/src/examples/default-theme/App.js
@@ -18,7 +18,6 @@ import {
 } from 'react-instantsearch/dom';
 import { connectStateResults } from 'react-instantsearch/connectors';
 import { withUrlSync } from '../urlSync';
-import 'instantsearch.css/themes/reset.css';
 import 'instantsearch.css/themes/algolia.css';
 
 const App = props => (

--- a/docgen/src/examples/e-commerce-infinite/App.js
+++ b/docgen/src/examples/e-commerce-infinite/App.js
@@ -20,7 +20,6 @@ import {
   connectInfiniteHits,
   connectStateResults,
 } from 'react-instantsearch/connectors';
-import 'instantsearch.css/themes/reset.css';
 import 'instantsearch.css/themes/algolia.css';
 
 export default function App() {

--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -22,7 +22,6 @@ import {
   connectStateResults,
 } from 'react-instantsearch/connectors';
 import { withUrlSync } from '../urlSync';
-import 'instantsearch.css/themes/reset.css';
 import 'instantsearch.css/themes/algolia.css';
 
 const App = props => (

--- a/docgen/src/examples/media/App.js
+++ b/docgen/src/examples/media/App.js
@@ -14,7 +14,6 @@ import {
   connectSearchBox,
   connectRefinementList,
 } from 'react-instantsearch/connectors';
-import 'instantsearch.css/themes/reset.css';
 import 'instantsearch.css/themes/algolia.css';
 import { withUrlSync } from '../urlSync';
 

--- a/docgen/src/guide/Migration_guide_v5.md
+++ b/docgen/src/guide/Migration_guide_v5.md
@@ -114,6 +114,8 @@ Here is the new jsDelivr links for the theme:
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/algolia-min.css">
 ```
 
+The `reset` theme is ship with the `algolia` one, so no need to import it when you are using the `algolia` theme.
+
 You can also use `npm` to install it, please refer to the [Styling Widgets guide](guide/Styling_widgets.html#via-npm-webpack) for more informations.
 
 The CSS naming convention used for widgets has been changed in favour of the [SUIT CSS](https://suitcss.github.io/) methodology.

--- a/docgen/src/guide/Migration_guide_v5.md
+++ b/docgen/src/guide/Migration_guide_v5.md
@@ -108,6 +108,9 @@ Here is the new jsDelivr links for the theme:
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/reset-min.css">
+
+<!-- or -->
+
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/algolia-min.css">
 ```
 

--- a/docgen/src/guide/Styling_widgets.md
+++ b/docgen/src/guide/Styling_widgets.md
@@ -34,6 +34,8 @@ manually:
 
 We **strongly** recommend that you use at least **reset.css** in order to neglect visual side effects caused by the new HTML semantics.
 
+The `reset` theme is ship with the `algolia` one, so no need to import it when you are using the `algolia` theme.
+
 ### Via CDN
 
 The themes are available on jsDelivr:

--- a/docgen/src/guide/Styling_widgets.md
+++ b/docgen/src/guide/Styling_widgets.md
@@ -52,6 +52,9 @@ You can either copy paste the content in your own app or use a direct link to js
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/reset-min.css">
+
+<!-- or -->
+
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/algolia-min.css">
 ```
 
@@ -66,6 +69,9 @@ App.js:
 
 ```js
 import 'instantsearch.css/themes/reset.css';
+
+// or
+
 import 'instantsearch.css/themes/algolia.css';
 ```
 

--- a/packages/react-instantsearch/examples/geo-search/src/index.js
+++ b/packages/react-instantsearch/examples/geo-search/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
-import 'instantsearch.css/themes/reset.css';
 import 'instantsearch.css/themes/algolia.css';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/react-instantsearch/examples/multi-index/src/index.js
+++ b/packages/react-instantsearch/examples/multi-index/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
-import 'instantsearch.css/themes/reset.css';
 import 'instantsearch.css/themes/algolia.css';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/react-instantsearch/examples/next-app/components/head.js
+++ b/packages/react-instantsearch/examples/next-app/components/head.js
@@ -33,10 +33,6 @@ export const Head = props => (
     <meta property="og:image:height" content="630" />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/reset-min.css"
-    />
-    <link
-      rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.0.0/themes/algolia-min.css"
     />
     <link rel="stylesheet" href="../static/instantsearch.css" />

--- a/packages/react-instantsearch/examples/react-router-v3/src/index.js
+++ b/packages/react-instantsearch/examples/react-router-v3/src/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import { Router, Route, browserHistory } from 'react-router';
-import 'instantsearch.css/themes/reset.css';
 import 'instantsearch.css/themes/algolia.css';
 
 ReactDOM.render(

--- a/packages/react-instantsearch/examples/react-router/src/index.js
+++ b/packages/react-instantsearch/examples/react-router/src/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
-import 'instantsearch.css/themes/reset.css';
 import 'instantsearch.css/themes/algolia.css';
 
 ReactDOM.render(

--- a/stories/util.js
+++ b/stories/util.js
@@ -10,7 +10,6 @@ import {
 } from '../packages/react-instantsearch/dom';
 import { connectHits } from '../packages/react-instantsearch/connectors';
 import { linkTo } from '@storybook/addon-links';
-import 'instantsearch.css/themes/reset.css';
 import 'instantsearch.css/themes/algolia.css';
 
 const Wrap = props => (


### PR DESCRIPTION
**Summary**

Remove the import of the `reset` from the documentation & examples, because it's already loaded with the `algolia` theme.