### PR TITLE
feat(createConnector): add uiState

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['algolia/react', 'algolia/jest'],
   rules: {
+    'max-params': ['error', 7],
     'no-param-reassign': 'off',
     'import/no-extraneous-dependencies': [
       'error',

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -269,7 +269,8 @@ export default function createConnector(connectorDesc) {
           searchResults,
           metadata,
           resultsFacetValues,
-          uiState
+          uiState,
+          this.setUiState
         );
       };
 
@@ -305,6 +306,28 @@ export default function createConnector(connectorDesc) {
         );
 
       cleanUp = (...args) => connectorDesc.cleanUp.call(this, ...args);
+
+      setUiState = uiStateUpdater =>
+        this.setState(prevState => {
+          const nextSliceUiState = uiStateUpdater(prevState.uiState);
+
+          if (!nextSliceUiState) {
+            return null;
+          }
+
+          const nextUiState = {
+            ...prevState.uiState,
+            ...nextSliceUiState,
+          };
+
+          return {
+            uiState: nextUiState,
+            props: this.getProvidedProps({
+              props: prevState.props,
+              uiState: nextUiState,
+            }),
+          };
+        });
 
       render() {
         if (this.state.props === null) {

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -181,13 +181,18 @@ export default function createConnector(connectorDesc) {
         }
       }
 
+      // The canRender props is not sync with the one from the state because
+      // in this lifecycle we don't pass the `canRender` prop to the getProvidedProps
+      // function. It means that every time a component received new props the canRender
+      // prop is `undefined`.
       componentWillReceiveProps(nextProps) {
         if (!isEqual(this.props, nextProps)) {
-          this.setState({
+          this.setState(prevState => ({
             props: this.getProvidedProps({
+              uiState: prevState.uiState,
               props: nextProps,
             }),
-          });
+          }));
 
           if (isWidget) {
             // Since props might have changed, we need to re-run getSearchParameters

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -82,19 +82,22 @@ export default function createConnector(connectorDesc) {
 
         this.unsubscribe = store.subscribe(() => {
           if (this.state.canRender) {
-            this.setState({
+            this.setState(prevState => ({
               props: this.getProvidedProps({
+                uiState: prevState.uiState,
                 props: {
                   ...this.props,
-                  canRender: this.state.canRender,
+                  canRender: prevState.canRender,
                 },
               }),
-            });
+            }));
           }
         });
+
         if (isWidget) {
           this.unregisterWidget = widgetsManager.registerWidget(this);
         }
+
         if (process.env.NODE_ENV === 'development') {
           const onlyGetProvidedPropsUsage = !find(
             Object.keys(connectorDesc),

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -61,7 +61,9 @@ export default function createConnector(connectorDesc) {
       constructor(props, context) {
         super(props, context);
 
-        const { ais: { store, widgetsManager } } = context;
+        const {
+          ais: { store, widgetsManager },
+        } = context;
         const canRender = false;
 
         const initialUiState = connectorDesc.getInitialUiState

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -61,12 +61,22 @@ export default function createConnector(connectorDesc) {
       constructor(props, context) {
         super(props, context);
 
-        const {
-          ais: { store, widgetsManager },
-        } = context;
+        const { ais: { store, widgetsManager } } = context;
         const canRender = false;
+
+        const initialUiState = connectorDesc.getInitialUiState
+          ? connectorDesc.getInitialUiState(props)
+          : {};
+
         this.state = {
-          props: this.getProvidedProps({ ...props, canRender }),
+          uiState: initialUiState,
+          props: this.getProvidedProps({
+            uiState: initialUiState,
+            props: {
+              ...props,
+              canRender,
+            },
+          }),
           canRender, // use to know if a component is rendered (browser), or not (server).
         };
 
@@ -74,8 +84,10 @@ export default function createConnector(connectorDesc) {
           if (this.state.canRender) {
             this.setState({
               props: this.getProvidedProps({
-                ...this.props,
-                canRender: this.state.canRender,
+                props: {
+                  ...this.props,
+                  canRender: this.state.canRender,
+                },
               }),
             });
           }
@@ -169,7 +181,9 @@ export default function createConnector(connectorDesc) {
       componentWillReceiveProps(nextProps) {
         if (!isEqual(this.props, nextProps)) {
           this.setState({
-            props: this.getProvidedProps(nextProps),
+            props: this.getProvidedProps({
+              props: nextProps,
+            }),
           });
 
           if (isWidget) {
@@ -220,10 +234,7 @@ export default function createConnector(connectorDesc) {
         return !propsEqual || !shallowEqual(this.state.props, nextState.props);
       }
 
-      getProvidedProps = props => {
-        const {
-          ais: { store },
-        } = this.context;
+      getProvidedProps = ({ props, uiState }) => {
         const {
           results,
           searching,
@@ -233,7 +244,8 @@ export default function createConnector(connectorDesc) {
           resultsFacetValues,
           searchingForFacetValues,
           isSearchStalled,
-        } = store.getState();
+        } = this.context.ais.store.getState();
+
         const searchResults = {
           results,
           searching,
@@ -241,13 +253,15 @@ export default function createConnector(connectorDesc) {
           searchingForFacetValues,
           isSearchStalled,
         };
+
         return connectorDesc.getProvidedProps.call(
           this,
           props,
           widgets,
           searchResults,
           metadata,
-          resultsFacetValues
+          resultsFacetValues,
+          uiState
         );
       };
 

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -206,6 +206,91 @@ describe('createConnector', () => {
       });
     });
 
+    it('updates on props change (with uiState)', () => {
+      const initialUiState = { isOpen: false };
+      const getInitialUiState = jest.fn(() => initialUiState);
+      const getProvidedProps = jest.fn((props, _, __, ___, ____, uiState) => ({
+        isMenuOpen: uiState.isOpen,
+        gotProps: props,
+      }));
+
+      const Dummy = () => null;
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getInitialUiState,
+        getProvidedProps,
+        getId,
+      })(Dummy);
+
+      const state = createState();
+
+      const props = {
+        hello: 'there',
+      };
+
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => state,
+              subscribe: () => null,
+            },
+          },
+        },
+      });
+
+      expect(getProvidedProps).toHaveBeenCalledTimes(1);
+      expect(getProvidedProps).toHaveBeenLastCalledWith(
+        { ...props, canRender: false },
+        state.widgets,
+        {
+          results: state.results,
+          error: state.error,
+          searching: state.searching,
+          searchingForFacetValues: state.searchingForFacetValues,
+        },
+        state.metadata,
+        state.resultsFacetValues,
+        initialUiState
+      );
+
+      expect(wrapper.find(Dummy).props()).toEqual({
+        ...props,
+        isMenuOpen: false,
+        gotProps: {
+          ...props,
+          canRender: false,
+        },
+      });
+
+      const nextProps = {
+        hello: 'you',
+      };
+
+      wrapper.setProps(nextProps);
+
+      expect(getProvidedProps).toHaveBeenCalledTimes(2);
+      expect(getProvidedProps).toHaveBeenLastCalledWith(
+        nextProps,
+        state.widgets,
+        {
+          results: state.results,
+          error: state.error,
+          searching: state.searching,
+          searchingForFacetValues: state.searchingForFacetValues,
+        },
+        state.metadata,
+        state.resultsFacetValues,
+        initialUiState
+      );
+
+      expect(wrapper.find(Dummy).props()).toEqual({
+        ...nextProps,
+        gotProps: nextProps,
+        isMenuOpen: false,
+      });
+    });
+
     it('updates on state change', () => {
       const getProvidedProps = jest.fn((props, state) => state);
       const Dummy = () => null;

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -251,7 +251,8 @@ describe('createConnector', () => {
         },
         state.metadata,
         state.resultsFacetValues,
-        initialUiState
+        initialUiState,
+        expect.any(Function)
       );
 
       expect(wrapper.find(Dummy).props()).toEqual({
@@ -281,7 +282,8 @@ describe('createConnector', () => {
         },
         state.metadata,
         state.resultsFacetValues,
-        initialUiState
+        initialUiState,
+        expect.any(Function)
       );
 
       expect(wrapper.find(Dummy).props()).toEqual({
@@ -408,7 +410,8 @@ describe('createConnector', () => {
         },
         state.metadata,
         state.resultsFacetValues,
-        initialUiState
+        initialUiState,
+        expect.any(Function)
       );
 
       expect(wrapper.find(Dummy).props()).toEqual({
@@ -439,7 +442,8 @@ describe('createConnector', () => {
         },
         state.metadata,
         state.resultsFacetValues,
-        initialUiState
+        initialUiState,
+        expect.any(Function)
       );
 
       expect(wrapper.find(Dummy).props()).toEqual({
@@ -1007,6 +1011,232 @@ describe('createConnector', () => {
       expect(searchForFacetValues.mock.calls[0][2]).toBe(facetName);
       expect(searchForFacetValues.mock.calls[0][3]).toBe(query);
       expect(onSearchForFacetValues.mock.calls[0][0]).toBe(searchState);
+    });
+  });
+
+  describe('setUiState', () => {
+    it('expect to update the uiState and trigger a render', () => {
+      const initialUiState = { isOpen: false };
+      const nextUiState = { isOpen: true };
+      const uiStateUpdater = jest.fn(prevUiState => ({
+        isOpen: !prevUiState.isOpen,
+      }));
+
+      const getInitialUiState = jest.fn(() => initialUiState);
+
+      const getProvidedProps = jest.fn(
+        (_, __, ___, ____, _____, uiState, setUiState) => ({
+          isMenuOpen: uiState.isOpen,
+          toggleMenu: () => setUiState(uiStateUpdater),
+        })
+      );
+
+      const Dummy = jest.fn(() => null);
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getInitialUiState,
+        getProvidedProps,
+      })(Dummy);
+
+      const wrapper = mount(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => createState(),
+              subscribe: () => null,
+            },
+          },
+        },
+      });
+
+      expect(getInitialUiState).toHaveBeenCalledTimes(1);
+      expect(getProvidedProps).toHaveBeenCalledTimes(1);
+      expect(uiStateUpdater).toHaveBeenCalledTimes(0);
+      expect(Dummy).toHaveBeenCalledTimes(1);
+
+      expect(getProvidedProps).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        initialUiState,
+        expect.any(Function)
+      );
+
+      expect(wrapper.find(Dummy).props()).toEqual({
+        isMenuOpen: false,
+        toggleMenu: expect.any(Function),
+      });
+
+      wrapper
+        .find(Dummy)
+        .props()
+        .toggleMenu();
+
+      wrapper.update();
+
+      expect(getInitialUiState).toHaveBeenCalledTimes(1);
+      expect(getProvidedProps).toHaveBeenCalledTimes(2);
+      expect(uiStateUpdater).toHaveBeenCalledTimes(1);
+      expect(Dummy).toHaveBeenCalledTimes(2);
+
+      expect(getProvidedProps).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        nextUiState,
+        expect.any(Function)
+      );
+
+      expect(wrapper.find(Dummy).props()).toEqual({
+        isMenuOpen: true,
+        toggleMenu: expect.any(Function),
+      });
+    });
+
+    it('expect to shallow merge the updated uiState', () => {
+      const uiStateUpdater = prevUiState => ({
+        isOpen: !prevUiState.isOpen,
+      });
+
+      const getInitialUiState = () => ({
+        isOpen: false,
+        willCloseOnClick: true,
+      });
+
+      const getProvidedProps = (
+        _,
+        __,
+        ___,
+        ____,
+        _____,
+        uiState,
+        setUiState
+      ) => ({
+        isMenuOpen: uiState.isOpen,
+        willMenuCloseOnClick: uiState.willCloseOnClick,
+        toggleMenu: () => setUiState(uiStateUpdater),
+      });
+
+      const Dummy = () => null;
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getInitialUiState,
+        getProvidedProps,
+      })(Dummy);
+
+      const wrapper = mount(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => createState(),
+              subscribe: () => null,
+            },
+          },
+        },
+      });
+
+      expect(wrapper.find(Dummy).props()).toEqual({
+        isMenuOpen: false,
+        willMenuCloseOnClick: true,
+        toggleMenu: expect.any(Function),
+      });
+
+      wrapper
+        .find(Dummy)
+        .props()
+        .toggleMenu();
+
+      wrapper.update();
+
+      expect(wrapper.find(Dummy).props()).toEqual({
+        isMenuOpen: true,
+        willMenuCloseOnClick: true,
+        toggleMenu: expect.any(Function),
+      });
+    });
+
+    it('expect to not update the uiState and prevent the render', () => {
+      const initialUiState = { isOpen: false };
+      const uiStateUpdater = jest.fn(() => false);
+
+      const getInitialUiState = jest.fn(() => initialUiState);
+
+      const getProvidedProps = jest.fn(
+        (_, __, ___, ____, _____, uiState, setUiState) => ({
+          isMenuOpen: uiState.isOpen,
+          willMenuCloseOnClick: uiState.willCloseOnClick,
+          toggleMenu: () => setUiState(uiStateUpdater),
+        })
+      );
+
+      const Dummy = jest.fn(() => null);
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getInitialUiState,
+        getProvidedProps,
+      })(Dummy);
+
+      const wrapper = mount(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => createState(),
+              subscribe: () => null,
+            },
+          },
+        },
+      });
+
+      expect(getInitialUiState).toHaveBeenCalledTimes(1);
+      expect(getProvidedProps).toHaveBeenCalledTimes(1);
+      expect(uiStateUpdater).toHaveBeenCalledTimes(0);
+      expect(Dummy).toHaveBeenCalledTimes(1);
+
+      expect(getProvidedProps).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        initialUiState,
+        expect.any(Function)
+      );
+
+      expect(wrapper.find(Dummy).props()).toEqual({
+        isMenuOpen: false,
+        toggleMenu: expect.any(Function),
+      });
+
+      wrapper
+        .find(Dummy)
+        .props()
+        .toggleMenu();
+
+      wrapper.update();
+
+      expect(getInitialUiState).toHaveBeenCalledTimes(1);
+      expect(getProvidedProps).toHaveBeenCalledTimes(1);
+      expect(uiStateUpdater).toHaveBeenCalledTimes(1);
+      expect(Dummy).toHaveBeenCalledTimes(1);
+
+      expect(getProvidedProps).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        initialUiState,
+        expect.any(Function)
+      );
+
+      expect(wrapper.find(Dummy).props()).toEqual({
+        isMenuOpen: false,
+        toggleMenu: expect.any(Function),
+      });
     });
   });
 });


