### PR TITLE
poc: connectGeoSeach with createConnector

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react": "16.3.1",
     "react-autosuggest": "9.3.4",
     "react-dom": "16.3.1",
+    "react-google-maps": "9.4.5",
     "rheostat": "2.1.3",
     "storybook-addon-a11y": "3.1.9",
     "storybook-addon-jsx": "5.3.0",

--- a/packages/react-instantsearch/connectors.js
+++ b/packages/react-instantsearch/connectors.js
@@ -51,3 +51,6 @@ export {
 export {
   default as connectStateResults,
 } from './src/connectors/connectStateResults.js';
+export {
+  default as connectGeoSearch,
+} from './src/connectors/connectGeoSearch.js';

--- a/packages/react-instantsearch/dom.js
+++ b/packages/react-instantsearch/dom.js
@@ -39,3 +39,4 @@ export { default as Stats } from './src/widgets/Stats.js';
 export { default as ToggleRefinement } from './src/widgets/ToggleRefinement.js';
 export { default as Panel } from './src/widgets/Panel.js';
 export { default as Breadcrumb } from './src/widgets/Breadcrumb';
+export { default as GeoSearch } from './src/widgets/GeoSearch';

--- a/packages/react-instantsearch/src/components/GeoSearch.js
+++ b/packages/react-instantsearch/src/components/GeoSearch.js
@@ -33,6 +33,8 @@ class GeoSearch extends Component {
     this.fitViewToBounds();
   }
 
+  createRef = c => (this.element = c);
+
   onChange = () => {
     const { isRefineOnMapMove, setMapMoveSinceLastRefine } = this.props;
 
@@ -61,7 +63,7 @@ class GeoSearch extends Component {
 
     if (isFitBoundsEnable) {
       this.isUserInteraction = false;
-      this.mapElement.fitBounds(
+      this.element.fitBounds(
         items.reduce(
           (acc, item) =>
             acc.extend({ lat: item._geoloc.lat, lng: item._geoloc.lng }),
@@ -75,8 +77,8 @@ class GeoSearch extends Component {
   refineWithMap = () => {
     const { refine, setMapMoveSinceLastRefine } = this.props;
 
-    const ne = this.mapElement.getBounds().getNorthEast();
-    const sw = this.mapElement.getBounds().getSouthWest();
+    const ne = this.element.getBounds().getNorthEast();
+    const sw = this.element.getBounds().getSouthWest();
 
     refine({
       northEast: { lat: ne.lat(), lng: ne.lng() },
@@ -106,7 +108,7 @@ class GeoSearch extends Component {
     return (
       <div>
         <GoogleMap
-          ref={c => (this.mapElement = c)}
+          ref={this.createRef}
           defaultZoom={8}
           defaultCenter={{ lat: -34.397, lng: 150.644 }}
           options={{

--- a/packages/react-instantsearch/src/components/GeoSearch.js
+++ b/packages/react-instantsearch/src/components/GeoSearch.js
@@ -57,8 +57,7 @@ class GeoSearch extends Component {
 
   fitViewToBounds() {
     const { items, hasMapMoveSinceLastRefine, isRefinedWithMap } = this.props;
-    const isFitBoundsEnable =
-      !hasMapMoveSinceLastRefine && !isRefinedWithMap && !this.isPendingRefine;
+    const isFitBoundsEnable = !hasMapMoveSinceLastRefine && !isRefinedWithMap;
 
     if (isFitBoundsEnable) {
       this.isUserInteraction = false;
@@ -79,20 +78,20 @@ class GeoSearch extends Component {
     const ne = this.mapElement.getBounds().getNorthEast();
     const sw = this.mapElement.getBounds().getSouthWest();
 
-    setMapMoveSinceLastRefine(false);
-
     refine({
       northEast: { lat: ne.lat(), lng: ne.lng() },
       southWest: { lat: sw.lat(), lng: sw.lng() },
     });
+
+    setMapMoveSinceLastRefine(false);
   };
 
   clearMapRefinement = () => {
     const { refine, setMapMoveSinceLastRefine } = this.props;
 
-    setMapMoveSinceLastRefine(false);
-
     refine();
+
+    setMapMoveSinceLastRefine(false);
   };
 
   render() {

--- a/packages/react-instantsearch/src/components/GeoSearch.js
+++ b/packages/react-instantsearch/src/components/GeoSearch.js
@@ -1,0 +1,153 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* global google */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import {
+  GoogleMap,
+  Marker,
+  withGoogleMap,
+  withScriptjs,
+} from 'react-google-maps';
+
+class GeoSearch extends Component {
+  static propTypes = {
+    items: PropTypes.arrayOf(PropTypes.object).isRequired,
+    isRefinedWithMap: PropTypes.bool.isRequired,
+    isRefineOnMapMove: PropTypes.bool.isRequired,
+    hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
+    refine: PropTypes.func.isRequired,
+    toggleRefineOnMapMove: PropTypes.func.isRequired,
+    setMapMoveSinceLastRefine: PropTypes.func.isRequired,
+  };
+
+  isMapAlreadyLoaded = false;
+  isPendingRefine = false;
+  isUserInteraction = true;
+
+  componentDidMount() {
+    this.fitViewToBounds();
+  }
+
+  componentDidUpdate() {
+    this.fitViewToBounds();
+  }
+
+  onChange = () => {
+    const { setMapMoveSinceLastRefine } = this.props;
+
+    if (this.isMapAlreadyLoaded && this.isUserInteraction) {
+      this.isPendingRefine = true;
+      setMapMoveSinceLastRefine();
+    }
+  };
+
+  onIdle = () => {
+    const { isRefineOnMapMove } = this.props;
+
+    this.isMapAlreadyLoaded = true;
+
+    if (this.isUserInteraction && this.isPendingRefine && isRefineOnMapMove) {
+      this.refineWithMap();
+
+      this.isPendingRefine = false;
+    }
+  };
+
+  fitViewToBounds() {
+    const { items, hasMapMoveSinceLastRefine, isRefinedWithMap } = this.props;
+
+    if (!hasMapMoveSinceLastRefine && !isRefinedWithMap) {
+      this.isUserInteraction = false;
+      this.mapElement.fitBounds(
+        items.reduce(
+          (acc, item) =>
+            acc.extend({ lat: item._geoloc.lat, lng: item._geoloc.lng }),
+          new google.maps.LatLngBounds()
+        )
+      );
+      this.isUserInteraction = true;
+    }
+  }
+
+  refineWithMap = () => {
+    const { refine } = this.props;
+
+    const ne = this.mapElement.getBounds().getNorthEast();
+    const sw = this.mapElement.getBounds().getSouthWest();
+
+    refine({
+      reset: false,
+      bounds: {
+        northEast: { lat: ne.lat(), lng: ne.lng() },
+        southWest: { lat: sw.lat(), lng: sw.lng() },
+      },
+    });
+  };
+
+  clearMapRefinement = () => {
+    const { refine } = this.props;
+
+    refine({
+      reset: true,
+    });
+  };
+
+  render() {
+    const {
+      items,
+      isRefineOnMapMove,
+      isRefinedWithMap,
+      hasMapMoveSinceLastRefine,
+      toggleRefineOnMapMove,
+    } = this.props;
+
+    return (
+      <div>
+        <GoogleMap
+          ref={c => (this.mapElement = c)}
+          defaultZoom={8}
+          defaultCenter={{ lat: -34.397, lng: 150.644 }}
+          options={{
+            mapTypeControl: false,
+            fullscreenControl: false,
+            streetViewControl: false,
+            clickableIcons: false,
+            zoomControlOptions: {
+              position: google.maps.ControlPosition.LEFT_TOP,
+            },
+          }}
+          onDragStart={this.onChange}
+          onCenterChanged={this.onChange}
+          onZoomChanged={this.onChange}
+          onIdle={this.onIdle}
+        >
+          {items.map(item => (
+            <Marker key={item.objectID} position={item._geoloc} />
+          ))}
+        </GoogleMap>
+
+        {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
+          <label>
+            <input
+              type="checkbox"
+              checked={isRefineOnMapMove}
+              onChange={toggleRefineOnMapMove}
+            />
+            Search as I move the map
+          </label>
+        ) : (
+          <button onClick={this.refineWithMap}>Redo search here</button>
+        )}
+
+        {isRefinedWithMap && (
+          <button onClick={this.clearMapRefinement}>
+            Clear map refinement
+          </button>
+        )}
+      </div>
+    );
+  }
+}
+
+export default withScriptjs(withGoogleMap(GeoSearch));

--- a/packages/react-instantsearch/src/components/GeoSearch.js
+++ b/packages/react-instantsearch/src/components/GeoSearch.js
@@ -34,20 +34,21 @@ class GeoSearch extends Component {
   }
 
   onChange = () => {
-    const { setMapMoveSinceLastRefine } = this.props;
+    const { isRefineOnMapMove, setMapMoveSinceLastRefine } = this.props;
 
     if (this.isMapAlreadyLoaded && this.isUserInteraction) {
-      this.isPendingRefine = true;
-      setMapMoveSinceLastRefine();
+      setMapMoveSinceLastRefine(true);
+
+      if (isRefineOnMapMove) {
+        this.isPendingRefine = true;
+      }
     }
   };
 
   onIdle = () => {
-    const { isRefineOnMapMove } = this.props;
-
     this.isMapAlreadyLoaded = true;
 
-    if (this.isUserInteraction && this.isPendingRefine && isRefineOnMapMove) {
+    if (this.isUserInteraction && this.isPendingRefine) {
       this.refineWithMap();
 
       this.isPendingRefine = false;
@@ -56,8 +57,10 @@ class GeoSearch extends Component {
 
   fitViewToBounds() {
     const { items, hasMapMoveSinceLastRefine, isRefinedWithMap } = this.props;
+    const isFitBoundsEnable =
+      !hasMapMoveSinceLastRefine && !isRefinedWithMap && !this.isPendingRefine;
 
-    if (!hasMapMoveSinceLastRefine && !isRefinedWithMap) {
+    if (isFitBoundsEnable) {
       this.isUserInteraction = false;
       this.mapElement.fitBounds(
         items.reduce(
@@ -71,26 +74,25 @@ class GeoSearch extends Component {
   }
 
   refineWithMap = () => {
-    const { refine } = this.props;
+    const { refine, setMapMoveSinceLastRefine } = this.props;
 
     const ne = this.mapElement.getBounds().getNorthEast();
     const sw = this.mapElement.getBounds().getSouthWest();
 
+    setMapMoveSinceLastRefine(false);
+
     refine({
-      reset: false,
-      bounds: {
-        northEast: { lat: ne.lat(), lng: ne.lng() },
-        southWest: { lat: sw.lat(), lng: sw.lng() },
-      },
+      northEast: { lat: ne.lat(), lng: ne.lng() },
+      southWest: { lat: sw.lat(), lng: sw.lng() },
     });
   };
 
   clearMapRefinement = () => {
-    const { refine } = this.props;
+    const { refine, setMapMoveSinceLastRefine } = this.props;
 
-    refine({
-      reset: true,
-    });
+    setMapMoveSinceLastRefine(false);
+
+    refine();
   };
 
   render() {

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -38,9 +38,10 @@ export default createConnector({
     hasMapMoveSinceLastRefine: false,
   }),
 
-  getProvidedProps({ searchResults, searchState, setUiState }) {
+  getProvidedProps({ searchResults, searchState, uiState }) {
     // @TODO: Handle multi-index
     const results = searchResults.results;
+    const { state: uiStateValue, update: setUiState } = uiState;
     const searchParameters = results && results._state;
     const isRefinedWithMapFromSearchState = Boolean(searchState[getId()]);
     const isRefinedWithMapFromSearchParameters =
@@ -58,7 +59,9 @@ export default createConnector({
     return {
       // position: null // fetch from somewhere
       items: results ? results.hits.filter(_ => Boolean(_._geoloc)) : [],
+      isRefineOnMapMove: uiStateValue.isRefineOnMapMove,
       toggleRefineOnMapMove: toggleRefineOnMapMove(setUiState),
+      hasMapMoveSinceLastRefine: uiStateValue.hasMapMoveSinceLastRefine,
       setMapMoveSinceLastRefine: setMapMoveSinceLastRefine(setUiState),
       isRefinedWithMap,
     };

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -43,7 +43,7 @@ export default createConnector({
   getProvidedProps({ searchResults, searchState, uiState }) {
     // @TODO: Handle multi-index
     const results = searchResults.results;
-    const { state: uiStateValue, update: setUiState } = uiState;
+    const { value: uiStateValue, updater: uiStateUpdater } = uiState;
     const searchParameters = results && results._state;
     const isRefinedWithMapFromSearchState = Boolean(searchState[getId()]);
     const isRefinedWithMapFromSearchParameters =
@@ -62,9 +62,9 @@ export default createConnector({
       // position: null // fetch from somewhere
       items: results ? results.hits.filter(_ => Boolean(_._geoloc)) : [],
       isRefineOnMapMove: uiStateValue.isRefineOnMapMove,
-      toggleRefineOnMapMove: toggleRefineOnMapMove(setUiState),
+      toggleRefineOnMapMove: toggleRefineOnMapMove(uiStateUpdater),
       hasMapMoveSinceLastRefine: uiStateValue.hasMapMoveSinceLastRefine,
-      setMapMoveSinceLastRefine: setMapMoveSinceLastRefine(setUiState),
+      setMapMoveSinceLastRefine: setMapMoveSinceLastRefine(uiStateUpdater),
       isRefinedWithMap,
     };
   },

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -70,7 +70,6 @@ export default createConnector({
   },
 
   refine({ searchState, nextRefinement }) {
-    // refine({ searchState, nextRefinement, setUiState }) {
     // @TODO: Handle multi-index
     const { northEast: ne, southWest: sw } = nextRefinement || {};
     const boundingBox = ne && sw ? [ne.lat, ne.lng, sw.lat, sw.lng].join() : '';

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -29,16 +29,29 @@ export default createConnector({
     hasMapMoveSinceLastRefine: false,
   }),
 
-  getProvidedProps({ searchState, searchResults, setUiState }) {
+  getProvidedProps({ searchResults, searchState, setUiState }) {
     // @TODO: Handle multi-index
     const results = searchResults.results;
+    const searchParameters = results && results._state;
+    const isRefinedWithMapFromSearchState = Boolean(searchState[getId()]);
+    const isRefinedWithMapFromSearchParameters =
+      searchParameters && Boolean(searchParameters.insideBoundingBox);
+    const isRefinedWithMap =
+      // We read it from both becuase the SearchParameters & the searchState are not always
+      // in sync. When we set the refinement the searchState is used when we clear the refinement
+      // the SearchParameters is used. In the first case when we render the results are not there
+      // so we can't find the value from the results. The most up to date value is the searchState.
+      // But whren we clear the refinement the searchState is immediatly clear even when the items
+      // retrieve are still the one from the previous query with the bounding box. It leads to some
+      // issue with fitBounds.
+      isRefinedWithMapFromSearchState || isRefinedWithMapFromSearchParameters;
 
     return {
       // position: null // fetch from somewhere
       items: results ? results.hits.filter(_ => Boolean(_._geoloc)) : [],
-      isRefinedWithMap: Boolean(searchState[getId()]),
       toggleRefineOnMapMove: toggleRefineOnMapMove(setUiState),
       setMapMoveSinceLastRefine: setMapMoveSinceLastRefine(setUiState),
+      isRefinedWithMap,
     };
   },
 

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -82,11 +82,6 @@ export default createConnector({
     const { northEast: ne, southWest: sw } = nextRefinement || {};
     const boundingBox = ne && sw ? [ne.lat, ne.lng, sw.lat, sw.lng].join() : '';
 
-    // setUiState(() => ({
-    //   hasMapMoveSinceLastRefine: false,
-    //   isRefinedWithMap: !reset,
-    // }));
-
     return {
       ...searchState,
       [getId()]: boundingBox,

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -40,10 +40,18 @@ export default createConnector({
     hasMapMoveSinceLastRefine: false,
   }),
 
-  getProvidedProps({ searchResults, searchState, uiState }) {
+  // eslint-disable-next-line max-params
+  getProvidedProps(
+    props,
+    searchState,
+    searchResults,
+    _,
+    __,
+    uiState,
+    setUiState
+  ) {
     // @TODO: Handle multi-index
     const results = searchResults.results;
-    const { value: uiStateValue, updater: uiStateUpdater } = uiState;
     const searchParameters = results && results._state;
     const isRefinedWithMapFromSearchState = Boolean(searchState[getId()]);
     const isRefinedWithMapFromSearchParameters =
@@ -60,16 +68,16 @@ export default createConnector({
 
     return {
       // position: null // fetch from somewhere
-      items: results ? results.hits.filter(_ => Boolean(_._geoloc)) : [],
-      isRefineOnMapMove: uiStateValue.isRefineOnMapMove,
-      toggleRefineOnMapMove: toggleRefineOnMapMove(uiStateUpdater),
-      hasMapMoveSinceLastRefine: uiStateValue.hasMapMoveSinceLastRefine,
-      setMapMoveSinceLastRefine: setMapMoveSinceLastRefine(uiStateUpdater),
+      items: results ? results.hits.filter(hit => Boolean(hit._geoloc)) : [],
+      isRefineOnMapMove: uiState.isRefineOnMapMove,
+      toggleRefineOnMapMove: toggleRefineOnMapMove(setUiState),
+      hasMapMoveSinceLastRefine: uiState.hasMapMoveSinceLastRefine,
+      setMapMoveSinceLastRefine: setMapMoveSinceLastRefine(setUiState),
       isRefinedWithMap,
     };
   },
 
-  refine({ searchState, nextRefinement }) {
+  refine(props, searchState, nextRefinement) {
     // @TODO: Handle multi-index
     const { northEast: ne, southWest: sw } = nextRefinement || {};
     const boundingBox = ne && sw ? [ne.lat, ne.lng, sw.lat, sw.lng].join() : '';

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -9,9 +9,18 @@ const toggleRefineOnMapMove = update => () =>
   }));
 
 const setMapMoveSinceLastRefine = update => value =>
-  update(() => ({
-    hasMapMoveSinceLastRefine: value,
-  }));
+  update(prevState => {
+    // Prevent useless rendering, only render the first
+    // time we change the value. It will avoid to run
+    // the render on each move.
+    if (prevState.hasMapMoveSinceLastRefine === value) {
+      return null;
+    }
+
+    return {
+      hasMapMoveSinceLastRefine: value,
+    };
+  });
 
 export default createConnector({
   displayName: 'AlgoliaGeoSearch',

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -8,9 +8,9 @@ const toggleRefineOnMapMove = update => () =>
     isRefineOnMapMove: !prevProps.isRefineOnMapMove,
   }));
 
-const setMapMoveSinceLastRefine = update => () =>
+const setMapMoveSinceLastRefine = update => value =>
   update(() => ({
-    hasMapMoveSinceLastRefine: true,
+    hasMapMoveSinceLastRefine: value,
   }));
 
 export default createConnector({
@@ -42,16 +42,16 @@ export default createConnector({
     };
   },
 
-  refine({ searchState, nextRefinement, setUiState }) {
+  refine({ searchState, nextRefinement }) {
+    // refine({ searchState, nextRefinement, setUiState }) {
     // @TODO: Handle multi-index
-    const { bounds = {}, reset = true } = nextRefinement || {};
-    const { northEast: ne, southWest: sw } = bounds;
+    const { northEast: ne, southWest: sw } = nextRefinement || {};
     const boundingBox = ne && sw ? [ne.lat, ne.lng, sw.lat, sw.lng].join() : '';
 
-    setUiState(() => ({
-      hasMapMoveSinceLastRefine: false,
-      isRefinedWithMap: !reset,
-    }));
+    // setUiState(() => ({
+    //   hasMapMoveSinceLastRefine: false,
+    //   isRefinedWithMap: !reset,
+    // }));
 
     return {
       ...searchState,

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -1,0 +1,85 @@
+import PropTypes from 'prop-types';
+import createConnector from '../core/createConnector';
+
+const getId = () => 'geoSearch';
+
+const toggleRefineOnMapMove = update => () =>
+  update(prevProps => ({
+    isRefineOnMapMove: !prevProps.isRefineOnMapMove,
+  }));
+
+const setMapMoveSinceLastRefine = update => () =>
+  update(() => ({
+    hasMapMoveSinceLastRefine: true,
+  }));
+
+export default createConnector({
+  displayName: 'AlgoliaGeoSearch',
+
+  propTypes: {
+    enableRefineOnMapMove: PropTypes.bool,
+  },
+
+  defaultProps: {
+    enableRefineOnMapMove: true,
+  },
+
+  initialUiState: ({ enableRefineOnMapMove }) => ({
+    isRefineOnMapMove: enableRefineOnMapMove,
+    hasMapMoveSinceLastRefine: false,
+  }),
+
+  getProvidedProps({ searchState, searchResults, setUiState }) {
+    // @TODO: Handle multi-index
+    const results = searchResults.results;
+
+    return {
+      // position: null // fetch from somewhere
+      items: results ? results.hits.filter(_ => Boolean(_._geoloc)) : [],
+      isRefinedWithMap: Boolean(searchState[getId()]),
+      toggleRefineOnMapMove: toggleRefineOnMapMove(setUiState),
+      setMapMoveSinceLastRefine: setMapMoveSinceLastRefine(setUiState),
+    };
+  },
+
+  refine({ searchState, nextRefinement, setUiState }) {
+    // @TODO: Handle multi-index
+    const { bounds = {}, reset = true } = nextRefinement || {};
+    const { northEast: ne, southWest: sw } = bounds;
+    const boundingBox = ne && sw ? [ne.lat, ne.lng, sw.lat, sw.lng].join() : '';
+
+    setUiState(() => ({
+      hasMapMoveSinceLastRefine: false,
+      isRefinedWithMap: !reset,
+    }));
+
+    return {
+      ...searchState,
+      [getId()]: boundingBox,
+    };
+  },
+
+  getSearchParameters(searchParameters, props, searchState) {
+    // @TODO: Handle position & IP
+    // @TODO: Handle multi-index
+    const bbox = searchState[getId()];
+
+    if (!bbox) {
+      return searchParameters.setQueryParameter('aroundLatLngViaIP', true);
+    }
+
+    return searchParameters.setQueryParameter('insideBoundingBox', bbox);
+  },
+
+  cleanUp(props, searchState) {
+    // @TODO: implement
+    return searchState;
+  },
+
+  getMetadata() {
+    // @TODO: implement
+    return {
+      items: [],
+    };
+  },
+});

--- a/packages/react-instantsearch/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch/src/connectors/connectGeoSearch.js
@@ -4,16 +4,18 @@ import createConnector from '../core/createConnector';
 const getId = () => 'geoSearch';
 
 const toggleRefineOnMapMove = update => () =>
-  update(prevProps => ({
-    isRefineOnMapMove: !prevProps.isRefineOnMapMove,
+  update(prevUiState => ({
+    isRefineOnMapMove: !prevUiState.isRefineOnMapMove,
   }));
 
 const setMapMoveSinceLastRefine = update => value =>
-  update(prevState => {
+  update(prevUiState => {
+    const { hasMapMoveSinceLastRefine } = prevUiState;
+
     // Prevent useless rendering, only render the first
     // time we change the value. It will avoid to run
     // the render on each move.
-    if (prevState.hasMapMoveSinceLastRefine === value) {
+    if (hasMapMoveSinceLastRefine === value) {
       return null;
     }
 

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -270,8 +270,8 @@ export default function createConnector(connectorDesc) {
         };
 
         const uiStateUpdater = {
-          state: uiState,
-          update: this.setUiState,
+          value: uiState,
+          updater: this.setUiState,
         };
 
         if (connectorDesc.getProvidedProps.length === 1) {

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -246,9 +246,7 @@ export default function createConnector(connectorDesc) {
         return !propsEqual || !statePropsEqual;
       }
 
-      getProvidedProps({ props, uiState }) {
-        const { ais: { store } } = this.context;
-
+      getProvidedProps = ({ props, uiState }) => {
         const {
           results,
           searching,
@@ -278,13 +276,12 @@ export default function createConnector(connectorDesc) {
           uiState,
           this.setUiState
         );
-      }
+      };
 
       refine = (...args) => {
         this.context.ais.onInternalStateUpdate(
           connectorDesc.refine.call(
             this,
-            // @TODO: merge the ui props
             this.props,
             this.context.ais.store.getState().widgets,
             ...args

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -258,7 +258,7 @@ export default function createConnector(connectorDesc) {
           resultsFacetValues,
           searchingForFacetValues,
           isSearchStalled,
-        } = store.getState();
+        } = this.context.ais.store.getState();
 
         const searchResults = {
           results,
@@ -268,23 +268,6 @@ export default function createConnector(connectorDesc) {
           isSearchStalled,
         };
 
-        const uiStateUpdater = {
-          value: uiState,
-          updater: this.setUiState,
-        };
-
-        if (connectorDesc.getProvidedProps.length === 1) {
-          return connectorDesc.getProvidedProps({
-            props,
-            uiState: uiStateUpdater,
-            context: this.context,
-            searchState: widgets,
-            searchForFacetValuesResults: resultsFacetValues,
-            searchResults,
-            metadata,
-          });
-        }
-
         return connectorDesc.getProvidedProps.call(
           this,
           props,
@@ -292,27 +275,12 @@ export default function createConnector(connectorDesc) {
           searchResults,
           metadata,
           resultsFacetValues,
-          uiStateUpdater
+          uiState,
+          this.setUiState
         );
       }
 
       refine = (...args) => {
-        if (connectorDesc.refine.length === 1) {
-          const [nextRefinement, ...rest] = args;
-          this.context.ais.onInternalStateUpdate(
-            connectorDesc.refine({
-              // @TODO: merge the ui props
-              props: this.props,
-              setUiState: this.setUiState,
-              searchState: this.context.ais.store.getState().widgets,
-              nextRefinement,
-              ...rest,
-            })
-          );
-
-          return;
-        }
-
         this.context.ais.onInternalStateUpdate(
           connectorDesc.refine.call(
             this,

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -228,8 +228,8 @@ export default function createConnector(connectorDesc) {
       }
 
       shouldComponentUpdate(nextProps, nextState) {
-        const { props: stateProps, uiState: uiStateProps } = this.state;
-        const { props: nextStateProps, uiState: nextUiStateProps } = nextState;
+        const { props: stateProps } = this.state;
+        const { props: nextStateProps } = nextState;
 
         const propsEqual = shallowEqual(this.props, nextProps);
 
@@ -242,9 +242,8 @@ export default function createConnector(connectorDesc) {
         }
 
         const statePropsEqual = shallowEqual(stateProps, nextStateProps);
-        const uiStatePropsEqual = shallowEqual(uiStateProps, nextUiStateProps);
 
-        return !propsEqual || !statePropsEqual || !uiStatePropsEqual;
+        return !propsEqual || !statePropsEqual;
       }
 
       getProvidedProps({ props, uiState }) {

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -292,7 +292,6 @@ export default function createConnector(connectorDesc) {
       searchForFacetValues = (...args) => {
         this.context.ais.onSearchForFacetValues(
           connectorDesc.searchForFacetValues(
-            // @TODO: merge the ui props
             this.props,
             this.context.ais.store.getState().widgets,
             ...args
@@ -304,7 +303,6 @@ export default function createConnector(connectorDesc) {
         this.context.ais.createHrefForState(
           connectorDesc.refine.call(
             this,
-            // @TODO: merge the ui props
             this.props,
             this.context.ais.store.getState().widgets,
             ...args

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -194,6 +194,7 @@ export default function createInstantSearchManager({
       },
       'resultsFacetValues'
     );
+
     store.setState(nextState);
   }
 

--- a/packages/react-instantsearch/src/widgets/GeoSearch.js
+++ b/packages/react-instantsearch/src/widgets/GeoSearch.js
@@ -1,0 +1,4 @@
+import connectGeoSearch from '../connectors/connectGeoSearch';
+import GeoSearch from '../components/GeoSearch';
+
+export default connectGeoSearch(GeoSearch);

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { setAddon, storiesOf } from '@storybook/react';
+import { GeoSearch } from '../packages/react-instantsearch/dom';
+import { displayName, filterProps, WrapWithHits } from './util';
+import JSXAddon from 'storybook-addon-jsx';
+
+setAddon(JSXAddon);
+
+const stories = storiesOf('GeoSearch', module);
+
+stories.addWithJSX(
+  'default',
+  () => (
+    <WrapWithHits
+      linkedStoryGroup="GeoSearch"
+      indexName="airbnb"
+      searchParameters={{
+        hitsPerPage: 25,
+      }}
+    >
+      <GeoSearch
+        googleMapURL="https://maps.googleapis.com/maps/api/js?v=3.31&key=AIzaSyCl2TTJXpwxGuuc2zQZkAlIkWhpYbyjjP8"
+        loadingElement={<div style={{ height: `100%` }} />}
+        containerElement={<div style={{ height: `500px` }} />}
+        mapElement={<div style={{ height: `100%` }} />}
+      />
+    </WrapWithHits>
+  ),
+  {
+    displayName,
+    filterProps,
+  }
+);

--- a/stories/util.js
+++ b/stories/util.js
@@ -98,26 +98,11 @@ const CustomHits = connectHits(({ hits }) => (
   <div className="hits">
     {hits.map(hit => (
       <div key={hit.objectID} className="hit">
-        <div>
-          <div className="hit-picture">
-            <img
-              src={`https://res.cloudinary.com/hilnmyskv/image/fetch/h_100,q_100,f_auto/${
-                hit.image
-              }`}
-            />
-          </div>
-        </div>
         <div className="hit-content">
           <div>
             <Highlight attribute="name" hit={hit} />
             <span> - ${hit.price}</span>
             <span> - {hit.rating} stars</span>
-          </div>
-          <div className="hit-type">
-            <Highlight attribute="type" hit={hit} />
-          </div>
-          <div className="hit-description">
-            <Highlight attribute="description" hit={hit} />
           </div>
         </div>
       </div>

--- a/storybook/config.js
+++ b/storybook/config.js
@@ -8,7 +8,7 @@ setOptions({
   url: 'https://community.algolia.com/react-instantsearch/',
   goFullScreen: false,
   showStoriesPanel: true,
-  showAddonPanel: true,
+  showAddonPanel: false,
   showSearchBox: false,
   addonPanelInRight: true,
   sidebarAnimations: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3391,6 +3391,10 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
+can-use-dom@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
+
 caniuse-api@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
@@ -6597,6 +6601,10 @@ google-map-react@0.34.0:
     fbjs "^0.8.3"
     scriptjs "^2.5.7"
 
+google-maps-infobox@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/google-maps-infobox/-/google-maps-infobox-2.0.0.tgz#1ea6de93c0cdf4138c2d586331835c83dcc59dc2"
+
 got@5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-5.6.0.tgz#bb1d7ee163b78082bbc8eb836f3f395004ea6fbf"
@@ -7375,6 +7383,12 @@ interpret@^1.0.0:
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  dependencies:
+    loose-envify "^1.0.0"
+
+invariant@^2.2.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
   dependencies:
     loose-envify "^1.0.0"
 
@@ -8852,7 +8866,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.5, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.4:
+lodash@4.17.5, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.2, lodash@^4.17.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -9025,6 +9039,14 @@ marked-terminal@^2.0.0:
 marked@^0.3.12, marked@^0.3.9, marked@~0.3.6:
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.17.tgz#607f06668b3c6b1246b28f13da76116ac1aa2d2b"
+
+marker-clusterer-plus@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz#f8eff74d599dab3b7d0e3fed5264ea0e704f5d67"
+
+markerwithlabel@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/markerwithlabel/-/markerwithlabel-2.0.1.tgz#822f4eb68c488c2509c5ebdb75982eb84a856096"
 
 material-colors@^1.2.1:
   version "1.2.5"
@@ -11418,6 +11440,22 @@ react-fuzzy@^0.5.1, react-fuzzy@^0.5.2:
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
+react-google-maps@9.4.5:
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/react-google-maps/-/react-google-maps-9.4.5.tgz#920c199bdc925e0ce93880edffb09428d263aafa"
+  dependencies:
+    babel-runtime "^6.11.6"
+    can-use-dom "^0.1.0"
+    google-maps-infobox "^2.0.0"
+    invariant "^2.2.1"
+    lodash "^4.16.2"
+    marker-clusterer-plus "^2.1.4"
+    markerwithlabel "^2.0.1"
+    prop-types "^15.5.8"
+    recompose "^0.26.0"
+    scriptjs "^2.5.8"
+    warning "^3.0.0"
+
 react-hot-loader@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.0.1.tgz#48284350ae5d7ba07dac872bd5bbc6e477352593"
@@ -12493,7 +12531,7 @@ schema-utils@^0.4.0, schema-utils@^0.4.5:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
-scriptjs@^2.5.7:
+scriptjs@^2.5.7, scriptjs@^2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.8.tgz#d0c43955c2e6bad33b6e4edf7b53b8965aa7ca5f"
 


### PR DESCRIPTION
### **This PR is a POC, it's not intended to be merged**.

I played a bit around the connector API in order to handle a "'stateful" instance. This lets us the possibility to implement the UI logic directly in the connector.

- **`initialUiState`**: You can define a new property on the connector declaration. This property takes a function that returns the initial UI state for the connector. The function takes `props` as argument.

- **`setUiState`**: You can access this function in every method of the connector. It's wrapper around the `setState` function that lets you update only the `uiState`. It means that now we can trigger new render on the fly to respond to users interactions.

It's definitely not a final API, but it can fit pretty easily with the current implementation without rewriting everything. Happy to have your feedback!

You can play with the GeoSearch example on [Storybook](https://deploy-preview-1073--react-instantsearch.netlify.com/react-instantsearch/storybook/?selectedKind=GeoSearch&selectedStory=default&full=0&addons=0&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs).

**Note**: the test are failing it's completely normal.