### PR TITLE
fix(IndexUtils): avoid throw an error when cleanUp multi index

### DIFF
--- a/packages/react-instantsearch/src/core/indexUtils.js
+++ b/packages/react-instantsearch/src/core/indexUtils.js
@@ -189,7 +189,7 @@ export function getCurrentRefinementValue(
 export function cleanUpValue(searchState, context, id) {
   const index = getIndex(context);
   const { namespace, attributeName } = getNamespaceAndAttributeName(id);
-  if (hasMultipleIndex(context)) {
+  if (hasMultipleIndex(context) && Boolean(searchState.indices)) {
     return namespace
       ? {
           ...searchState,

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -497,6 +497,20 @@ describe('utility method for manipulating the search state', () => {
           },
         },
       });
+
+      // When nothing is refine the searchState doesn't have the indices
+      // attribute even if we are in a context with <Index>. This should
+      // not happen, the searchState should always be in sync (indices + no values).
+      searchState = {
+        page: 1,
+      };
+
+      searchState = cleanUpValue(searchState, context, 'namespace.refinement');
+
+      expect(searchState).toEqual({
+        page: 1,
+        namespace: {},
+      });
     });
 
     it('get results', () => {


### PR DESCRIPTION
**Summary**

Fix #986 

In a multi index context when a widget is unmount without having be refine it throws an error. The `searchState` is not always in sync with the widgets. On the first render the `searchState` will be an empty object. So when the widget is unmount the lib will try to cleanup the `indices` attribute. Since this attribute is missing the lib throws an error.

In order to avoid the error, before the cleanup we need to ensure that the we are in a multi index context but also that the `indices` attribute exist.

**Before**

![before](https://user-images.githubusercontent.com/6513513/36790755-2766f6a2-1c96-11e8-8696-50af71f752a3.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/36790759-2a7124b2-1c96-11e8-8dc1-eee7cf151d7d.gif)
