### PR TITLE
Resolved bug where connectRange connector fails to return results for queries with a max < 1

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -73,14 +73,27 @@ function getCurrentRefinement(props, searchState, currentRange, context) {
     `${namespace}.${getId(props)}`,
     {},
     currentRefinement => {
-      let { min, max } = currentRefinement;
-      if (typeof min === 'string') {
-        min = !props.precision ? parseInt(min, 10) : parseFloat(min);
+      const { min, max } = currentRefinement;
+      const isFloatPrecision = Boolean(props.precision);
+
+      let nextMin = min;
+      if (typeof nextMin === 'string') {
+        nextMin = isFloatPrecision
+          ? parseFloat(nextMin)
+          : parseInt(nextMin, 10);
       }
-      if (typeof max === 'string') {
-        max = !props.precision ? parseInt(max, 10) : parseFloat(max);
+
+      let nextMax = max;
+      if (typeof nextMax === 'string') {
+        nextMax = isFloatPrecision
+          ? parseFloat(nextMax)
+          : parseInt(nextMax, 10);
       }
-      return { min, max };
+
+      return {
+        min: nextMin,
+        max: nextMax,
+      };
     }
   );
 

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -75,10 +75,10 @@ function getCurrentRefinement(props, searchState, currentRange, context) {
     currentRefinement => {
       let { min, max } = currentRefinement;
       if (typeof min === 'string') {
-        min = parseInt(min, 10);
+        min = !props.precision ? parseInt(min, 10) : parseFloat(min);
       }
       if (typeof max === 'string') {
-        max = parseInt(max, 10);
+        max = !props.precision ? parseInt(max, 10) : parseFloat(max);
       }
       return { min, max };
     }

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -296,6 +296,50 @@ describe('connectRange', () => {
         precision: 2,
       });
 
+      // With a precision of 0 -> parseInt
+      props = getProvidedProps(
+        {
+          attribute: 'ok',
+          min: 5,
+          max: 10,
+          precision: 0,
+        },
+        {
+          range: { ok: { min: '6.9', max: '9.6' } },
+        },
+        {}
+      );
+      expect(props).toEqual({
+        min: 5,
+        max: 10,
+        currentRefinement: { min: 6, max: 9 },
+        count: [],
+        canRefine: false,
+        precision: 0,
+      });
+
+      // With a precision of > 0 -> parseFloat
+      props = getProvidedProps(
+        {
+          attribute: 'ok',
+          min: 5,
+          max: 10,
+          precision: 1,
+        },
+        {
+          range: { ok: { min: '6.9', max: '9.6' } },
+        },
+        {}
+      );
+      expect(props).toEqual({
+        min: 5,
+        max: 10,
+        currentRefinement: { min: 6.9, max: 9.6 },
+        count: [],
+        canRefine: false,
+        precision: 1,
+      });
+
       props = getProvidedProps(
         {
           attribute: 'ok',


### PR DESCRIPTION
**Summary**

When calling `refine` through the `connectRange` connector using a max value below 1, the query is made properly and the expected results are returned, but immediate subsequent refinement queries are then called (not through this connector's refine method) that coerce the max and min values into integers, irregardless of the specified precision attribute, and thus return inaccurate results. This is problematic whenever precision is used, but discovered in my use case wherein the desired data contains an attribute with values between 0.1 and 0.9 (this queries for values between 0 and 0, which will result in nothing for my dataset). A slider component using `connectRange` was returning these erroneous results.

This PR resolves the issue by modifying the `connectRange` code to use `parseFloat` rather than `parseInt` within the `getCurrentRefinement` method.

**Result**

For my dataset, when I query for an attribute with values between 0.1 and 0.9, the correct results appear and are maintained even as other filters are applied with other widgets.