### PR TITLE
docs: add requirements on faceting for range

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -16,7 +16,9 @@ import createConnector from '../core/createConnector';
  * a numeric range.
  * @name connectRange
  * @kind connector
- * @requirements The attribute passed to the `attribute` prop must be holding numerical values.
+ * @requirements The attribute passed to the `attribute` prop must be present in “attributes for faceting”
+ * on the Algolia dashboard or configured as `attributesForFaceting` via a set settings call to the Algolia API.
+ * The values inside the attribute must be JavaScript numbers (not strings).
  * @propType {string} attribute - Name of the attribute for faceting
  * @propType {{min?: number, max?: number}} [defaultRefinement] - Default searchState of the widget containing the start and the end of the range.
  * @propType {number} [min] - Minimum value. When this isn't set, the minimum value will be automatically computed by Algolia using the data in the index.

--- a/packages/react-instantsearch/src/widgets/RangeInput.js
+++ b/packages/react-instantsearch/src/widgets/RangeInput.js
@@ -7,7 +7,9 @@ import RangeInput from '../components/RangeInput';
  * RangeInput allows a user to select a numeric range using a minimum and maximum input.
  * @name RangeInput
  * @kind widget
- * @requirements The attribute passed to the `attribute` prop must be holding numerical values.
+ * @requirements The attribute passed to the `attribute` prop must be present in “attributes for faceting”
+ * on the Algolia dashboard or configured as `attributesForFaceting` via a set settings call to the Algolia API.
+ * The values inside the attribute must be JavaScript numbers (not strings).
  * @propType {string} attribute - the name of the attribute in the record
  * @propType {{min: number, max: number}} [defaultRefinement] - Default state of the widget containing the start and the end of the range.
  * @propType {number} [min] - Minimum value. When this isn't set, the minimum value will be automatically computed by Algolia using the data in the index.

--- a/packages/react-instantsearch/src/widgets/RatingMenu.js
+++ b/packages/react-instantsearch/src/widgets/RatingMenu.js
@@ -10,6 +10,9 @@ import RatingMenu from '../components/RatingMenu';
  * @requirements The attribute passed to the `attribute` prop must be holding numerical values.
  * @name RatingMenu
  * @kind widget
+ * @requirements The attribute passed to the `attribute` prop must be present in “attributes for faceting”
+ * on the Algolia dashboard or configured as `attributesForFaceting` via a set settings call to the Algolia API.
+ * The values inside the attribute must be JavaScript numbers (not strings).
  * @propType {string} attribute - the name of the attribute in the record
  * @propType {number} [min] - Minimum value for the rating. When this isn't set, the minimum value will be automatically computed by Algolia using the data in the index.
  * @propType {number} [max] - Maximum value for the rating. When this isn't set, the maximum value will be automatically computed by Algolia using the data in the index.


### PR DESCRIPTION
**Summary**

Inside the documentation every widgets that is related to the `connectRange` connector has a section "requirements" about the fact that the value must be a number. But we don't precise that the value must be also declared as `attributeForFaceting`. This PR adds those requirements in:

- `connectRange`
- `RangeInput`
- `RatingMenu`