### PR TITLE
fix(connectRange): update default refinement propTypes

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -18,7 +18,7 @@ import createConnector from '../core/createConnector';
  * @kind connector
  * @requirements The attribute passed to the `attributeName` prop must be holding numerical values.
  * @propType {string} attributeName - Name of the attribute for faceting
- * @propType {{min: number, max: number}} [defaultRefinement] - Default searchState of the widget containing the start and the end of the range.
+ * @propType {{min?: number, max?: number}} [defaultRefinement] - Default searchState of the widget containing the start and the end of the range.
  * @propType {number} [min] - Minimum value. When this isn't set, the minimum value will be automatically computed by Algolia using the data in the index.
  * @propType {number} [max] - Maximum value. When this isn't set, the maximum value will be automatically computed by Algolia using the data in the index.
  * @propType {number} [precision=2] - Number of digits after decimal point to use.
@@ -185,8 +185,8 @@ export default createConnector({
     id: PropTypes.string,
     attributeName: PropTypes.string.isRequired,
     defaultRefinement: PropTypes.shape({
-      min: PropTypes.number.isRequired,
-      max: PropTypes.number.isRequired,
+      min: PropTypes.number,
+      max: PropTypes.number,
     }),
     min: PropTypes.number,
     max: PropTypes.number,

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -72,6 +72,18 @@ stories
     'with default value',
     () => (
       <WrapWithHits linkedStoryGroup="RangeInput">
+        <RangeInput attributeName="price" defaultRefinement={{ min: 50 }} />
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with default values',
+    () => (
+      <WrapWithHits linkedStoryGroup="RangeInput">
         <RangeInput
           attributeName="price"
           defaultRefinement={{ min: 50, max: 200 }}


### PR DESCRIPTION
**Summary**

Fix #564 

With the current implementation when we provide a `defaultRefinement` to `connectRange` we must pass an object with both `min` & `max`. There are some cases when we want to pass only a min, max or even an empty object. In the latter case it allow the widget to be "controlled" by the `defaultRefinement`. See #892.
