### PR TITLE
refactor: GeoSearch example

### DIFF
--- a/packages/react-instantsearch/examples/geo-search/src/App.js
+++ b/packages/react-instantsearch/examples/geo-search/src/App.js
@@ -115,10 +115,15 @@ function CustomMarker() {
 }
 
 function HitsMap({ hits, onLatLngChange }) {
+  if (!hits.length) {
+    return null;
+  }
+
   const availableSpace = {
     width: document.body.getBoundingClientRect().width * 5 / 12,
     height: 400,
   };
+
   const boundingPoints = hits.reduce(
     (bounds, hit) => {
       const pos = hit;
@@ -134,17 +139,18 @@ function HitsMap({ hits, onLatLngChange }) {
       se: { lat: 85, lng: -180 },
     }
   );
-  const boundsConfig =
-    hits.length > 0
-      ? fitBounds(boundingPoints, availableSpace)
-      : { zoom: 11, center: { lat: -85, lng: 180 } };
+
+  const boundsConfig = fitBounds(boundingPoints, availableSpace);
+
   const markers = hits.map(hit => (
     <CustomMarker lat={hit.lat} lng={hit.lng} key={hit.objectID} />
   ));
+
   const options = {
     minZoomOverride: true,
     minZoom: 2,
   };
+
   return (
     <GoogleMap
       options={() => options}

--- a/packages/react-instantsearch/examples/geo-search/src/App.js
+++ b/packages/react-instantsearch/examples/geo-search/src/App.js
@@ -1,4 +1,9 @@
-import { InstantSearch, SearchBox, Configure } from 'react-instantsearch/dom';
+import {
+  InstantSearch,
+  SearchBox,
+  Configure,
+  Pagination,
+} from 'react-instantsearch/dom';
 import { connectHits } from 'react-instantsearch/connectors';
 
 import PropTypes from 'prop-types';
@@ -35,6 +40,7 @@ class App extends Component {
     this.setState(prevState => ({
       searchState: {
         ...prevState.searchState,
+        page: 1,
         query: '',
       },
       aroundLatLng: `${lat},${lng}`,
@@ -81,6 +87,7 @@ class App extends Component {
         <div className="map">
           <ConnectedHitsMap onLatLngChange={this.onLatLngChange} />
         </div>
+        <Pagination />
       </InstantSearch>
     );
   }


### PR DESCRIPTION
**Summary**

Avoid to render the map when there is no results, otherwise the map doesn't update. Add the `<Pagination>` to illustrate the usage of `Configure` for control the position & reset the page.

On the first example when we click on the map the page is not reset, on the second example the page is reset.

**Before**

![before](https://user-images.githubusercontent.com/6513513/36836818-b63d38b0-1d3a-11e8-82bf-48016f23fb47.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/36836797-a757b92e-1d3a-11e8-955d-f4f0e8927577.gif)
