### PR TITLE
fix(release): install all the yarn dependencies

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,7 +41,7 @@ git pull origin master
 git fetch origin --tags
 
 # printf "Release: install dependencies"
-yarn
+yarn --production=false
 
 # No need for complex release process for now, only patch releases should be ok
 currentVersion=`cat package.json | json version`


### PR DESCRIPTION
**Summary**

The `release` script is trigger with `NODE_ENV` set to `production`. Yarn will install by default only the production dependencies. Previously the install was done with the `yarn boot` command, the `NODE_ENV` was override inside the script (see below). This PR fixes the issue by providing the option `--production=false` to yarn.
