### PR TITLE
chore(travis): trigger build on every PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 language: node_js
+
 before_script:
   - yarn boot
-branches:
-  only:
-    - master
+
 addons:
   firefox: 56.0
+
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH=$HOME/.yarn/bin:$PATH
+
 cache:
   yarn: true
   directories:
     - node_modules
     - packages/react-instantsearch/node_modules
+
 env:
   global:
   # ARGOS


### PR DESCRIPTION
**Summary**

By removing this option and disabling the build on push on the Travis UI we are able to run the build only once on **every** PR. Even on PR that don't target `master`. Previously the build wasn't trigger on a PR that didn't target `master`.

![screen shot 2018-03-22 at 16 32 38](https://user-images.githubusercontent.com/6513513/37780253-a6b18ca6-2dee-11e8-98e5-04ddbe6df58d.png)
