### PR TITLE
fix(connectInfiniteHits): always provide an array for hits

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -43,17 +43,17 @@ export default createConnector({
   getProvidedProps(props, searchState, searchResults) {
     const results = getResults(searchResults, this.context);
 
+    this._allResults = this._allResults || [];
+
     if (!results) {
-      this._allResults = [];
       return {
-        hits: this._allResults,
+        hits: [],
         hasMore: false,
       };
     }
 
     const { hits, page, nbPages } = results;
 
-    // If it is the same page we do not touch the page result list
     if (page === 0) {
       this._allResults = hits;
     } else if (page > this.previousPage) {
@@ -64,7 +64,9 @@ export default createConnector({
 
     const lastPageIndex = nbPages - 1;
     const hasMore = page < lastPageIndex;
+
     this.previousPage = page;
+
     return {
       hits: this._allResults,
       hasMore,

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -202,6 +202,33 @@ describe('connectInfiniteHits', () => {
       const state1 = refine(props, state0);
       expect(state1).toEqual({ page: 1 });
     });
+
+    it('expect to always return an array of hits', () => {
+      const context = createSingleIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
+
+      const props = {};
+      const searchState = {};
+
+      // Retrieve the results from the cache that's why
+      // the page it's not zero on the first render
+      const searchResults = {
+        results: {
+          hits: [{}, {}, {}],
+          page: 1,
+          nbPages: 3,
+        },
+      };
+
+      const expectation = {
+        hits: [],
+        hasMore: true,
+      };
+
+      const actual = getProvidedProps(props, searchState, searchResults);
+
+      expect(actual).toEqual(expectation);
+    });
   });
 
   describe('multi index', () => {

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -1,28 +1,42 @@
-import connect from './connectInfiniteHits.js';
+import connect from './connectInfiniteHits';
 
 jest.mock('../core/createConnector');
 
 describe('connectInfiniteHits', () => {
   describe('single index', () => {
-    const context = { context: { ais: { mainTargetedIndex: 'index' } } };
-    const getProvidedProps = connect.getProvidedProps.bind(context);
-    const refine = connect.refine.bind(context);
+    const createSingleIndexContext = () => ({
+      context: {
+        ais: {
+          mainTargetedIndex: 'index',
+        },
+      },
+    });
+
     it('provides the current hits to the component', () => {
+      const context = createSingleIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
+
       const hits = [{}];
       const props = getProvidedProps(null, null, {
         results: { hits, page: 0, hitsPerPage: 2, nbPages: 3 },
       });
+
       expect(props).toEqual({ hits, hasMore: true });
     });
 
     it('accumulate hits internally', () => {
+      const context = createSingleIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
+
       const hits = [{}, {}];
       const hits2 = [{}, {}];
       const res1 = getProvidedProps(null, null, {
         results: { hits, page: 0, hitsPerPage: 2, nbPages: 3 },
       });
+
       expect(res1.hits).toEqual(hits);
       expect(res1.hasMore).toBe(true);
+
       const res2 = getProvidedProps(null, null, {
         results: {
           hits: hits2,
@@ -31,19 +45,26 @@ describe('connectInfiniteHits', () => {
           nbPages: 3,
         },
       });
+
       expect(res2.hits).toEqual([...hits, ...hits2]);
       expect(res2.hasMore).toBe(true);
     });
 
     it('accumulate hits internally while changing hitsPerPage configuration', () => {
+      const context = createSingleIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
+
       const hits = [{}, {}, {}, {}, {}, {}];
       const hits2 = [{}, {}, {}, {}, {}, {}];
       const hits3 = [{}, {}, {}, {}, {}, {}, {}, {}];
+
       const res1 = getProvidedProps(null, null, {
         results: { hits, page: 0, hitsPerPage: 6, nbPages: 10 },
       });
+
       expect(res1.hits).toEqual(hits);
       expect(res1.hasMore).toBe(true);
+
       const res2 = getProvidedProps(null, null, {
         results: {
           hits: hits2,
@@ -52,8 +73,10 @@ describe('connectInfiniteHits', () => {
           nbPages: 10,
         },
       });
+
       expect(res2.hits).toEqual([...hits, ...hits2]);
       expect(res2.hasMore).toBe(true);
+
       let res3 = getProvidedProps(null, null, {
         results: {
           hits: hits3,
@@ -62,8 +85,11 @@ describe('connectInfiniteHits', () => {
           nbPages: 10,
         },
       });
+
       expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
       expect(res3.hasMore).toBe(true);
+
+      // re-render with the same property
       res3 = getProvidedProps(null, null, {
         results: {
           hits: hits3,
@@ -71,18 +97,23 @@ describe('connectInfiniteHits', () => {
           hitsPerPage: 8,
           nbPages: 10,
         },
-      }); // re-render with the same property
+      });
+
       expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
       expect(res3.hasMore).toBe(true);
     });
 
     it('should not reset while accumulating results', () => {
-      const nbPages = 100;
-      let allHits = [];
+      const context = createSingleIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
 
+      const hits = [{}, {}];
+      const nbPages = 100;
+
+      let allHits = [];
       for (let page = 0; page < nbPages - 1; page++) {
-        const hits = [{}, {}];
         allHits = [...allHits, ...hits];
+
         const res = getProvidedProps(null, null, {
           results: {
             hits,
@@ -91,13 +122,14 @@ describe('connectInfiniteHits', () => {
             nbPages,
           },
         });
+
         expect(res.hits).toEqual(allHits);
         expect(res.hits).toHaveLength((page + 1) * 2);
         expect(res.hasMore).toBe(true);
       }
 
-      const hits = [{}, {}];
       allHits = [...allHits, ...hits];
+
       const res = getProvidedProps(null, null, {
         results: {
           hits,
@@ -106,18 +138,24 @@ describe('connectInfiniteHits', () => {
           nbPages,
         },
       });
+
       expect(res.hits).toHaveLength(nbPages * 2);
       expect(res.hits).toEqual(allHits);
       expect(res.hasMore).toBe(false);
     });
 
     it('Indicates the last page after several pages', () => {
+      const context = createSingleIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
+
       const hits = [{}, {}];
       const hits2 = [{}, {}];
       const hits3 = [{}];
+
       getProvidedProps(null, null, {
         results: { hits, page: 0, hitsPerPage: 2, nbPages: 3 },
       });
+
       getProvidedProps(null, null, {
         results: {
           hits: hits2,
@@ -126,6 +164,7 @@ describe('connectInfiniteHits', () => {
           nbPages: 3,
         },
       });
+
       const props = getProvidedProps(null, null, {
         results: {
           hits: hits3,
@@ -134,13 +173,16 @@ describe('connectInfiniteHits', () => {
           nbPages: 3,
         },
       });
+
       expect(props.hits).toEqual([...hits, ...hits2, ...hits3]);
       expect(props.hasMore).toBe(false);
     });
 
     it('adds 1 to page when calling refine', () => {
-      const props = {};
+      const context = createSingleIndexContext();
+      const refine = connect.refine.bind(context);
 
+      const props = {};
       const state0 = {};
 
       const state1 = refine(props, state0);
@@ -151,86 +193,120 @@ describe('connectInfiniteHits', () => {
     });
 
     it('automatically converts String state to Number', () => {
-      const props = {};
+      const context = createSingleIndexContext();
+      const refine = connect.refine.bind(context);
 
+      const props = {};
       const state0 = { page: '0' };
 
       const state1 = refine(props, state0);
       expect(state1).toEqual({ page: 1 });
     });
   });
+
   describe('multi index', () => {
-    const context = {
+    const createMultiIndexContext = () => ({
       context: {
-        ais: { mainTargetedIndex: 'first' },
-        multiIndexContext: { targetedIndex: 'second' },
+        ais: {
+          mainTargetedIndex: 'first',
+        },
+        multiIndexContext: {
+          targetedIndex: 'second',
+        },
       },
-    };
-    const getProvidedProps = connect.getProvidedProps.bind(context);
+    });
+
     it('provides the current hits to the component', () => {
+      const context = createMultiIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
+
       const hits = [{}];
       const props = getProvidedProps(null, null, {
         results: { second: { hits, page: 0, hitsPerPage: 2, nbPages: 3 } },
       });
+
       expect(props).toEqual({ hits, hasMore: true });
     });
 
     it('accumulate hits internally', () => {
+      const context = createMultiIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
+
       const hits = [{}, {}];
       const hits2 = [{}, {}];
+
       const res1 = getProvidedProps(null, null, {
         results: { second: { hits, page: 0, hitsPerPage: 2, nbPages: 3 } },
       });
+
       expect(res1.hits).toEqual(hits);
       expect(res1.hasMore).toBe(true);
+
       const res2 = getProvidedProps(null, null, {
         results: {
           second: { hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3 },
         },
       });
+
       expect(res2.hits).toEqual([...hits, ...hits2]);
       expect(res2.hasMore).toBe(true);
     });
 
     it('accumulate hits internally while changing hitsPerPage configuration', () => {
+      const context = createMultiIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
+
       const hits = [{}, {}, {}, {}, {}, {}];
       const hits2 = [{}, {}, {}, {}, {}, {}];
       const hits3 = [{}, {}, {}, {}, {}, {}, {}, {}];
+
       const res1 = getProvidedProps(null, null, {
         results: { second: { hits, page: 0, hitsPerPage: 6, nbPages: 10 } },
       });
+
       expect(res1.hits).toEqual(hits);
       expect(res1.hasMore).toBe(true);
+
       const res2 = getProvidedProps(null, null, {
         results: {
           second: { hits: hits2, page: 1, hitsPerPage: 6, nbPages: 10 },
         },
       });
+
       expect(res2.hits).toEqual([...hits, ...hits2]);
       expect(res2.hasMore).toBe(true);
+
       let res3 = getProvidedProps(null, null, {
         results: {
           second: { hits: hits3, page: 2, hitsPerPage: 8, nbPages: 10 },
         },
       });
+
       expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
       expect(res3.hasMore).toBe(true);
+
+      // re-render with the same property
       res3 = getProvidedProps(null, null, {
         results: {
           second: { hits: hits3, page: 2, hitsPerPage: 8, nbPages: 10 },
         },
-      }); // re-render with the same property
+      });
+
       expect(res3.hits).toEqual([...hits, ...hits2, ...hits3]);
       expect(res3.hasMore).toBe(true);
     });
 
     it('should not reset while accumulating results', () => {
-      const nbPages = 100;
-      let allHits = [];
+      const context = createMultiIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
 
+      const hits = [{}, {}];
+      const nbPages = 100;
+
+      let allHits = [];
       for (let page = 0; page < nbPages - 1; page++) {
-        const hits = [{}, {}];
         allHits = [...allHits, ...hits];
+
         const res = getProvidedProps(null, null, {
           results: {
             second: {
@@ -241,13 +317,14 @@ describe('connectInfiniteHits', () => {
             },
           },
         });
+
         expect(res.hits).toEqual(allHits);
         expect(res.hits).toHaveLength((page + 1) * 2);
         expect(res.hasMore).toBe(true);
       }
 
-      const hits = [{}, {}];
       allHits = [...allHits, ...hits];
+
       const res = getProvidedProps(null, null, {
         results: {
           second: {
@@ -258,28 +335,36 @@ describe('connectInfiniteHits', () => {
           },
         },
       });
+
       expect(res.hits).toHaveLength(nbPages * 2);
       expect(res.hits).toEqual(allHits);
       expect(res.hasMore).toBe(false);
     });
 
     it('Indicates the last page after several pages', () => {
+      const context = createMultiIndexContext();
+      const getProvidedProps = connect.getProvidedProps.bind(context);
+
       const hits = [{}, {}];
       const hits2 = [{}, {}];
       const hits3 = [{}];
+
       getProvidedProps(null, null, {
         results: { second: { hits, page: 0, hitsPerPage: 2, nbPages: 3 } },
       });
+
       getProvidedProps(null, null, {
         results: {
           second: { hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3 },
         },
       });
+
       const props = getProvidedProps(null, null, {
         results: {
           second: { hits: hits3, page: 2, hitsPerPage: 2, nbPages: 3 },
         },
       });
+
       expect(props.hits).toEqual([...hits, ...hits2, ...hits3]);
       expect(props.hasMore).toBe(false);
     });


### PR DESCRIPTION
**Summary**

In some cases it might happen that on the first render the `results` is not empty. It will happen if the component has been already mount previously for example. In that the case the widget will return an `undefined` value for this hits because all the condition are `false`. So we need to ensure that on every render the `hits` will be an array.