### PR TITLE
fix(StarRating): move to 1 based instead of 0

### DIFF
--- a/packages/react-instantsearch/src/components/StarRating.js
+++ b/packages/react-instantsearch/src/components/StarRating.js
@@ -131,8 +131,8 @@ class StarRating extends Component {
 
     // min & max are always set when there is a results, otherwise it means
     // that we don't want to render anything since we don't have any values.
-    const limitMin = min !== undefined && min >= 0 ? min : 0;
-    const limitMax = max !== undefined && max >= 0 ? max : -1;
+    const limitMin = min !== undefined && min >= 0 ? min : 1;
+    const limitMax = max !== undefined && max >= 0 ? max : 0;
     const inclusiveLength = limitMax - limitMin + 1;
     const safeInclusiveLength = Math.max(inclusiveLength, 0);
 

--- a/packages/react-instantsearch/src/components/StarRating.test.js
+++ b/packages/react-instantsearch/src/components/StarRating.test.js
@@ -104,9 +104,9 @@ describe('StarRating', () => {
     }).not.toThrow();
   });
 
-  it('expect to not throw when only max is defined', () => {
-    expect(() => {
-      renderer.create(
+  it('expect to render when only max is defined', () => {
+    const tree = renderer
+      .create(
         <StarRating
           createURL={() => '#'}
           refine={() => null}
@@ -124,11 +124,12 @@ describe('StarRating', () => {
           ]}
           canRefine={true}
         />
-      );
-    }).not.toThrow();
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
-  it('expect to render from from 0 when min is negative', () => {
+  it('expect to render from from 1 when min is negative', () => {
     const tree = renderer
       .create(
         <StarRating

--- a/packages/react-instantsearch/src/components/__snapshots__/StarRating.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/StarRating.test.js.snap
@@ -180,7 +180,7 @@ exports[`StarRating applies translations 1`] = `
 </div>
 `;
 
-exports[`StarRating expect to render from from 0 when min is negative 1`] = `
+exports[`StarRating expect to render from from 1 when min is negative 1`] = `
 <div
   className="ais-StarRating__root"
 >
@@ -324,11 +324,9 @@ exports[`StarRating expect to render from from 0 when min is negative 1`] = `
       14
     </span>
   </a>
-  <a
+  <div
     className="ais-StarRating__ratingLink ais-StarRating__ratingLinkSelected"
     disabled={false}
-    href="#"
-    onClick={[Function]}
   >
     <span
       className="ais-StarRating__ratingIcon ais-StarRating__ratingIconSelected"
@@ -358,6 +356,48 @@ exports[`StarRating expect to render from from 0 when min is negative 1`] = `
     >
       15
     </span>
+  </div>
+</div>
+`;
+
+exports[`StarRating expect to render nothing when min is higher than max 1`] = `
+<div
+  className="ais-StarRating__root"
+/>
+`;
+
+exports[`StarRating expect to render when only max is defined 1`] = `
+<div
+  className="ais-StarRating__root"
+>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      3
+    </span>
   </a>
   <a
     className="ais-StarRating__ratingLink"
@@ -366,13 +406,36 @@ exports[`StarRating expect to render from from 0 when min is negative 1`] = `
     onClick={[Function]}
   >
     <span
-      className="ais-StarRating__ratingIconEmpty"
+      className="ais-StarRating__ratingIcon"
+    />
+    <span
+      className="ais-StarRating__ratingIcon"
     />
     <span
       className="ais-StarRating__ratingIconEmpty"
     />
     <span
-      className="ais-StarRating__ratingIconEmpty"
+      className="ais-StarRating__ratingLabel"
+    >
+       & Up
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="ais-StarRating__ratingCount"
+    >
+      5
+    </span>
+  </a>
+  <a
+    className="ais-StarRating__ratingLink"
+    disabled={false}
+    href="#"
+    onClick={[Function]}
+  >
+    <span
+      className="ais-StarRating__ratingIcon"
     />
     <span
       className="ais-StarRating__ratingIconEmpty"
@@ -391,16 +454,10 @@ exports[`StarRating expect to render from from 0 when min is negative 1`] = `
     <span
       className="ais-StarRating__ratingCount"
     >
-      15
+      6
     </span>
   </a>
 </div>
-`;
-
-exports[`StarRating expect to render nothing when min is higher than max 1`] = `
-<div
-  className="ais-StarRating__root"
-/>
 `;
 
 exports[`StarRating supports passing max/min values 1`] = `


### PR DESCRIPTION
**Summary**

With the update of the `StarRating` widget I move for a zero based approach. But the most common approach is to have a 1 based menu. It could have some weird effect when you only set the `max` value on the first load.

**Before**

![before](https://user-images.githubusercontent.com/6513513/35858144-b429723e-0b3b-11e8-99db-a606640de6f8.gif)


**After**

![after](https://user-images.githubusercontent.com/6513513/35858139-b0cbd352-0b3b-11e8-9539-eb8ecb9c944c.gif)