### PR DESCRIPTION
**Summary**

This PR adds to `createConnector` the ability to save UI related state and trigger re-render without triggering a search (will be used for the geo search connector). Here is the lifecycle of a connector when the `uiState` is provided:

- **mount** → `getInitialUiState` → `getProvidedProps` → `render`
- **setUiState** → `uiStateUpdater` → `getProvidedProps` → `render`

The implementation didn't change the current behaviour when the `uiState` is not provided. 

The concept of getting new props from a connector remains the same. The only way to get them is to return them from `getProvidedProps`. The introduction of `uiState` doesn't change this rule. We pass the `uiState` to `getProvidedProps` in order to get them. We should not use `uiState` & `setUiState` in a other place than the view. Hence the new parameters are only available in `getProvidedProps`.

I don't think we need to make this API public, because a user could implement his own logic outside of the connector in a parent component.

**API**:

- **getInitialState**: `(props) => uiState`
- **setUiState**: `(uiStateUpdater) => void`
- **uiStateUpdater**: `(prevUiState) => nextSliceUiState`

**Usage**

```js
const connect = createConnector({
  getInitialUiState: props => ({
    isMenuOpen: props.isOpen
  }),

  getProvidedProps(_, _, _, _, _, uiState, setUiState) {
    return {
      ...uiState,
      toggleMenu: () =>
        setUiState(prevUiState => ({
          isMenuOpen: !prevUiState.isMenuOpen
        }))
    };
  }
});

const Header = connect(({ isMenuOpen, toggleMenu }) => (
  <header>
    <button onClick={toggleMenu}>Toggle</button>

    {isMenuOpen && (
      <nav>
        <Link />
        <Link />
        <Link />
      </nav>
    )}
  </header>
));
```