### PR TITLE
chore(travis): run yarn install only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 
-before_script:
-  - yarn boot
-
 addons:
   firefox: 56.0
 
@@ -11,6 +8,9 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH=$HOME/.yarn/bin:$PATH
+
+install:
+  - yarn boot
 
 cache:
   yarn: true


### PR DESCRIPTION
**Summary**

By default Travis run the install command for the current package manager (Yarn in our case). Since we do a `yarn boot` after we run the install command twice. This PR replace the default `install` behaviour with `yarn boot`.

**Before**

![screen shot 2018-03-22 at 17 10 21](https://user-images.githubusercontent.com/6513513/37782741-f31468f2-2df3-11e8-8b14-f1bac3cb2d09.png)

**After**

![screen shot 2018-03-22 at 17 09 08](https://user-images.githubusercontent.com/6513513/37782703-d9621db4-2df3-11e8-9fba-94d15056344e.png)
