### PR TITLE
feat(connectStateResults): expose isSearchStalled

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectStateResults.js
+++ b/packages/react-instantsearch/src/connectors/connectStateResults.js
@@ -12,6 +12,7 @@ import { getResults } from '../core/indexUtils';
  * @providedPropType {object} allSearchResults - In case of multiple indices you can retrieve all the results
  * @providedPropType {string} error - If the search failed, the error will be logged here.
  * @providedPropType {boolean} searching - If there is a search in progress.
+ * @providedPropType {boolean} isSearchStalled - Flag that indicates if React InstantSearch has detected that searches are stalled.
  * @providedPropType {boolean} searchingForFacetValues - If there is a search in a list in progress.
  * @providedPropType {object} props - component props.
  * @example
@@ -46,11 +47,13 @@ export default createConnector({
 
   getProvidedProps(props, searchState, searchResults) {
     const results = getResults(searchResults, this.context);
+
     return {
       searchState,
       searchResults: results,
       allSearchResults: searchResults.results,
       searching: searchResults.searching,
+      isSearchStalled: searchResults.isSearchStalled,
       error: searchResults.error,
       searchingForFacetValues: searchResults.searchingForFacetValues,
       props,

--- a/packages/react-instantsearch/src/connectors/connectStateResults.test.js
+++ b/packages/react-instantsearch/src/connectors/connectStateResults.test.js
@@ -1,14 +1,17 @@
-/* eslint-env jest, jasmine */
-
 import connect from './connectStateResults';
-jest.mock('../core/createConnector');
 
-let props;
+jest.mock('../core/createConnector');
 
 describe('connectStateResults', () => {
   describe('single index', () => {
-    const context = { context: { ais: { mainTargetedIndex: 'index' } } };
+    const context = {
+      context: {
+        ais: { mainTargetedIndex: 'index' },
+      },
+    };
+
     const getProvidedProps = connect.getProvidedProps.bind(context);
+
     it('provides the correct props to the component', () => {
       const searchState = { state: 'state' };
       const error = 'error';
@@ -21,8 +24,7 @@ describe('connectStateResults', () => {
         searchingForFacetValues,
       };
 
-      props = getProvidedProps({ props: 'props' }, searchState, searchResults);
-      expect(props).toEqual({
+      const expectation = {
         searchState,
         searchResults: searchResults.results,
         allSearchResults: searchResults.results,
@@ -30,9 +32,18 @@ describe('connectStateResults', () => {
         searching,
         searchingForFacetValues,
         props: { props: 'props' },
-      });
+      };
+
+      const actual = getProvidedProps(
+        { props: 'props' },
+        searchState,
+        searchResults
+      );
+
+      expect(actual).toEqual(expectation);
     });
   });
+
   describe('multi index', () => {
     const context = {
       context: {
@@ -40,7 +51,9 @@ describe('connectStateResults', () => {
         multiIndexContext: { targetedIndex: 'first' },
       },
     };
+
     const getProvidedProps = connect.getProvidedProps.bind(context);
+
     it('provides the correct props to the component', () => {
       const searchState = { state: 'state' };
       const error = 'error';
@@ -56,8 +69,7 @@ describe('connectStateResults', () => {
         searchingForFacetValues,
       };
 
-      props = getProvidedProps({ props: 'props' }, searchState, searchResults);
-      expect(props).toEqual({
+      const expectation = {
         searchState,
         searchResults: searchResults.results.first,
         allSearchResults: searchResults.results,
@@ -65,7 +77,15 @@ describe('connectStateResults', () => {
         searching,
         searchingForFacetValues,
         props: { props: 'props' },
-      });
+      };
+
+      const actual = getProvidedProps(
+        { props: 'props' },
+        searchState,
+        searchResults
+      );
+
+      expect(actual).toEqual(expectation);
     });
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectStateResults.test.js
+++ b/packages/react-instantsearch/src/connectors/connectStateResults.test.js
@@ -16,11 +16,13 @@ describe('connectStateResults', () => {
       const searchState = { state: 'state' };
       const error = 'error';
       const searching = true;
+      const isSearchStalled = true;
       const searchingForFacetValues = true;
       const searchResults = {
         results: { nbHits: 25, hits: [] },
         error,
         searching,
+        isSearchStalled,
         searchingForFacetValues,
       };
 
@@ -28,10 +30,11 @@ describe('connectStateResults', () => {
         searchState,
         searchResults: searchResults.results,
         allSearchResults: searchResults.results,
+        props: { props: 'props' },
         error,
         searching,
+        isSearchStalled,
         searchingForFacetValues,
-        props: { props: 'props' },
       };
 
       const actual = getProvidedProps(
@@ -58,6 +61,7 @@ describe('connectStateResults', () => {
       const searchState = { state: 'state' };
       const error = 'error';
       const searching = true;
+      const isSearchStalled = true;
       const searchingForFacetValues = true;
       const searchResults = {
         results: {
@@ -66,6 +70,7 @@ describe('connectStateResults', () => {
         },
         error,
         searching,
+        isSearchStalled,
         searchingForFacetValues,
       };
 
@@ -73,10 +78,11 @@ describe('connectStateResults', () => {
         searchState,
         searchResults: searchResults.results.first,
         allSearchResults: searchResults.results,
+        props: { props: 'props' },
         error,
         searching,
+        isSearchStalled,
         searchingForFacetValues,
-        props: { props: 'props' },
       };
 
       const actual = getProvidedProps(


### PR DESCRIPTION
**Summary**

This PR expose the flag `isSearchStalled` through the `connectStateResults` connector.  It could be interesting to have this information for an Autocomplete experience for example. In order to avoid to inject this props everywhere we can compose the connectors.

```js
const AutoCompleteConnected = connectAutoComplete(connectStateResults(AutoComplete));
```