### PR TITLE
feat(geo): add connector [PART-1]

### DIFF
--- a/docgen/src/stylesheets/components/_documentation.sass
+++ b/docgen/src/stylesheets/components/_documentation.sass
@@ -3,7 +3,7 @@ $offset-height: 60px
 
 .documentation-section,
 .examples-section
-  padding-bottom: 300px
+  padding-bottom: 320px
 
   .container
     article
@@ -136,7 +136,6 @@ $offset-height: 60px
       background: #fff
       border: 1px solid #d8d8d8
       border-radius: 2px 2px 0 0
-      margin: -8px 0 0
       padding: 0.75em 1em
       font-family: $paragraphs-font-family
       border-radius: 6px 6px 0 0
@@ -201,6 +200,10 @@ $offset-height: 60px
         display: block
         height: $offset-height
         // margin: (-$offset-height) 0 0
+
+    .sub-component-title
+      &:before
+        height: 10px
 
     .anchor
       margin-left: .2em

--- a/docgen/src/widgets/GeoSearch.md
+++ b/docgen/src/widgets/GeoSearch.md
@@ -1,0 +1,735 @@
+---
+mainTitle: Widgets
+title: GeoSearch
+layout: widget.pug
+category: widget
+showInNav: true
+navWeight: 0
+external: true
+---
+
+## Description
+
+The `GeoSearch` widget displays the list of results from the search on a Google Maps. It also provides a way to search for results based on their position. The widget provides some of the common GeoSearch patterns like search on map interaction.
+
+<div class="storybook-section">
+  <a class="btn btn-cta" href="https://community.algolia.com/react-instantsearch/storybook?selectedKind=GeoSearch&selectedStory=default" target="_blank">
+    See live example
+  </a>
+</div>
+
+## Requirements
+
+The API of this widget is a bit different than the others that you can find in React InstantSearch. The API is component driven rather than options driven. We chose the former because it brings more flexibility to the widget. Since the geo search pattern is not a use case for every applications we decided to ship the widget in a separate package. Be sure to install it before using it:
+
+```shell
+yarn add react-instantsearch-dom-maps
+```
+
+The GeoSearch widget uses the [geo search](https://www.algolia.com/doc/guides/searching/geo-search) capabilities of Algolia. Your hits **must** have a `_geoloc` attribute in order to be available in the render prop.
+
+Currently, the feature is not compatible with multiple values in the `_geoloc` attribute (e.g. a restaurant with multiple locations). In that case you can duplicate your records and use the [distinct](https://www.algolia.com/doc/guides/ranking/distinct) feature of Algolia to only retrieve unique results.
+
+You are also responsible for loading the Google Maps library. We provide a component to load the library ([`<GoogleMapsLoader />`](/widgets/GeoSearch.html#googlemapsloader)) but its usage **is not required to use the geo widget**. You can use any strategy you want to load Google Maps. You can find more informations about that in [the Google Maps documentation](https://developers.google.com/maps/documentation/javascript/tutorial).
+
+Don’t forget to explicitly set the `height` of the map container, otherwise it won’t be shown (it’s a requirement of Google Maps).
+
+## Example
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GoogleMapsLoader, GeoSearch, Control, Marker } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <div style={{ height: 500 }}>
+      <GoogleMapsLoader apiKey="GOOGLE_MAPS_API_KEY">
+        {google => (
+          <GeoSearch google={google}>
+            {({ hits }) => (
+              <div>
+                <Control />
+
+                {hits.map(hit => (
+                  <Marker key={hit.objectID} hit={hit} />
+                ))}
+              </div>
+            )}
+          </GeoSearch>
+        )}
+      </GoogleMapsLoader>
+    </div>
+  </InstantSearch>
+);
+```
+
+## `<GeoSearch />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component provides the `hits` to display. All the other geo components need to be nested under it.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        // render the hits
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>google*</td>
+      <td>Type: <code>object</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Reference to the global window.google object. See <a href="https://developers.google.com/maps/documentation/javascript/tutorial" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>children*</td>
+      <td>Type: <code>({ hits: object[] }) => React.ReactNode</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          The render function takes an object as argument with the <code>hits</code> inside.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>initialZoom</td>
+      <td>Type: <code>number</code></td>
+      <td>Default: <code>1</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>By default the map will set the zoom accordingly to the markers displayed on it. When we refine it may happen that the results are empty. For those situations we need to provide a zoom to render the map.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>initialPosition</td>
+      <td>Type: <code>{ lat: number, lng: number }</code></td>
+      <td>Default: <code>{ lat: 0, lng: 0 }</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>By default the map will set the position accordingly to the markers displayed on it. When we refine it may happen that the results are empty. For those situations we need to provide a position to render the map.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+This component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+This component has no translations.
+
+## `<Marker />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component is a wapper around [`google.maps.Marker`](https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#MarkerOptions), all the options avaible on the Marker class can be provided as props. This component cannot render any children components. See [`<CustomMarker />`](/widgets/GeoSearch.html#custommarker) for this behaviour.
+
+Currently the component does not support the update of the options. Once the component is rendered changing the props won't update the marker options.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, Marker } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <div>
+          {hits.map(hit => (
+            <Marker key={hit.objectID} hit={hit} />
+          ))}
+        </div>
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>hit*</td>
+      <td>Type: <code>object</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Hit to attach on the marker.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the marker icon was clicked, see <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.click" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onDoubleClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the marker icon was double clicked, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.dblclick" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseDown</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired for a mousedown on the marker, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mousedown" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOut</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the mouse leaves the area of the marker icon, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mouseout" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOver</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the mouse enters the area of the marker icon, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mouseover" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseUp</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired for a mouseup on the marker, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mouseup" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+This component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+This component has no translations.
+
+## `<CustomMarker />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component is an alternative to [`<Marker />`](/widgets/GeoSearch.html#marker). In some cases you may want to have the full control of the marker rendering. You can provide any React components to design your custom marker.
+
+Currently the component does not support the update of the options. Once the component is rendered changing the props won't update the marker options.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, CustomMarker } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <div>
+          {hits.map(hit => (
+            <CustomMarker key={hit.objectID} hit={hit}>
+              <span>{hit.price}</span>
+            </CustomMarker>
+          ))}
+        </div>
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>hit*</td>
+      <td>Type: <code>object</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Hit to attach on the marker.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>className</td>
+      <td>Type: <code>string</code></td>
+      <td><code>''</<code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>The className to add on the marker wrapper element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>anchor</td>
+      <td>Type: <code>{ x: number, y: number }</code></td>
+      <td><code>{ x: 0, y: 0 }</<code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Offset for the marker element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onDoubleClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseDown</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseEnter</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseLeave</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseMove</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOut</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOver</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseUp</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+This component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+This component has no translations.
+
+## `<Control />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component allows the user to control the different strategy for the refinement (enable / disable refine on map move).
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, Control } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <Control />
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>enableRefineOnMapMove</td>
+      <td>Type: <code>boolean</code></td>
+      <td>Default: <code>true</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>If true, refine will be triggered as you move the map.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>.ais-GeoSearch-control {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The control element of the widget.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-label {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the control element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-input {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The input of the control element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-redo {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The redo search button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>control</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the radio button.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>redo</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the redo button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## `<Redo />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component disable the refine on map move behaviour.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, Redo } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <Redo />
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+The component has no props.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>.ais-GeoSearch-control {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The control element of the widget.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-redo {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The redo search button.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-redo--disabled {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The disabled redo search button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>redo</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the redo button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## `<GoogleMapsLoader />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component provide a built-in solution to load the `google.maps` library in your application. Its usage is completely optional. You can use any strategy you want to load the library. You can find more informations about that in [the Google Maps documentation](https://developers.google.com/maps/documentation/javascript/tutorial).
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GoogleMapsLoader, GeoSearch } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GoogleMapsLoader apiKey="GOOGLE_MAPS_API_KEY">
+      {google => (
+        <GeoSearch google={google}>
+          {({ hits }) => (
+            <Redo />
+          )}
+        </GeoSearch>
+      )}
+    </GoogleMapsLoader>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>apiKey*</td>
+      <td>Type: <code>string</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          Your Google API Key in case you don't have one you can create it on <a href="https://developers.google.com/maps/documentation/javascript/get-api-key" target="_blank" rel="noopener">the Google documentation</a>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>children*</td>
+      <td>Type: <code>(google: object) => React.ReactNode</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          The render function that takes the <code>google</code> object as argument.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>endpoint</td>
+      <td>Type: <code>string</code></td>
+      <td>Default: <code>https://maps.googleapis.com/maps/api/js?v=3.31</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          Endpoint that will be used to fetch the Google Maps library, can be used to load a different version, libraries, ... You can find more inforamtion <a href="https://developers.google.com/maps/documentation/javascript/libraries" target="_blank" rel="noopener">in the Google documentation</a>.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+The component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+The component has no translations keys.

--- a/examples/geo-search/package.json
+++ b/examples/geo-search/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "google-map-react": "0.29.0",
-    "instantsearch.css": "7.0.0",
+    "instantsearch.css": "7.1.0",
     "prop-types": "15.6.0",
     "qs": "6.5.1",
     "react": "16.2.0",

--- a/examples/geo-search/yarn.lock
+++ b/examples/geo-search/yarn.lock
@@ -3475,9 +3475,9 @@ inquirer@3.3.0, inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-instantsearch.css@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.0.0.tgz#74fb9aa25ce64c80effc663fe92bc9ec785cc5e3"
+instantsearch.css@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.1.0.tgz#49264d2bdc3d6c1f6395812ce9422ed1e987fccb"
 
 internal-ip@1.2.0:
   version "1.2.0"

--- a/examples/multi-index/package.json
+++ b/examples/multi-index/package.json
@@ -14,7 +14,7 @@
     "react-test-renderer": "16.2.0"
   },
   "dependencies": {
-    "instantsearch.css": "7.0.0",
+    "instantsearch.css": "7.1.0",
     "prop-types": "15.6.0",
     "react": "16.2.0",
     "react-dom": "16.2.0",

--- a/examples/multi-index/yarn.lock
+++ b/examples/multi-index/yarn.lock
@@ -3238,9 +3238,9 @@ inquirer@3.3.0, inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-instantsearch.css@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.0.0.tgz#74fb9aa25ce64c80effc663fe92bc9ec785cc5e3"
+instantsearch.css@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.1.0.tgz#49264d2bdc3d6c1f6395812ce9422ed1e987fccb"
 
 internal-ip@1.2.0:
   version "1.2.0"

--- a/examples/react-router-v3/package.json
+++ b/examples/react-router-v3/package.json
@@ -15,7 +15,7 @@
     "react-test-renderer": "16.2.0"
   },
   "dependencies": {
-    "instantsearch.css": "7.0.0",
+    "instantsearch.css": "7.1.0",
     "lodash": "4.17.4",
     "prop-types": "15.6.0",
     "qs": "6.5.1",

--- a/examples/react-router-v3/yarn.lock
+++ b/examples/react-router-v3/yarn.lock
@@ -3262,9 +3262,9 @@ inquirer@3.3.0, inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-instantsearch.css@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.0.0.tgz#74fb9aa25ce64c80effc663fe92bc9ec785cc5e3"
+instantsearch.css@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.1.0.tgz#49264d2bdc3d6c1f6395812ce9422ed1e987fccb"
 
 internal-ip@1.2.0:
   version "1.2.0"

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -16,7 +16,7 @@
     "history": "^4.7.2"
   },
   "dependencies": {
-    "instantsearch.css": "7.0.0",
+    "instantsearch.css": "7.1.0",
     "lodash": "4.17.4",
     "prop-types": "15.6.0",
     "qs": "6.5.1",

--- a/examples/react-router/yarn.lock
+++ b/examples/react-router/yarn.lock
@@ -3255,9 +3255,9 @@ inquirer@3.3.0, inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-instantsearch.css@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.0.0.tgz#74fb9aa25ce64c80effc663fe92bc9ec785cc5e3"
+instantsearch.css@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.1.0.tgz#49264d2bdc3d6c1f6395812ce9422ed1e987fccb"
 
 internal-ip@1.2.0:
   version "1.2.0"

--- a/package.json
+++ b/package.json
@@ -110,11 +110,11 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "63 kB"
+      "maxSize": "63.5 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "40 kB"
+      "maxSize": "40.5 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",

--- a/package.json
+++ b/package.json
@@ -73,12 +73,14 @@
     "lodash.orderby": "4.6.0",
     "mversion": "1.10.1",
     "netlify-cli": "1.2.2",
+    "places.js": "1.7.3",
     "prettier": "1.13.5",
     "prop-types": "15.6.1",
     "react": "16.4.1",
     "react-autosuggest": "9.3.4",
     "react-dom": "16.4.1",
     "react-instantsearch-dom": "5.2.0-beta.2",
+    "react-instantsearch-dom-maps": "5.2.0-beta.2",
     "react-native": "0.54.2",
     "rheostat": "2.2.0",
     "storybook-addon-a11y": "3.1.9",
@@ -119,6 +121,10 @@
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
       "maxSize": "63 kB"
+    },
+    {
+      "path": "packages/react-instantsearch-dom-geo/dist/umd/ReactInstantSearchDOMMaps.min.js",
+      "maxSize": "10 kB"
     }
   ]
 }

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -38,8 +38,8 @@ describe('connectGeoSearch', () => {
 
       const expectation = {
         hits: [],
-        position: null,
-        currentRefinement: null,
+        position: undefined,
+        currentRefinement: undefined,
         isRefinedWithMap: false,
       };
 
@@ -146,7 +146,7 @@ describe('connectGeoSearch', () => {
         });
       });
 
-      it('expect to return null from an empty searchState', () => {
+      it('expect to return undefined from an empty searchState', () => {
         const instance = createSingleIndexInstance();
         const props = {};
         const searchState = {};
@@ -159,7 +159,7 @@ describe('connectGeoSearch', () => {
           searchResults
         );
 
-        expect(actual.position).toBe(null);
+        expect(actual.position).toBe(undefined);
       });
     });
 
@@ -200,7 +200,7 @@ describe('connectGeoSearch', () => {
         });
       });
 
-      it('expect to return an null from an empty searchState', () => {
+      it('expect to return an undefined from an empty searchState', () => {
         const instance = createSingleIndexInstance();
         const props = {};
         const searchState = {};
@@ -213,7 +213,7 @@ describe('connectGeoSearch', () => {
           searchResults
         );
 
-        expect(actual.currentRefinement).toBe(null);
+        expect(actual.currentRefinement).toBe(undefined);
       });
     });
 

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -201,7 +201,34 @@ describe('connectGeoSearch', () => {
           });
         });
 
-        it('expect to return an undefined from an empty searchState', () => {
+        it('expect to return the boundingBox from the SearchResults', () => {
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = createSingleSearchResults([], {
+            insideBoundingBox: '10, 12, 12, 14',
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toEqual({
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          });
+        });
+
+        it('expect to return undefined from an empty searchState', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchState = {};
@@ -786,6 +813,33 @@ describe('connectGeoSearch', () => {
                 lng: 14,
               },
             },
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toEqual({
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          });
+        });
+
+        it('expect to return the boundingBox from the SearchResults', () => {
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = createSingleSearchResults([], {
+            insideBoundingBox: '10, 12, 12, 14',
           });
 
           const actual = connector.getProvidedProps.call(

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -417,4 +417,51 @@ describe('connectGeoSearch', () => {
       expect(actual).toEqual(expectation);
     });
   });
+
+  describe('getSearchParameters', () => {
+    it('expect to set the paremeter "insideBoundingBox" when boundingBox is provided', () => {
+      const instance = createSingleIndexInstance();
+      const searchParameters = new SearchParameters();
+      const props = {};
+      const searchState = {
+        boundingBox: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      const actual = connector.getSearchParameters.call(
+        instance,
+        searchParameters,
+        props,
+        searchState
+      );
+
+      const expectation = '10,12,12,14';
+
+      expect(actual.insideBoundingBox).toEqual(expectation);
+    });
+
+    it('expect to return the given searchParameters when boundingBox is omit', () => {
+      const instance = createSingleIndexInstance();
+      const searchParameters = new SearchParameters();
+      const props = {};
+      const searchState = {};
+
+      const actual = connector.getSearchParameters.call(
+        instance,
+        searchParameters,
+        props,
+        searchState
+      );
+
+      expect(actual).toEqual(searchParameters);
+    });
+  });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -464,4 +464,48 @@ describe('connectGeoSearch', () => {
       expect(actual).toEqual(searchParameters);
     });
   });
+
+  describe('cleanUp', () => {
+    it('expect to remove the refinement from the searchState when boundingBox is provided', () => {
+      const instance = createSingleIndexInstance();
+      const props = {};
+      const searchState = {
+        query: 'studio',
+        boundingBox: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      const actual = connector.cleanUp.call(instance, props, searchState);
+
+      const expectation = {
+        query: 'studio',
+      };
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return the given searchState when boundingBox is omit', () => {
+      const instance = createSingleIndexInstance();
+      const props = {};
+      const searchState = {
+        query: 'studio',
+      };
+
+      const actual = connector.cleanUp.call(instance, props, searchState);
+
+      const expectation = {
+        query: 'studio',
+      };
+
+      expect(actual).toEqual(expectation);
+    });
+  });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -222,6 +222,42 @@ describe('connectGeoSearch', () => {
           });
         });
 
+        it('expect to return the boundingBox from the searchState with string values', () => {
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults();
+          const searchState = {
+            boundingBox: {
+              northEast: {
+                lat: '10.12',
+                lng: 12.1,
+              },
+              southWest: {
+                lat: 12.14,
+                lng: '14.12',
+              },
+            },
+          };
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toEqual({
+            northEast: {
+              lat: 10.12,
+              lng: 12.1,
+            },
+            southWest: {
+              lat: 12.14,
+              lng: 14.12,
+            },
+          });
+        });
+
         it('expect to return the boundingBox from the SearchResults', () => {
           const instance = createSingleIndexInstance();
           const props = {};
@@ -860,6 +896,42 @@ describe('connectGeoSearch', () => {
             southWest: {
               lat: 12,
               lng: 14,
+            },
+          });
+        });
+
+        it('expect to return the boundingBox from the searchState with string values', () => {
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults();
+          const searchState = createMultiIndexSearchState({
+            boundingBox: {
+              northEast: {
+                lat: '10.12',
+                lng: 12.1,
+              },
+              southWest: {
+                lat: 12.14,
+                lng: '14.12',
+              },
+            },
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toEqual({
+            northEast: {
+              lat: 10.12,
+              lng: 12.1,
+            },
+            southWest: {
+              lat: 12.14,
+              lng: 14.12,
             },
           });
         });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -508,4 +508,92 @@ describe('connectGeoSearch', () => {
       expect(actual).toEqual(expectation);
     });
   });
+
+  describe('getMetadata', () => {
+    it('expect to return the meta when boudingBox is provided', () => {
+      const instance = createSingleIndexInstance();
+      const props = {};
+      const searchState = {
+        boundingBox: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      const actual = connector.getMetadata.call(instance, props, searchState);
+
+      const expectation = {
+        id: 'boundingBox',
+        index: 'index',
+        items: [
+          {
+            label: 'boundingBox: 10,12,12,14',
+            value: expect.any(Function),
+            currentRefinement: {
+              northEast: {
+                lat: 10,
+                lng: 12,
+              },
+              southWest: {
+                lat: 12,
+                lng: 14,
+              },
+            },
+          },
+        ],
+      };
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return an empty meta when boudingBox is omit', () => {
+      const instance = createSingleIndexInstance();
+      const props = {};
+      const searchState = {};
+
+      const actual = connector.getMetadata.call(instance, props, searchState);
+
+      const expectation = {
+        id: 'boundingBox',
+        index: 'index',
+        items: [],
+      };
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to clear the boundingBox when value is called', () => {
+      const instance = createSingleIndexInstance();
+      const props = {};
+      const searchState = {
+        query: 'studio',
+        boundingBox: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      const metadata = connector.getMetadata.call(instance, props, searchState);
+      const actual = metadata.items[0].value(searchState);
+
+      const expectation = {
+        query: 'studio',
+        page: 1,
+      };
+
+      expect(actual).toEqual(expectation);
+    });
+  });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -300,4 +300,121 @@ describe('connectGeoSearch', () => {
       });
     });
   });
+
+  describe('refine', () => {
+    it('expect to set the boundingBox when boundingBox is provided', () => {
+      const instance = createSingleIndexInstance();
+      const props = {};
+      const searchState = {};
+      const nextRefinement = {
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      };
+
+      const actual = connector.refine.call(
+        instance,
+        props,
+        searchState,
+        nextRefinement
+      );
+
+      const expectation = {
+        page: 1,
+        boundingBox: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to replace the previous value when boundingBox is provided', () => {
+      const instance = createSingleIndexInstance();
+      const props = {};
+      const searchState = {
+        boundingBox: {
+          northEast: {
+            lat: 8,
+            lng: 10,
+          },
+          southWest: {
+            lat: 10,
+            lng: 12,
+          },
+        },
+      };
+
+      const nextRefinement = {
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      };
+
+      const actual = connector.refine.call(
+        instance,
+        props,
+        searchState,
+        nextRefinement
+      );
+
+      const expectation = {
+        page: 1,
+        boundingBox: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to clear the previous value when boundingBox is omit', () => {
+      const instance = createSingleIndexInstance();
+      const props = {};
+      const searchState = {
+        boundingBox: {
+          northEast: {
+            lat: 8,
+            lng: 10,
+          },
+          southWest: {
+            lat: 10,
+            lng: 12,
+          },
+        },
+      };
+
+      const actual = connector.refine.call(instance, props, searchState);
+
+      const expectation = {
+        page: 1,
+      };
+
+      expect(actual).toEqual(expectation);
+    });
+  });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -647,6 +647,15 @@ describe('connectGeoSearch', () => {
         expect(actual).toEqual(expectation);
       });
     });
+
+    describe('shouldUpdate', () => {
+      it('expect to always return true', () => {
+        const expectation = true;
+        const actual = connector.shouldUpdate();
+
+        expect(actual).toBe(expectation);
+      });
+    });
   });
 
   describe('multi index', () => {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -123,7 +123,7 @@ describe('connectGeoSearch', () => {
       });
 
       describe('position', () => {
-        it('expect to return the position from the searchState', () => {
+        it('expect to return the position from the searchState (aroundLatLng)', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchResults = createSingleSearchResults();
@@ -131,6 +131,29 @@ describe('connectGeoSearch', () => {
             aroundLatLng: {
               lat: 10,
               lng: 12,
+            },
+          };
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.position).toEqual({
+            lat: 10,
+            lng: 12,
+          });
+        });
+
+        it('expect to return the position from the searchState (configure.aroundLatLng)', () => {
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults();
+          const searchState = {
+            configure: {
+              aroundLatLng: '10, 12',
             },
           };
 
@@ -822,7 +845,7 @@ describe('connectGeoSearch', () => {
       });
 
       describe('position', () => {
-        it('expect to return the position from the searchState', () => {
+        it('expect to return the position from the searchState (aroundLatLng)', () => {
           const instance = createMultiIndexInstance();
           const props = {};
           const searchResults = createSingleSearchResults();
@@ -830,6 +853,29 @@ describe('connectGeoSearch', () => {
             aroundLatLng: {
               lat: 10,
               lng: 12,
+            },
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.position).toEqual({
+            lat: 10,
+            lng: 12,
+          });
+        });
+
+        it('expect to return the position from the searchState (configure.aroungLatLng)', () => {
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults();
+          const searchState = createMultiIndexSearchState({
+            configure: {
+              aroundLatLng: '10, 12',
             },
           });
 

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -147,6 +147,27 @@ describe('connectGeoSearch', () => {
           });
         });
 
+        it('expect to return the position from the SearchResults', () => {
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = createSingleSearchResults([], {
+            aroundLatLng: '10, 12',
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.position).toEqual({
+            lat: 10,
+            lng: 12,
+          });
+        });
+
         it('expect to return undefined from an empty searchState', () => {
           const instance = createSingleIndexInstance();
           const props = {};

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -1,0 +1,303 @@
+import { SearchResults, SearchParameters } from 'algoliasearch-helper';
+import connector from '../connectGeoSearch';
+
+jest.mock('../../core/createConnector', () => x => x);
+
+describe('connectGeoSearch', () => {
+  const empty = {};
+
+  const createSingleIndexInstance = () => ({
+    context: {
+      ais: {
+        mainTargetedIndex: 'index',
+      },
+    },
+  });
+
+  const createSearchResults = (hits = [], state) => ({
+    results: new SearchResults(new SearchParameters(state), [
+      {
+        hits,
+      },
+    ]),
+  });
+
+  describe('getProvidedProps', () => {
+    it('expect to return default provided props', () => {
+      const instance = createSingleIndexInstance();
+      const props = {};
+      const searchState = {};
+      const searchResults = empty;
+
+      const actual = connector.getProvidedProps.call(
+        instance,
+        props,
+        searchState,
+        searchResults
+      );
+
+      const expectation = {
+        hits: [],
+        position: null,
+        currentRefinement: null,
+        isRefinedWithMap: false,
+      };
+
+      expect(actual).toEqual(expectation);
+    });
+
+    describe('hits', () => {
+      it('expect to return hits when we have results', () => {
+        const hits = [
+          { objectID: '123', _geoloc: true },
+          { objectID: '456', _geoloc: true },
+          { objectID: '789', _geoloc: true },
+        ];
+
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {};
+        const searchResults = createSearchResults(hits);
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        const expectation = [
+          { objectID: '123', _geoloc: true },
+          { objectID: '456', _geoloc: true },
+          { objectID: '789', _geoloc: true },
+        ];
+
+        expect(actual.hits).toEqual(expectation);
+      });
+
+      it('expect to return hits with only "_geoloc" when we have results', () => {
+        const hits = [
+          { objectID: '123', _geoloc: true },
+          { objectID: '456', _geoloc: false },
+          { objectID: '789', _geoloc: true },
+        ];
+
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {};
+        const searchResults = createSearchResults(hits);
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        const expectation = [
+          { objectID: '123', _geoloc: true },
+          { objectID: '789', _geoloc: true },
+        ];
+
+        expect(actual.hits).toEqual(expectation);
+      });
+
+      it("expect to return empty hits when we don't have results", () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {};
+        const searchResults = empty;
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        const expectation = [];
+
+        expect(actual.hits).toEqual(expectation);
+      });
+    });
+
+    describe('position', () => {
+      it('expect to return the position from the searchState', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchResults = createSearchResults();
+        const searchState = {
+          aroundLatLng: {
+            lat: 10,
+            lng: 12,
+          },
+        };
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        expect(actual.position).toEqual({
+          lat: 10,
+          lng: 12,
+        });
+      });
+
+      it('expect to return null from an empty searchState', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {};
+        const searchResults = createSearchResults();
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        expect(actual.position).toBe(null);
+      });
+    });
+
+    describe('currentRefinement', () => {
+      it('expect to return the boundingBox from the searchState', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchResults = createSearchResults();
+        const searchState = {
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        };
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        expect(actual.currentRefinement).toEqual({
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        });
+      });
+
+      it('expect to return an null from an empty searchState', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {};
+        const searchResults = createSearchResults();
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        expect(actual.currentRefinement).toBe(null);
+      });
+    });
+
+    describe('isRefinedWithMap', () => {
+      it("expect to return true when it's refined with the map (from the searchState)", () => {
+        const hits = [
+          { objectID: '123', _geoloc: true },
+          { objectID: '456', _geoloc: true },
+          { objectID: '789', _geoloc: true },
+        ];
+
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchResults = createSearchResults(hits);
+        const searchState = {
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        };
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        expect(actual.isRefinedWithMap).toBe(true);
+      });
+
+      it("expect to return true when it's refined with the map (from the searchParameters)", () => {
+        const sliceSearchParameters = {
+          insideBoundingBox: '10, 12, 12, 14',
+        };
+
+        const hits = [
+          { objectID: '123', _geoloc: true },
+          { objectID: '456', _geoloc: true },
+          { objectID: '789', _geoloc: true },
+        ];
+
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {};
+        const searchResults = createSearchResults(hits, sliceSearchParameters);
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        expect(actual.isRefinedWithMap).toBe(true);
+      });
+
+      it("expect to return false when it's not refined with the map", () => {
+        const hits = [
+          { objectID: '123', _geoloc: true },
+          { objectID: '456', _geoloc: true },
+          { objectID: '789', _geoloc: true },
+        ];
+
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {};
+        const searchResults = createSearchResults(hits);
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        expect(actual.isRefinedWithMap).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -6,103 +6,25 @@ jest.mock('../../core/createConnector', () => x => x);
 describe('connectGeoSearch', () => {
   const empty = {};
 
-  const createSingleIndexInstance = () => ({
-    context: {
-      ais: {
-        mainTargetedIndex: 'index',
+  describe('single index', () => {
+    const createSingleIndexInstance = () => ({
+      context: {
+        ais: {
+          mainTargetedIndex: 'index',
+        },
       },
-    },
-  });
-
-  const createSearchResults = (hits = [], state) => ({
-    results: new SearchResults(new SearchParameters(state), [
-      {
-        hits,
-      },
-    ]),
-  });
-
-  describe('getProvidedProps', () => {
-    it('expect to return default provided props', () => {
-      const instance = createSingleIndexInstance();
-      const props = {};
-      const searchState = {};
-      const searchResults = empty;
-
-      const actual = connector.getProvidedProps.call(
-        instance,
-        props,
-        searchState,
-        searchResults
-      );
-
-      const expectation = {
-        hits: [],
-        position: undefined,
-        currentRefinement: undefined,
-        isRefinedWithMap: false,
-      };
-
-      expect(actual).toEqual(expectation);
     });
 
-    describe('hits', () => {
-      it('expect to return hits when we have results', () => {
-        const hits = [
-          { objectID: '123', _geoloc: true },
-          { objectID: '456', _geoloc: true },
-          { objectID: '789', _geoloc: true },
-        ];
+    const createSingleSearchResults = (hits = [], state) => ({
+      results: new SearchResults(new SearchParameters(state), [
+        {
+          hits,
+        },
+      ]),
+    });
 
-        const instance = createSingleIndexInstance();
-        const props = {};
-        const searchState = {};
-        const searchResults = createSearchResults(hits);
-
-        const actual = connector.getProvidedProps.call(
-          instance,
-          props,
-          searchState,
-          searchResults
-        );
-
-        const expectation = [
-          { objectID: '123', _geoloc: true },
-          { objectID: '456', _geoloc: true },
-          { objectID: '789', _geoloc: true },
-        ];
-
-        expect(actual.hits).toEqual(expectation);
-      });
-
-      it('expect to return hits with only "_geoloc" when we have results', () => {
-        const hits = [
-          { objectID: '123', _geoloc: true },
-          { objectID: '456', _geoloc: false },
-          { objectID: '789', _geoloc: true },
-        ];
-
-        const instance = createSingleIndexInstance();
-        const props = {};
-        const searchState = {};
-        const searchResults = createSearchResults(hits);
-
-        const actual = connector.getProvidedProps.call(
-          instance,
-          props,
-          searchState,
-          searchResults
-        );
-
-        const expectation = [
-          { objectID: '123', _geoloc: true },
-          { objectID: '789', _geoloc: true },
-        ];
-
-        expect(actual.hits).toEqual(expectation);
-      });
-
-      it("expect to return empty hits when we don't have results", () => {
+    describe('getProvidedProps', () => {
+      it('expect to return default provided props', () => {
         const instance = createSingleIndexInstance();
         const props = {};
         const searchState = {};
@@ -115,427 +37,140 @@ describe('connectGeoSearch', () => {
           searchResults
         );
 
-        const expectation = [];
-
-        expect(actual.hits).toEqual(expectation);
-      });
-    });
-
-    describe('position', () => {
-      it('expect to return the position from the searchState', () => {
-        const instance = createSingleIndexInstance();
-        const props = {};
-        const searchResults = createSearchResults();
-        const searchState = {
-          aroundLatLng: {
-            lat: 10,
-            lng: 12,
-          },
+        const expectation = {
+          hits: [],
+          position: undefined,
+          currentRefinement: undefined,
+          isRefinedWithMap: false,
         };
 
-        const actual = connector.getProvidedProps.call(
-          instance,
-          props,
-          searchState,
-          searchResults
-        );
+        expect(actual).toEqual(expectation);
+      });
 
-        expect(actual.position).toEqual({
-          lat: 10,
-          lng: 12,
+      describe('hits', () => {
+        it('expect to return hits when we have results', () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = createSingleSearchResults(hits);
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          const expectation = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          expect(actual.hits).toEqual(expectation);
+        });
+
+        it('expect to return hits with only "_geoloc" when we have results', () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: false },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = createSingleSearchResults(hits);
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          const expectation = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          expect(actual.hits).toEqual(expectation);
+        });
+
+        it("expect to return empty hits when we don't have results", () => {
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = empty;
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          const expectation = [];
+
+          expect(actual.hits).toEqual(expectation);
         });
       });
 
-      it('expect to return undefined from an empty searchState', () => {
-        const instance = createSingleIndexInstance();
-        const props = {};
-        const searchState = {};
-        const searchResults = createSearchResults();
-
-        const actual = connector.getProvidedProps.call(
-          instance,
-          props,
-          searchState,
-          searchResults
-        );
-
-        expect(actual.position).toBe(undefined);
-      });
-    });
-
-    describe('currentRefinement', () => {
-      it('expect to return the boundingBox from the searchState', () => {
-        const instance = createSingleIndexInstance();
-        const props = {};
-        const searchResults = createSearchResults();
-        const searchState = {
-          boundingBox: {
-            northEast: {
+      describe('position', () => {
+        it('expect to return the position from the searchState', () => {
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults();
+          const searchState = {
+            aroundLatLng: {
               lat: 10,
               lng: 12,
             },
-            southWest: {
-              lat: 12,
-              lng: 14,
-            },
-          },
-        };
+          };
 
-        const actual = connector.getProvidedProps.call(
-          instance,
-          props,
-          searchState,
-          searchResults
-        );
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
 
-        expect(actual.currentRefinement).toEqual({
-          northEast: {
+          expect(actual.position).toEqual({
             lat: 10,
             lng: 12,
-          },
-          southWest: {
-            lat: 12,
-            lng: 14,
-          },
+          });
+        });
+
+        it('expect to return undefined from an empty searchState', () => {
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = createSingleSearchResults();
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.position).toBe(undefined);
         });
       });
 
-      it('expect to return an undefined from an empty searchState', () => {
-        const instance = createSingleIndexInstance();
-        const props = {};
-        const searchState = {};
-        const searchResults = createSearchResults();
-
-        const actual = connector.getProvidedProps.call(
-          instance,
-          props,
-          searchState,
-          searchResults
-        );
-
-        expect(actual.currentRefinement).toBe(undefined);
-      });
-    });
-
-    describe('isRefinedWithMap', () => {
-      it("expect to return true when it's refined with the map (from the searchState)", () => {
-        const hits = [
-          { objectID: '123', _geoloc: true },
-          { objectID: '456', _geoloc: true },
-          { objectID: '789', _geoloc: true },
-        ];
-
-        const instance = createSingleIndexInstance();
-        const props = {};
-        const searchResults = createSearchResults(hits);
-        const searchState = {
-          boundingBox: {
-            northEast: {
-              lat: 10,
-              lng: 12,
-            },
-            southWest: {
-              lat: 12,
-              lng: 14,
-            },
-          },
-        };
-
-        const actual = connector.getProvidedProps.call(
-          instance,
-          props,
-          searchState,
-          searchResults
-        );
-
-        expect(actual.isRefinedWithMap).toBe(true);
-      });
-
-      it("expect to return true when it's refined with the map (from the searchParameters)", () => {
-        const sliceSearchParameters = {
-          insideBoundingBox: '10, 12, 12, 14',
-        };
-
-        const hits = [
-          { objectID: '123', _geoloc: true },
-          { objectID: '456', _geoloc: true },
-          { objectID: '789', _geoloc: true },
-        ];
-
-        const instance = createSingleIndexInstance();
-        const props = {};
-        const searchState = {};
-        const searchResults = createSearchResults(hits, sliceSearchParameters);
-
-        const actual = connector.getProvidedProps.call(
-          instance,
-          props,
-          searchState,
-          searchResults
-        );
-
-        expect(actual.isRefinedWithMap).toBe(true);
-      });
-
-      it("expect to return false when it's not refined with the map", () => {
-        const hits = [
-          { objectID: '123', _geoloc: true },
-          { objectID: '456', _geoloc: true },
-          { objectID: '789', _geoloc: true },
-        ];
-
-        const instance = createSingleIndexInstance();
-        const props = {};
-        const searchState = {};
-        const searchResults = createSearchResults(hits);
-
-        const actual = connector.getProvidedProps.call(
-          instance,
-          props,
-          searchState,
-          searchResults
-        );
-
-        expect(actual.isRefinedWithMap).toBe(false);
-      });
-    });
-  });
-
-  describe('refine', () => {
-    it('expect to set the boundingBox when boundingBox is provided', () => {
-      const instance = createSingleIndexInstance();
-      const props = {};
-      const searchState = {};
-      const nextRefinement = {
-        northEast: {
-          lat: 10,
-          lng: 12,
-        },
-        southWest: {
-          lat: 12,
-          lng: 14,
-        },
-      };
-
-      const actual = connector.refine.call(
-        instance,
-        props,
-        searchState,
-        nextRefinement
-      );
-
-      const expectation = {
-        page: 1,
-        boundingBox: {
-          northEast: {
-            lat: 10,
-            lng: 12,
-          },
-          southWest: {
-            lat: 12,
-            lng: 14,
-          },
-        },
-      };
-
-      expect(actual).toEqual(expectation);
-    });
-
-    it('expect to replace the previous value when boundingBox is provided', () => {
-      const instance = createSingleIndexInstance();
-      const props = {};
-      const searchState = {
-        boundingBox: {
-          northEast: {
-            lat: 8,
-            lng: 10,
-          },
-          southWest: {
-            lat: 10,
-            lng: 12,
-          },
-        },
-      };
-
-      const nextRefinement = {
-        northEast: {
-          lat: 10,
-          lng: 12,
-        },
-        southWest: {
-          lat: 12,
-          lng: 14,
-        },
-      };
-
-      const actual = connector.refine.call(
-        instance,
-        props,
-        searchState,
-        nextRefinement
-      );
-
-      const expectation = {
-        page: 1,
-        boundingBox: {
-          northEast: {
-            lat: 10,
-            lng: 12,
-          },
-          southWest: {
-            lat: 12,
-            lng: 14,
-          },
-        },
-      };
-
-      expect(actual).toEqual(expectation);
-    });
-
-    it('expect to clear the previous value when boundingBox is omit', () => {
-      const instance = createSingleIndexInstance();
-      const props = {};
-      const searchState = {
-        boundingBox: {
-          northEast: {
-            lat: 8,
-            lng: 10,
-          },
-          southWest: {
-            lat: 10,
-            lng: 12,
-          },
-        },
-      };
-
-      const actual = connector.refine.call(instance, props, searchState);
-
-      const expectation = {
-        page: 1,
-      };
-
-      expect(actual).toEqual(expectation);
-    });
-  });
-
-  describe('getSearchParameters', () => {
-    it('expect to set the paremeter "insideBoundingBox" when boundingBox is provided', () => {
-      const instance = createSingleIndexInstance();
-      const searchParameters = new SearchParameters();
-      const props = {};
-      const searchState = {
-        boundingBox: {
-          northEast: {
-            lat: 10,
-            lng: 12,
-          },
-          southWest: {
-            lat: 12,
-            lng: 14,
-          },
-        },
-      };
-
-      const actual = connector.getSearchParameters.call(
-        instance,
-        searchParameters,
-        props,
-        searchState
-      );
-
-      const expectation = '10,12,12,14';
-
-      expect(actual.insideBoundingBox).toEqual(expectation);
-    });
-
-    it('expect to return the given searchParameters when boundingBox is omit', () => {
-      const instance = createSingleIndexInstance();
-      const searchParameters = new SearchParameters();
-      const props = {};
-      const searchState = {};
-
-      const actual = connector.getSearchParameters.call(
-        instance,
-        searchParameters,
-        props,
-        searchState
-      );
-
-      expect(actual).toEqual(searchParameters);
-    });
-  });
-
-  describe('cleanUp', () => {
-    it('expect to remove the refinement from the searchState when boundingBox is provided', () => {
-      const instance = createSingleIndexInstance();
-      const props = {};
-      const searchState = {
-        query: 'studio',
-        boundingBox: {
-          northEast: {
-            lat: 10,
-            lng: 12,
-          },
-          southWest: {
-            lat: 12,
-            lng: 14,
-          },
-        },
-      };
-
-      const actual = connector.cleanUp.call(instance, props, searchState);
-
-      const expectation = {
-        query: 'studio',
-      };
-
-      expect(actual).toEqual(expectation);
-    });
-
-    it('expect to return the given searchState when boundingBox is omit', () => {
-      const instance = createSingleIndexInstance();
-      const props = {};
-      const searchState = {
-        query: 'studio',
-      };
-
-      const actual = connector.cleanUp.call(instance, props, searchState);
-
-      const expectation = {
-        query: 'studio',
-      };
-
-      expect(actual).toEqual(expectation);
-    });
-  });
-
-  describe('getMetadata', () => {
-    it('expect to return the meta when boudingBox is provided', () => {
-      const instance = createSingleIndexInstance();
-      const props = {};
-      const searchState = {
-        boundingBox: {
-          northEast: {
-            lat: 10,
-            lng: 12,
-          },
-          southWest: {
-            lat: 12,
-            lng: 14,
-          },
-        },
-      };
-
-      const actual = connector.getMetadata.call(instance, props, searchState);
-
-      const expectation = {
-        id: 'boundingBox',
-        index: 'index',
-        items: [
-          {
-            label: 'boundingBox: 10,12,12,14',
-            value: expect.any(Function),
-            currentRefinement: {
+      describe('currentRefinement', () => {
+        it('expect to return the boundingBox from the searchState', () => {
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults();
+          const searchState = {
+            boundingBox: {
               northEast: {
                 lat: 10,
                 lng: 12,
@@ -545,35 +180,132 @@ describe('connectGeoSearch', () => {
                 lng: 14,
               },
             },
-          },
-        ],
-      };
+          };
 
-      expect(actual).toEqual(expectation);
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toEqual({
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          });
+        });
+
+        it('expect to return an undefined from an empty searchState', () => {
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = createSingleSearchResults();
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toBe(undefined);
+        });
+      });
+
+      describe('isRefinedWithMap', () => {
+        it("expect to return true when it's refined with the map (from the searchState)", () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults(hits);
+          const searchState = {
+            boundingBox: {
+              northEast: {
+                lat: 10,
+                lng: 12,
+              },
+              southWest: {
+                lat: 12,
+                lng: 14,
+              },
+            },
+          };
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.isRefinedWithMap).toBe(true);
+        });
+
+        it("expect to return true when it's refined with the map (from the searchParameters)", () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = createSingleSearchResults(hits, {
+            insideBoundingBox: '10, 12, 12, 14',
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.isRefinedWithMap).toBe(true);
+        });
+
+        it("expect to return false when it's not refined with the map", () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createSingleIndexInstance();
+          const props = {};
+          const searchState = {};
+          const searchResults = createSingleSearchResults(hits);
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.isRefinedWithMap).toBe(false);
+        });
+      });
     });
 
-    it('expect to return an empty meta when boudingBox is omit', () => {
-      const instance = createSingleIndexInstance();
-      const props = {};
-      const searchState = {};
-
-      const actual = connector.getMetadata.call(instance, props, searchState);
-
-      const expectation = {
-        id: 'boundingBox',
-        index: 'index',
-        items: [],
-      };
-
-      expect(actual).toEqual(expectation);
-    });
-
-    it('expect to clear the boundingBox when value is called', () => {
-      const instance = createSingleIndexInstance();
-      const props = {};
-      const searchState = {
-        query: 'studio',
-        boundingBox: {
+    describe('refine', () => {
+      it('expect to set the boundingBox when boundingBox is provided', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {};
+        const nextRefinement = {
           northEast: {
             lat: 10,
             lng: 12,
@@ -582,18 +314,921 @@ describe('connectGeoSearch', () => {
             lat: 12,
             lng: 14,
           },
+        };
+
+        const actual = connector.refine.call(
+          instance,
+          props,
+          searchState,
+          nextRefinement
+        );
+
+        const expectation = {
+          page: 1,
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to replace the previous value when boundingBox is provided', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {
+          boundingBox: {
+            northEast: {
+              lat: 8,
+              lng: 10,
+            },
+            southWest: {
+              lat: 10,
+              lng: 12,
+            },
+          },
+        };
+
+        const nextRefinement = {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        };
+
+        const actual = connector.refine.call(
+          instance,
+          props,
+          searchState,
+          nextRefinement
+        );
+
+        const expectation = {
+          page: 1,
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to clear the previous value when boundingBox is omit', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {
+          boundingBox: {
+            northEast: {
+              lat: 8,
+              lng: 10,
+            },
+            southWest: {
+              lat: 10,
+              lng: 12,
+            },
+          },
+        };
+
+        const actual = connector.refine.call(instance, props, searchState);
+
+        const expectation = {
+          page: 1,
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+    });
+
+    describe('getSearchParameters', () => {
+      it('expect to set the paremeter "insideBoundingBox" when boundingBox is provided', () => {
+        const instance = createSingleIndexInstance();
+        const searchParameters = new SearchParameters();
+        const props = {};
+        const searchState = {
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        };
+
+        const actual = connector.getSearchParameters.call(
+          instance,
+          searchParameters,
+          props,
+          searchState
+        );
+
+        const expectation = '10,12,12,14';
+
+        expect(actual.insideBoundingBox).toEqual(expectation);
+      });
+
+      it('expect to return the given searchParameters when boundingBox is omit', () => {
+        const instance = createSingleIndexInstance();
+        const searchParameters = new SearchParameters();
+        const props = {};
+        const searchState = {};
+
+        const actual = connector.getSearchParameters.call(
+          instance,
+          searchParameters,
+          props,
+          searchState
+        );
+
+        expect(actual).toEqual(searchParameters);
+      });
+    });
+
+    describe('cleanUp', () => {
+      it('expect to remove the refinement from the searchState when boundingBox is provided', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {
+          query: 'studio',
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        };
+
+        const actual = connector.cleanUp.call(instance, props, searchState);
+
+        const expectation = {
+          query: 'studio',
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to return the given searchState when boundingBox is omit', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {
+          query: 'studio',
+        };
+
+        const actual = connector.cleanUp.call(instance, props, searchState);
+
+        const expectation = {
+          query: 'studio',
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+    });
+
+    describe('getMetadata', () => {
+      it('expect to return the meta when boudingBox is provided', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        };
+
+        const actual = connector.getMetadata.call(instance, props, searchState);
+
+        const expectation = {
+          id: 'boundingBox',
+          index: 'index',
+          items: [
+            {
+              label: 'boundingBox: 10,12,12,14',
+              value: expect.any(Function),
+              currentRefinement: {
+                northEast: {
+                  lat: 10,
+                  lng: 12,
+                },
+                southWest: {
+                  lat: 12,
+                  lng: 14,
+                },
+              },
+            },
+          ],
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to return an empty meta when boudingBox is omit', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {};
+
+        const actual = connector.getMetadata.call(instance, props, searchState);
+
+        const expectation = {
+          id: 'boundingBox',
+          index: 'index',
+          items: [],
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to clear the boundingBox when value is called', () => {
+        const instance = createSingleIndexInstance();
+        const props = {};
+        const searchState = {
+          query: 'studio',
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        };
+
+        const metadata = connector.getMetadata.call(
+          instance,
+          props,
+          searchState
+        );
+        const actual = metadata.items[0].value(searchState);
+
+        const expectation = {
+          query: 'studio',
+          page: 1,
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+    });
+  });
+
+  describe('multi index', () => {
+    const createMultiIndexInstance = () => ({
+      context: {
+        ais: {
+          mainTargetedIndex: 'first',
         },
-      };
+        multiIndexContext: {
+          targetedIndex: 'second',
+        },
+      },
+    });
 
-      const metadata = connector.getMetadata.call(instance, props, searchState);
-      const actual = metadata.items[0].value(searchState);
+    const createMultiIndexSearchState = (state = {}) => ({
+      indices: {
+        second: state,
+      },
+    });
 
-      const expectation = {
-        query: 'studio',
-        page: 1,
-      };
+    const createSingleSearchResults = (hits = [], state) => ({
+      results: {
+        second: new SearchResults(new SearchParameters(state), [
+          {
+            hits,
+          },
+        ]),
+      },
+    });
 
-      expect(actual).toEqual(expectation);
+    describe('getProvidedProps', () => {
+      it('expect to return default provided props', () => {
+        const instance = createMultiIndexInstance();
+        const props = {};
+        const searchState = createMultiIndexSearchState();
+        const searchResults = empty;
+
+        const actual = connector.getProvidedProps.call(
+          instance,
+          props,
+          searchState,
+          searchResults
+        );
+
+        const expectation = {
+          hits: [],
+          position: undefined,
+          currentRefinement: undefined,
+          isRefinedWithMap: false,
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      describe('hits', () => {
+        it('expect to return hits when we have results', () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchState = createMultiIndexSearchState();
+          const searchResults = createSingleSearchResults(hits);
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          const expectation = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          expect(actual.hits).toEqual(expectation);
+        });
+
+        it('expect to return hits with only "_geoloc" when we have results', () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: false },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchState = createMultiIndexSearchState();
+          const searchResults = createSingleSearchResults(hits);
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          const expectation = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          expect(actual.hits).toEqual(expectation);
+        });
+
+        it("expect to return empty hits when we don't have results", () => {
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchState = createMultiIndexSearchState();
+          const searchResults = empty;
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          const expectation = [];
+
+          expect(actual.hits).toEqual(expectation);
+        });
+      });
+
+      describe('position', () => {
+        it('expect to return the position from the searchState', () => {
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults();
+          const searchState = createMultiIndexSearchState({
+            aroundLatLng: {
+              lat: 10,
+              lng: 12,
+            },
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.position).toEqual({
+            lat: 10,
+            lng: 12,
+          });
+        });
+
+        it('expect to return undefined from an empty searchState', () => {
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchState = createMultiIndexSearchState();
+          const searchResults = createSingleSearchResults();
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.position).toBe(undefined);
+        });
+      });
+
+      describe('currentRefinement', () => {
+        it('expect to return the boundingBox from the searchState', () => {
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults();
+          const searchState = createMultiIndexSearchState({
+            boundingBox: {
+              northEast: {
+                lat: 10,
+                lng: 12,
+              },
+              southWest: {
+                lat: 12,
+                lng: 14,
+              },
+            },
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toEqual({
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          });
+        });
+
+        it('expect to return an undefined from an empty searchState', () => {
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchState = createMultiIndexSearchState();
+          const searchResults = createSingleSearchResults();
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toBe(undefined);
+        });
+      });
+
+      describe('isRefinedWithMap', () => {
+        it("expect to return true when it's refined with the map (from the searchState)", () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchResults = createSingleSearchResults(hits);
+          const searchState = createMultiIndexSearchState({
+            boundingBox: {
+              northEast: {
+                lat: 10,
+                lng: 12,
+              },
+              southWest: {
+                lat: 12,
+                lng: 14,
+              },
+            },
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.isRefinedWithMap).toBe(true);
+        });
+
+        it("expect to return true when it's refined with the map (from the searchParameters)", () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchState = createMultiIndexSearchState();
+          const searchResults = createSingleSearchResults(hits, {
+            insideBoundingBox: '10, 12, 12, 14',
+          });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.isRefinedWithMap).toBe(true);
+        });
+
+        it("expect to return false when it's not refined with the map", () => {
+          const hits = [
+            { objectID: '123', _geoloc: true },
+            { objectID: '456', _geoloc: true },
+            { objectID: '789', _geoloc: true },
+          ];
+
+          const instance = createMultiIndexInstance();
+          const props = {};
+          const searchState = createMultiIndexSearchState();
+          const searchResults = createSingleSearchResults(hits);
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.isRefinedWithMap).toBe(false);
+        });
+      });
+    });
+
+    describe('refine', () => {
+      it('expect to set the boundingBox when boundingBox is provided', () => {
+        const instance = createMultiIndexInstance();
+        const props = {};
+        const searchState = createMultiIndexSearchState();
+        const nextRefinement = {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        };
+
+        const actual = connector.refine.call(
+          instance,
+          props,
+          searchState,
+          nextRefinement
+        );
+
+        const expectation = {
+          indices: {
+            second: {
+              page: 1,
+              boundingBox: {
+                northEast: {
+                  lat: 10,
+                  lng: 12,
+                },
+                southWest: {
+                  lat: 12,
+                  lng: 14,
+                },
+              },
+            },
+          },
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to replace the previous value when boundingBox is provided', () => {
+        const instance = createMultiIndexInstance();
+        const props = {};
+        const searchState = createMultiIndexSearchState({
+          boundingBox: {
+            northEast: {
+              lat: 8,
+              lng: 10,
+            },
+            southWest: {
+              lat: 10,
+              lng: 12,
+            },
+          },
+        });
+
+        const nextRefinement = {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        };
+
+        const actual = connector.refine.call(
+          instance,
+          props,
+          searchState,
+          nextRefinement
+        );
+
+        const expectation = {
+          indices: {
+            second: {
+              page: 1,
+              boundingBox: {
+                northEast: {
+                  lat: 10,
+                  lng: 12,
+                },
+                southWest: {
+                  lat: 12,
+                  lng: 14,
+                },
+              },
+            },
+          },
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to clear the previous value when boundingBox is omit', () => {
+        const instance = createMultiIndexInstance();
+        const props = {};
+        const searchState = createMultiIndexSearchState({
+          boundingBox: {
+            northEast: {
+              lat: 8,
+              lng: 10,
+            },
+            southWest: {
+              lat: 10,
+              lng: 12,
+            },
+          },
+        });
+
+        const actual = connector.refine.call(instance, props, searchState);
+
+        const expectation = {
+          indices: {
+            second: {
+              page: 1,
+            },
+          },
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+    });
+
+    describe('getSearchParameters', () => {
+      it('expect to set the paremeter "insideBoundingBox" when boundingBox is provided', () => {
+        const instance = createMultiIndexInstance();
+        const searchParameters = new SearchParameters();
+        const props = {};
+        const searchState = createMultiIndexSearchState({
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        });
+
+        const actual = connector.getSearchParameters.call(
+          instance,
+          searchParameters,
+          props,
+          searchState
+        );
+
+        const expectation = '10,12,12,14';
+
+        expect(actual.insideBoundingBox).toEqual(expectation);
+      });
+
+      it('expect to return the given searchParameters when boundingBox is omit', () => {
+        const instance = createMultiIndexInstance();
+        const searchParameters = new SearchParameters();
+        const props = {};
+        const searchState = {};
+
+        const actual = connector.getSearchParameters.call(
+          instance,
+          searchParameters,
+          props,
+          searchState
+        );
+
+        expect(actual).toEqual(searchParameters);
+      });
+    });
+
+    describe('cleanUp', () => {
+      it('expect to remove the refinement from the searchState when boundingBox is provided', () => {
+        const instance = createMultiIndexInstance();
+        const props = {};
+        const searchState = createMultiIndexSearchState({
+          query: 'studio',
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        });
+
+        const actual = connector.cleanUp.call(instance, props, searchState);
+
+        const expectation = {
+          indices: {
+            second: {
+              query: 'studio',
+            },
+          },
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to return the given searchState when boundingBox is omit', () => {
+        const instance = createMultiIndexInstance();
+        const props = {};
+        const searchState = createMultiIndexSearchState({
+          query: 'studio',
+        });
+
+        const actual = connector.cleanUp.call(instance, props, searchState);
+
+        const expectation = {
+          indices: {
+            second: {
+              query: 'studio',
+            },
+          },
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+    });
+
+    describe('getMetadata', () => {
+      it('expect to return the meta when boudingBox is provided', () => {
+        const instance = createMultiIndexInstance();
+        const props = {};
+        const searchState = createMultiIndexSearchState({
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        });
+
+        const actual = connector.getMetadata.call(instance, props, searchState);
+
+        const expectation = {
+          id: 'boundingBox',
+          index: 'second',
+          items: [
+            {
+              label: 'boundingBox: 10,12,12,14',
+              value: expect.any(Function),
+              currentRefinement: {
+                northEast: {
+                  lat: 10,
+                  lng: 12,
+                },
+                southWest: {
+                  lat: 12,
+                  lng: 14,
+                },
+              },
+            },
+          ],
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to return an empty meta when boudingBox is omit', () => {
+        const instance = createMultiIndexInstance();
+        const props = {};
+        const searchState = createMultiIndexSearchState();
+
+        const actual = connector.getMetadata.call(instance, props, searchState);
+
+        const expectation = {
+          id: 'boundingBox',
+          index: 'second',
+          items: [],
+        };
+
+        expect(actual).toEqual(expectation);
+      });
+
+      it('expect to clear the boundingBox when value is called', () => {
+        const instance = createMultiIndexInstance();
+        const props = {};
+        const searchState = createMultiIndexSearchState({
+          query: 'studio',
+          boundingBox: {
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          },
+        });
+
+        const metadata = connector.getMetadata.call(
+          instance,
+          props,
+          searchState
+        );
+
+        const actual = metadata.items[0].value(searchState);
+
+        const expectation = {
+          indices: {
+            second: {
+              query: 'studio',
+              page: 1,
+            },
+          },
+        };
+
+        expect(actual).toEqual(expectation);
+      });
     });
   });
 });

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -29,11 +29,32 @@ import {
 const getBoundingBoxId = () => 'boundingBox';
 const getAroundLatLngId = () => 'aroundLatLng';
 
-const getRefinement = id => (props, searchState, context) =>
-  getCurrentRefinementValue(props, searchState, context, id);
+const getCurrentRefinement = (props, searchState, context) => {
+  const refinement = getCurrentRefinementValue(
+    props,
+    searchState,
+    context,
+    getBoundingBoxId()
+  );
 
-const getCurrentRefinement = getRefinement(getBoundingBoxId());
-const getCurrentPosition = getRefinement(getAroundLatLngId());
+  if (!refinement) {
+    return refinement;
+  }
+
+  return {
+    northEast: {
+      lat: parseFloat(refinement.northEast.lat),
+      lng: parseFloat(refinement.northEast.lng),
+    },
+    southWest: {
+      lat: parseFloat(refinement.southWest.lat),
+      lng: parseFloat(refinement.southWest.lng),
+    },
+  };
+};
+
+const getCurrentPosition = (props, searchState, context) =>
+  getCurrentRefinementValue(props, searchState, context, getAroundLatLngId());
 
 const refine = (searchState, nextValue, context) => {
   const resetPage = true;

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -7,31 +7,16 @@ import {
   cleanUpValue,
 } from '../core/indexUtils';
 
-const getBoundingBoxId = () => 'boundingBox';
-
 // To control the map with an external widget the other widget
-// must write the value in the attribute `aroundLatLng`
+// **must** write the value in the attribute `aroundLatLng`
+const getBoundingBoxId = () => 'boundingBox';
 const getAroundLatLngId = () => 'aroundLatLng';
 
-const getCurrentRefinement = (props, searchState, context) =>
-  getCurrentRefinementValue(
-    props,
-    searchState,
-    context,
-    getBoundingBoxId(),
-    null,
-    x => x
-  );
+const getRefinement = id => (props, searchState, context) =>
+  getCurrentRefinementValue(props, searchState, context, id);
 
-const getCurrentPosition = (props, searchState, context) =>
-  getCurrentRefinementValue(
-    props,
-    searchState,
-    context,
-    getAroundLatLngId(),
-    null,
-    x => x
-  );
+const getCurrentRefinement = getRefinement(getBoundingBoxId());
+const getCurrentPosition = getRefinement(getAroundLatLngId());
 
 const refine = (searchState, nextValue, context) => {
   const resetPage = true;

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -125,12 +125,12 @@ export default createConnector({
   getProvidedProps(props, searchState, searchResults) {
     const results = getResults(searchResults, this.context);
 
-    // We read it from both becuase the SearchParameters & the searchState are not always
-    // in sync. When we set the refinement the searchState is used when we clear the refinement
-    // the SearchParameters is used. In the first case when we render the results are not there
+    // We read it from both because the SearchParameters & the searchState are not always
+    // in sync. When we set the refinement the searchState is used but when we clear the refinement
+    // the SearchParameters is used. In the first case when we render, the results are not there
     // so we can't find the value from the results. The most up to date value is the searchState.
-    // But whren we clear the refinement the searchState is immediatly clear even when the items
-    // retrieve are still the one from the previous query with the bounding box. It leads to some
+    // But when we clear the refinement the searchState is immediatly cleared even when the items
+    // retrieved are still the one from the previous query with the bounding box. It leads to some
     // issue with the position of the map. We should rely on 1 source of truth or at least always
     // be sync.
 

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -179,4 +179,8 @@ export default createConnector({
       items,
     };
   },
+
+  shouldUpdate() {
+    return true;
+  },
 });

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -73,4 +73,26 @@ export default createConnector({
 
     return refineValue(searchState, nextRefinement, this.context, resetPage);
   },
+
+  getSearchParameters(searchParameters, props, searchState) {
+    const currentRefinement = getCurrentRefinement(
+      props,
+      searchState,
+      this.context
+    );
+
+    if (!currentRefinement) {
+      return searchParameters;
+    }
+
+    return searchParameters.setQueryParameter(
+      'insideBoundingBox',
+      [
+        currentRefinement.northEast.lat,
+        currentRefinement.northEast.lng,
+        currentRefinement.southWest.lat,
+        currentRefinement.southWest.lng,
+      ].join()
+    );
+  },
 });

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -7,6 +7,23 @@ import {
   cleanUpValue,
 } from '../core/indexUtils';
 
+/**
+ * The GeoSearch connector provides the logic to build a widget that will display the results on a map.
+ * It also provides a way to search for results based on their position. The connector provides function to manage the search experience (search on map interaction).
+ * @name connectGeoSearch
+ * @kind connector
+ * @requirements Note that the GeoSearch connector uses the [geosearch](https://www.algolia.com/doc/guides/searching/geo-search) capabilities of Algolia.
+ * Your hits **must** have a `_geoloc` attribute in order to be passed to the rendering function.
+ * Currently, the feature is not compatible with multiple values in the `_geoloc` attribute.
+ * @propType {{ northEast: { lat: number, lng: number }, southWest: { lat: number, lng: number } }} [defaultRefinement] - Default search state of the widget containing the bounds for the map
+ * @providedPropType {function({ northEast: { lat: number, lng: number }, southWest: { lat: number, lng: number } })} refine - a function to toggle the refinement
+ * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
+ * @providedPropType {array.<object>} hits - the records that matched the search
+ * @providedPropType {boolean} isRefinedWithMap - true if the current refinement is set with the map bounds
+ * @providedPropType {{ northEast: { lat: number, lng: number }, southWest: { lat: number, lng: number } }} [currentRefinement] - the refinement currently applied
+ * @providedPropType {{ lat: number, lng: number }} [position] - the position of the search
+ */
+
 // To control the map with an external widget the other widget
 // **must** write the value in the attribute `aroundLatLng`
 const getBoundingBoxId = () => 'boundingBox';

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -1,0 +1,63 @@
+import createConnector from '../core/createConnector';
+import { getResults, getCurrentRefinementValue } from '../core/indexUtils';
+
+const getBoundingBoxId = () => 'boundingBox';
+
+// To control the map with an external widget the other widget
+// must write the value in the attribute `aroundLatLng`
+const getAroundLatLngId = () => 'aroundLatLng';
+
+const getCurrentRefinement = (props, searchState, context) =>
+  getCurrentRefinementValue(
+    props,
+    searchState,
+    context,
+    getBoundingBoxId(),
+    null,
+    x => x
+  );
+
+const getCurrentPosition = (props, searchState, context) =>
+  getCurrentRefinementValue(
+    props,
+    searchState,
+    context,
+    getAroundLatLngId(),
+    null,
+    x => x
+  );
+
+export default createConnector({
+  displayName: 'AlgoliaGeoSearch',
+
+  getProvidedProps(props, searchState, searchResults) {
+    const results = getResults(searchResults, this.context);
+    const currentRefinement = getCurrentRefinement(
+      props,
+      searchState,
+      this.context
+    );
+
+    const isRefinedWithMapFromSearchState = Boolean(currentRefinement);
+    const isRefinedWithMapFromSearchParameters = Boolean(
+      results && results._state.insideBoundingBox
+    );
+
+    const isRefinedWithMap =
+      // We read it from both becuase the SearchParameters & the searchState are not always
+      // in sync. When we set the refinement the searchState is used when we clear the refinement
+      // the SearchParameters is used. In the first case when we render the results are not there
+      // so we can't find the value from the results. The most up to date value is the searchState.
+      // But whren we clear the refinement the searchState is immediatly clear even when the items
+      // retrieve are still the one from the previous query with the bounding box. It leads to some
+      // issue with fitBounds.
+      isRefinedWithMapFromSearchState || isRefinedWithMapFromSearchParameters;
+
+    return {
+      hits: !results ? [] : results.hits.filter(_ => Boolean(_._geoloc)),
+      position: getCurrentPosition(props, searchState, this.context),
+      currentRefinement,
+      isRefinedWithMap,
+    };
+  },
+});

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -1,5 +1,9 @@
 import createConnector from '../core/createConnector';
-import { getResults, getCurrentRefinementValue } from '../core/indexUtils';
+import {
+  getResults,
+  getCurrentRefinementValue,
+  refineValue,
+} from '../core/indexUtils';
 
 const getBoundingBoxId = () => 'boundingBox';
 
@@ -59,5 +63,14 @@ export default createConnector({
       currentRefinement,
       isRefinedWithMap,
     };
+  },
+
+  refine(props, searchState, nextValue) {
+    const resetPage = true;
+    const nextRefinement = {
+      [getBoundingBoxId()]: nextValue,
+    };
+
+    return refineValue(searchState, nextRefinement, this.context, resetPage);
   },
 });

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -3,6 +3,7 @@ import {
   getResults,
   getCurrentRefinementValue,
   refineValue,
+  cleanUpValue,
 } from '../core/indexUtils';
 
 const getBoundingBoxId = () => 'boundingBox';
@@ -94,5 +95,9 @@ export default createConnector({
         currentRefinement.southWest.lng,
       ].join()
     );
+  },
+
+  cleanUp(props, searchState) {
+    return cleanUpValue(searchState, this.context, getBoundingBoxId());
   },
 });

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -28,42 +28,7 @@ import {
 // **must** write the value in the attribute `aroundLatLng`
 const getBoundingBoxId = () => 'boundingBox';
 const getAroundLatLngId = () => 'aroundLatLng';
-
-const getCurrentRefinement = (props, searchState, context) => {
-  const refinement = getCurrentRefinementValue(
-    props,
-    searchState,
-    context,
-    getBoundingBoxId()
-  );
-
-  if (!refinement) {
-    return refinement;
-  }
-
-  return {
-    northEast: {
-      lat: parseFloat(refinement.northEast.lat),
-      lng: parseFloat(refinement.northEast.lng),
-    },
-    southWest: {
-      lat: parseFloat(refinement.southWest.lat),
-      lng: parseFloat(refinement.southWest.lng),
-    },
-  };
-};
-
-const getCurrentPosition = (props, searchState, context) =>
-  getCurrentRefinementValue(props, searchState, context, getAroundLatLngId());
-
-const refine = (searchState, nextValue, context) => {
-  const resetPage = true;
-  const nextRefinement = {
-    [getBoundingBoxId()]: nextValue,
-  };
-
-  return refineValue(searchState, nextRefinement, context, resetPage);
-};
+const getConfigureAroundLatLngId = () => 'configure.aroundLatLng';
 
 const currentRefinementToString = currentRefinement =>
   [
@@ -96,6 +61,62 @@ const stringToPosition = value => {
     lat: parseFloat(pattern[1]),
     lng: parseFloat(pattern[2]),
   };
+};
+
+const getCurrentRefinement = (props, searchState, context) => {
+  const refinement = getCurrentRefinementValue(
+    props,
+    searchState,
+    context,
+    getBoundingBoxId()
+  );
+
+  if (!refinement) {
+    return refinement;
+  }
+
+  return {
+    northEast: {
+      lat: parseFloat(refinement.northEast.lat),
+      lng: parseFloat(refinement.northEast.lng),
+    },
+    southWest: {
+      lat: parseFloat(refinement.southWest.lat),
+      lng: parseFloat(refinement.southWest.lng),
+    },
+  };
+};
+
+const getCurrentPosition = (props, searchState, context) => {
+  const aroundLatLng = getCurrentRefinementValue(
+    props,
+    searchState,
+    context,
+    getAroundLatLngId()
+  );
+
+  if (!aroundLatLng) {
+    // Fallback on `configure.aroundLatLng`
+    const configureAroundLatLng = getCurrentRefinementValue(
+      props,
+      searchState,
+      context,
+      getConfigureAroundLatLngId()
+    );
+
+    return configureAroundLatLng && stringToPosition(configureAroundLatLng);
+  }
+
+  return aroundLatLng;
+};
+
+const refine = (searchState, nextValue, context) => {
+  const resetPage = true;
+  const nextRefinement = {
+    [getBoundingBoxId()]: nextValue,
+  };
+
+  return refineValue(searchState, nextRefinement, context, resetPage);
 };
 
 export default createConnector({

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -13,8 +13,8 @@ import {
  * @name connectGeoSearch
  * @kind connector
  * @requirements Note that the GeoSearch connector uses the [geosearch](https://www.algolia.com/doc/guides/searching/geo-search) capabilities of Algolia.
- * Your hits **must** have a `_geoloc` attribute in order to be passed to the rendering function.
- * Currently, the feature is not compatible with multiple values in the `_geoloc` attribute.
+ * Your hits **must** have a `_geoloc` attribute in order to be passed to the rendering function. Currently, the feature is not compatible with multiple values in the `_geoloc` attribute
+ * (e.g. a restaurant with multiple locations). In that case you can duplicate your records and use the [distinct](https://www.algolia.com/doc/guides/ranking/distinct) feature of Algolia to only retrieve unique results.
  * @propType {{ northEast: { lat: number, lng: number }, southWest: { lat: number, lng: number } }} [defaultRefinement] - Default search state of the widget containing the bounds for the map
  * @providedPropType {function({ northEast: { lat: number, lng: number }, southWest: { lat: number, lng: number } })} refine - a function to toggle the refinement
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -538,6 +538,54 @@ describe('createConnector', () => {
       expect(transitionState.mock.calls).toHaveLength(0);
     });
 
+    it('use shouldUpdate when provided', () => {
+      const shouldUpdate = jest.fn(() => true);
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps: () => null,
+        getMetadata: () => null,
+        getId,
+        shouldUpdate,
+      })(() => null);
+
+      const onSearchStateChange = jest.fn();
+      const update = jest.fn();
+      const props = { hello: 'there' };
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => null,
+              update,
+            },
+            onSearchStateChange,
+          },
+        },
+      });
+
+      expect(shouldUpdate).toHaveBeenCalledTimes(1);
+      expect(shouldUpdate).toHaveBeenCalledWith(
+        { hello: 'there' },
+        { hello: 'there' },
+        { canRender: false, props: null },
+        { canRender: true, props: null }
+      );
+
+      wrapper.setProps({ hello: 'here' });
+
+      expect(shouldUpdate).toHaveBeenCalledTimes(2);
+      expect(shouldUpdate).toHaveBeenCalledWith(
+        { hello: 'there' },
+        { hello: 'here' },
+        { canRender: true, props: null },
+        { canRender: true, props: null }
+      );
+    });
+
     describe('unmounting', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -41,6 +41,7 @@ export default function createConnector(connectorDesc) {
   const hasMetadata = has(connectorDesc, 'getMetadata');
   const hasTransitionState = has(connectorDesc, 'transitionState');
   const hasCleanUp = has(connectorDesc, 'cleanUp');
+  const hasShouldUpdate = has(connectorDesc, 'shouldUpdate');
   const isWidget = hasSearchParameters || hasMetadata || hasTransitionState;
 
   return Composed =>
@@ -210,6 +211,16 @@ export default function createConnector(connectorDesc) {
       }
 
       shouldComponentUpdate(nextProps, nextState) {
+        if (hasShouldUpdate) {
+          return connectorDesc.shouldUpdate.call(
+            this,
+            this.props,
+            nextProps,
+            this.state,
+            nextState
+          );
+        }
+
         const propsEqual = shallowEqual(this.props, nextProps);
         if (this.state.props === null || nextState.props === null) {
           if (this.state.props === nextState.props) {

--- a/packages/react-instantsearch-core/src/core/indexUtils.js
+++ b/packages/react-instantsearch-core/src/core/indexUtils.js
@@ -146,7 +146,7 @@ export function getCurrentRefinementValue(
   context,
   id,
   defaultValue,
-  refinementsCallback
+  refinementsCallback = x => x
 ) {
   const index = getIndex(context);
   const { namespace, attributeName } = getNamespaceAndAttributeName(id);

--- a/packages/react-instantsearch-core/src/index.js
+++ b/packages/react-instantsearch-core/src/index.js
@@ -20,6 +20,7 @@ export { default as connectConfigure } from './connectors/connectConfigure';
 export {
   default as connectCurrentRefinements,
 } from './connectors/connectCurrentRefinements';
+export { default as connectGeoSearch } from './connectors/connectGeoSearch';
 export {
   default as connectHierarchicalMenu,
 } from './connectors/connectHierarchicalMenu';

--- a/packages/react-instantsearch-dom-geo/.babelrc
+++ b/packages/react-instantsearch-dom-geo/.babelrc
@@ -1,0 +1,85 @@
+{
+  "env": {
+    "development": {
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "browsers": [
+                "last 2 versions",
+                "ie >= 9"
+              ]
+            }
+          }
+        ],
+        "react",
+        "stage-2"
+      ],
+      "plugins": [
+        "lodash"
+      ]
+    },
+    "test": {
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "browsers": [
+                "last 2 versions",
+                "ie >= 9"
+              ]
+            }
+          }
+        ],
+        "react",
+        "stage-2"
+      ],
+      "plugins": [
+        "lodash"
+      ]
+    },
+    "production": {
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "browsers": [
+                "last 2 versions",
+                "ie >= 9"
+              ]
+            }
+          }
+        ],
+        "react",
+        "stage-2"
+      ],
+      "plugins": [
+        "lodash"
+      ]
+    },
+    "es": {
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "browsers": [
+                "last 2 versions",
+                "ie >= 9"
+              ]
+            },
+            "modules": false
+          }
+        ],
+        "react",
+        "stage-2"
+      ],
+      "plugins": [
+        "lodash"
+      ]
+    }
+  }
+}

--- a/packages/react-instantsearch-dom-geo/README.md
+++ b/packages/react-instantsearch-dom-geo/README.md
@@ -1,0 +1,5 @@
+# react-instantsearch-dom-maps
+
+This is the geo search wiget for the [React](https://facebook.github.io/react) version of Algolia's `instantsearch` library.
+
+Go to the [React InstantSearch website](https://community.algolia.com/react-instantsearch) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.

--- a/packages/react-instantsearch-dom-geo/package.json
+++ b/packages/react-instantsearch-dom-geo/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "react-instantsearch-dom-maps",
+  "private": true,
+  "version": "5.2.0-beta.2",
+  "description": "⚡ Lightning-fast search for React DOM & Google Maps, by Algolia",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es/index.js",
+  "sideEffects": false,
+  "license": "MIT",
+  "homepage": "https://community.algolia.com/react-instantsearch",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/algolia/react-instantsearch"
+  },
+  "author": {
+    "name": "Algolia, Inc.",
+    "url": "https://www.algolia.com"
+  },
+  "keywords": [
+    "algolia",
+    "components",
+    "fast",
+    "instantsearch",
+    "react",
+    "react-dom",
+    "search",
+    "geo search",
+    "google maps"
+  ],
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "watch": "yarn build:cjs --watch",
+    "build": "yarn build:cjs && yarn build:es && yarn build:umd",
+    "build:cjs": "babel src --out-dir dist/cjs --ignore __tests__,__mocks__ --quiet",
+    "build:es": "BABEL_ENV=es babel src --out-dir dist/es --ignore __tests__,__mocks__ --quiet",
+    "build:umd": "BABEL_ENV=es rollup -c rollup.config.js",
+    "test": "jest",
+    "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
+    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4",
+    "prop-types": "^15.5.10",
+    "scriptjs": "^2.5.8"
+  },
+  "devDependencies": {
+    "babel-cli": "6.26.0",
+    "babel-core": "6.26.0",
+    "babel-plugin-external-helpers": "6.22.0",
+    "babel-plugin-lodash": "3.3.4",
+    "babel-preset-env": "1.7.0",
+    "babel-preset-react": "6.24.1",
+    "babel-preset-stage-2": "6.24.1",
+    "enzyme": "3.3.0",
+    "enzyme-adapter-react-16": "1.1.1",
+    "enzyme-to-json": "3.3.4",
+    "jest": "23.1.0",
+    "react": "16.4.1",
+    "react-dom": "16.4.1",
+    "react-test-renderer": "16.4.1",
+    "rollup": "0.60.7",
+    "rollup-plugin-babel": "3.0.4",
+    "rollup-plugin-commonjs": "9.1.3",
+    "rollup-plugin-filesize": "2.0.0",
+    "rollup-plugin-node-globals": "1.2.1",
+    "rollup-plugin-node-resolve": "3.3.0",
+    "rollup-plugin-replace": "2.0.0",
+    "rollup-plugin-uglify": "4.0.0"
+  },
+  "peerDependencies": {
+    "react-instantsearch-dom": ">= 5.2.0-beta.2"
+  },
+  "jest": {
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
+  }
+}

--- a/packages/react-instantsearch-dom-geo/rollup.config.js
+++ b/packages/react-instantsearch-dom-geo/rollup.config.js
@@ -1,0 +1,80 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import babel from 'rollup-plugin-babel';
+import globals from 'rollup-plugin-node-globals';
+import replace from 'rollup-plugin-replace';
+import { uglify } from 'rollup-plugin-uglify';
+import filesize from 'rollup-plugin-filesize';
+
+const clear = x => x.filter(Boolean);
+
+const version = process.env.VERSION || 'UNRELEASED';
+const algolia = '© Algolia, inc.';
+const link = 'https://community.algolia.com/react-instantsearch';
+const createLicence = name =>
+  `/*! React InstantSearch${name} ${version} | ${algolia} | ${link} */`;
+
+const plugins = [
+  babel({
+    exclude: ['../../node_modules/**', 'node_modules/**'],
+    plugins: ['external-helpers'],
+  }),
+  resolve({
+    browser: true,
+    preferBuiltins: false,
+  }),
+  commonjs({
+    namedExports: {
+      'algoliasearch-helper': [
+        'version',
+        'AlgoliaSearchHelper',
+        'SearchParameters',
+        'SearchResults',
+        'url',
+      ],
+    },
+  }),
+  globals(),
+  replace({
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  }),
+  filesize(),
+];
+
+const createConfiguration = ({ name, minify = false } = {}) => ({
+  input: 'src/index.js',
+  external: ['react', 'react-dom', 'react-instantsearch-dom'],
+  output: {
+    file: `dist/umd/ReactInstantSearch${name}${minify ? '.min' : ''}.js`,
+    name: `ReactInstantSearch${name}`,
+    format: 'umd',
+    globals: {
+      react: 'React',
+      'react-dom': 'ReactDOM',
+      'react-instantsearch-dom': 'ReactInstantSearchDOM',
+    },
+    banner: createLicence(name),
+    sourcemap: true,
+  },
+  plugins: plugins.concat(
+    clear([
+      minify &&
+        uglify({
+          output: {
+            preamble: createLicence(name),
+          },
+        }),
+    ])
+  ),
+});
+
+export default [
+  createConfiguration({
+    name: 'DOMMaps',
+  }),
+
+  createConfiguration({
+    name: 'DOMMaps',
+    minify: true,
+  }),
+];

--- a/packages/react-instantsearch-dom-geo/src/Connector.js
+++ b/packages/react-instantsearch-dom-geo/src/Connector.js
@@ -1,0 +1,66 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connectGeoSearch } from 'react-instantsearch-dom';
+import { LatLngPropType, BoundingBoxPropType } from './propTypes';
+
+export const STATE_CONTEXT = '__ais_geo_search__state__';
+
+export class Connector extends Component {
+  static propTypes = {
+    hits: PropTypes.arrayOf(PropTypes.object).isRequired,
+    isRefinedWithMap: PropTypes.bool.isRequired,
+    refine: PropTypes.func.isRequired,
+    children: PropTypes.func.isRequired,
+    position: LatLngPropType,
+    currentRefinement: BoundingBoxPropType,
+  };
+
+  state = {
+    isRefineOnMapMove: true,
+    hasMapMoveSinceLastRefine: false,
+  };
+
+  toggleRefineOnMapMove = () =>
+    this.setState(({ isRefineOnMapMove }) => ({
+      isRefineOnMapMove: !isRefineOnMapMove,
+    }));
+
+  setMapMoveSinceLastRefine = next => {
+    const { hasMapMoveSinceLastRefine } = this.state;
+
+    if (hasMapMoveSinceLastRefine === next) {
+      return;
+    }
+
+    this.setState(() => ({
+      hasMapMoveSinceLastRefine: next,
+    }));
+  };
+
+  render() {
+    const {
+      hits,
+      isRefinedWithMap,
+      position,
+      currentRefinement,
+      refine,
+      children,
+    } = this.props;
+
+    const { isRefineOnMapMove, hasMapMoveSinceLastRefine } = this.state;
+
+    return children({
+      toggleRefineOnMapMove: this.toggleRefineOnMapMove,
+      setMapMoveSinceLastRefine: this.setMapMoveSinceLastRefine,
+      hits,
+      isRefinedWithMap,
+      isRefineOnMapMove,
+      hasMapMoveSinceLastRefine,
+      position,
+      currentRefinement,
+      refine,
+    });
+  }
+}
+
+export default connectGeoSearch(Connector);

--- a/packages/react-instantsearch-dom-geo/src/Control.js
+++ b/packages/react-instantsearch-dom-geo/src/Control.js
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { createClassNames, translatable } from 'react-instantsearch-dom';
+import { STATE_CONTEXT } from './Provider';
+import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+
+const cx = createClassNames('GeoSearch');
+
+export class Control extends Component {
+  static propTypes = {
+    translate: PropTypes.func.isRequired,
+    enableRefineOnMapMove: PropTypes.bool,
+  };
+
+  static contextTypes = {
+    [STATE_CONTEXT]: PropTypes.shape({
+      isRefineOnMapMove: PropTypes.bool.isRequired,
+      toggleRefineOnMapMove: PropTypes.func.isRequired,
+      hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
+      refineWithInstance: PropTypes.func.isRequired,
+    }).isRequired,
+    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+      instance: PropTypes.object.isRequired,
+    }).isRequired,
+  };
+
+  static defaultProps = {
+    enableRefineOnMapMove: true,
+  };
+
+  getStateContext() {
+    return this.context[STATE_CONTEXT];
+  }
+
+  getGoogleMapsContext() {
+    return this.context[GOOGLE_MAPS_CONTEXT];
+  }
+
+  componentDidMount() {
+    const { enableRefineOnMapMove } = this.props;
+    const { isRefineOnMapMove, toggleRefineOnMapMove } = this.getStateContext();
+
+    if (!enableRefineOnMapMove && isRefineOnMapMove) {
+      toggleRefineOnMapMove();
+    }
+  }
+
+  render() {
+    const { translate } = this.props;
+    const { instance } = this.getGoogleMapsContext();
+    const {
+      isRefineOnMapMove,
+      hasMapMoveSinceLastRefine,
+      toggleRefineOnMapMove,
+      refineWithInstance,
+    } = this.getStateContext();
+
+    return (
+      <div className={cx('control')}>
+        {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
+          <label className={cx('label')}>
+            <input
+              className={cx('input')}
+              type="checkbox"
+              checked={isRefineOnMapMove}
+              onChange={toggleRefineOnMapMove}
+            />
+            {translate('control')}
+          </label>
+        ) : (
+          <button
+            className={cx('redo')}
+            onClick={() => refineWithInstance(instance)}
+          >
+            {translate('redo')}
+          </button>
+        )}
+      </div>
+    );
+  }
+}
+
+export default translatable({
+  control: 'Search as I move the map',
+  redo: 'Redo search here',
+})(Control);

--- a/packages/react-instantsearch-dom-geo/src/CustomMarker.js
+++ b/packages/react-instantsearch-dom-geo/src/CustomMarker.js
@@ -1,0 +1,117 @@
+import { Component } from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import createHTMLMarker from './elements/createHTMLMarker';
+import { registerEvents, createListenersPropTypes } from './utils';
+import { GeolocHitPropType } from './propTypes';
+import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+
+const eventTypes = {
+  onClick: 'click',
+  onDoubleClick: 'dblclick',
+  onMouseDown: 'mousedown',
+  onMouseEnter: 'mouseenter',
+  onMouseLeave: 'mouseleave',
+  onMouseMove: 'mousemove',
+  onMouseOut: 'mouseout',
+  onMouseOver: 'mouseover',
+  onMouseUp: 'mouseup',
+};
+
+class CustomMarker extends Component {
+  static propTypes = {
+    ...createListenersPropTypes(eventTypes),
+    hit: GeolocHitPropType.isRequired,
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    anchor: PropTypes.shape({
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
+    }),
+  };
+
+  static contextTypes = {
+    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+      google: PropTypes.object,
+      instance: PropTypes.object,
+    }),
+  };
+
+  static defaultProps = {
+    className: '',
+    anchor: {
+      x: 0,
+      y: 0,
+    },
+  };
+
+  static isReact16() {
+    return typeof ReactDOM.createPortal === 'function';
+  }
+
+  state = {
+    marker: null,
+  };
+
+  componentDidMount() {
+    const { hit, className, anchor } = this.props;
+    const { google, instance } = this.context[GOOGLE_MAPS_CONTEXT];
+    // Not the best way to create the reference of the CustomMarker
+    // but since the Google object is required didn't find another
+    // solution. Ideas?
+    const Marker = createHTMLMarker(google);
+
+    const marker = new Marker({
+      map: instance,
+      position: hit._geoloc,
+      className,
+      anchor,
+    });
+
+    this.removeListeners = registerEvents(eventTypes, this.props, marker);
+
+    this.setState(() => ({
+      marker,
+    }));
+  }
+
+  componentDidUpdate() {
+    const { children } = this.props;
+    const { marker } = this.state;
+
+    this.removeListeners();
+
+    this.removeListeners = registerEvents(eventTypes, this.props, marker);
+
+    if (!CustomMarker.isReact16()) {
+      ReactDOM.unstable_renderSubtreeIntoContainer(
+        this,
+        children,
+        marker.element
+      );
+    }
+  }
+
+  componentWillUnmount() {
+    const { marker } = this.state;
+
+    if (!CustomMarker.isReact16()) {
+      ReactDOM.unmountComponentAtNode(marker.element);
+    }
+
+    marker.setMap(null);
+  }
+
+  render() {
+    const { children } = this.props;
+    const { marker } = this.state;
+
+    if (!marker || !CustomMarker.isReact16()) {
+      return null;
+    }
+
+    return ReactDOM.createPortal(children, marker.element);
+  }
+}
+
+export default CustomMarker;

--- a/packages/react-instantsearch-dom-geo/src/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/GeoSearch.js
@@ -1,0 +1,76 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { LatLngPropType } from './propTypes';
+import Connector from './Connector';
+import Provider from './Provider';
+import GoogleMaps from './GoogleMaps';
+
+class GeoSearch extends Component {
+  static propTypes = {
+    google: PropTypes.object.isRequired,
+    children: PropTypes.func.isRequired,
+    initialZoom: PropTypes.number,
+    initialPosition: LatLngPropType,
+  };
+
+  static defaultProps = {
+    initialZoom: 1,
+    initialPosition: {
+      lat: 0,
+      lng: 0,
+    },
+  };
+
+  renderChildrenWithBoundFunction = ({ hits, position, ...rest }) => {
+    const {
+      google,
+      children,
+      initialZoom,
+      initialPosition,
+      ...mapOptions
+    } = this.props;
+
+    return (
+      <Provider
+        {...rest}
+        testID="Provider"
+        google={google}
+        hits={hits}
+        position={position}
+      >
+        {({
+          boundingBox,
+          boundingBoxPadding,
+          onChange,
+          onIdle,
+          shouldUpdate,
+        }) => (
+          <GoogleMaps
+            testID="GoogleMaps"
+            google={google}
+            initialZoom={initialZoom}
+            initialPosition={position || initialPosition}
+            mapOptions={mapOptions}
+            boundingBox={boundingBox}
+            boundingBoxPadding={boundingBoxPadding}
+            onChange={onChange}
+            onIdle={onIdle}
+            shouldUpdate={shouldUpdate}
+          >
+            {children({ hits })}
+          </GoogleMaps>
+        )}
+      </Provider>
+    );
+  };
+
+  render() {
+    return (
+      <Connector testID="Connector">
+        {this.renderChildrenWithBoundFunction}
+      </Connector>
+    );
+  }
+}
+
+export default GeoSearch;

--- a/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
@@ -1,0 +1,168 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { createClassNames } from 'react-instantsearch-dom';
+import { LatLngPropType, BoundingBoxPropType } from './propTypes';
+
+const cx = createClassNames('GeoSearch');
+
+export const GOOGLE_MAPS_CONTEXT = '__ais_geo_search__google_maps__';
+
+class GoogleMaps extends Component {
+  static propTypes = {
+    google: PropTypes.object.isRequired,
+    initialZoom: PropTypes.number.isRequired,
+    initialPosition: LatLngPropType.isRequired,
+    mapOptions: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onIdle: PropTypes.func.isRequired,
+    shouldUpdate: PropTypes.func.isRequired,
+    boundingBox: BoundingBoxPropType,
+    boundingBoxPadding: PropTypes.number,
+    children: PropTypes.node,
+  };
+
+  static childContextTypes = {
+    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+      google: PropTypes.object,
+      instance: PropTypes.object,
+    }),
+  };
+
+  isUserInteraction = true;
+  isPendingRefine = false;
+  listeners = [];
+
+  state = {
+    isMapReady: false,
+  };
+
+  getChildContext() {
+    const { google } = this.props;
+
+    return {
+      [GOOGLE_MAPS_CONTEXT]: {
+        instance: this.instance,
+        google,
+      },
+    };
+  }
+
+  componentDidMount() {
+    const { google, mapOptions } = this.props;
+
+    this.instance = new google.maps.Map(this.element, {
+      mapTypeControl: false,
+      fullscreenControl: false,
+      streetViewControl: false,
+      clickableIcons: false,
+      zoomControlOptions: {
+        position: google.maps.ControlPosition.LEFT_TOP,
+      },
+      ...mapOptions,
+    });
+
+    this.listeners.push(
+      google.maps.event.addListenerOnce(
+        this.instance,
+        'idle',
+        this.setupListenersWhenMapIsReady
+      )
+    );
+  }
+
+  componentDidUpdate() {
+    const {
+      google,
+      initialZoom,
+      initialPosition,
+      boundingBox,
+      boundingBoxPadding,
+      shouldUpdate,
+    } = this.props;
+
+    const { isMapReady } = this.state;
+
+    if (!isMapReady || !shouldUpdate()) {
+      return;
+    }
+
+    if (boundingBox) {
+      this.lockUserInteration(() => {
+        this.instance.fitBounds(
+          new google.maps.LatLngBounds(
+            boundingBox.southWest,
+            boundingBox.northEast
+          ),
+          boundingBoxPadding
+        );
+      });
+
+      return;
+    }
+
+    if (!boundingBox) {
+      this.lockUserInteration(() => {
+        this.instance.setZoom(initialZoom);
+        this.instance.setCenter(initialPosition);
+      });
+
+      return;
+    }
+  }
+
+  componentWillUnmount() {
+    this.listeners.forEach(listener => {
+      listener.remove();
+    });
+
+    this.listeners = [];
+  }
+
+  setupListenersWhenMapIsReady = () => {
+    this.listeners = [];
+
+    this.setState(() => ({
+      isMapReady: true,
+    }));
+
+    const onChange = () => {
+      if (this.isUserInteraction) {
+        this.props.onChange();
+      }
+    };
+
+    this.listeners.push(this.instance.addListener('center_changed', onChange));
+    this.listeners.push(this.instance.addListener('zoom_changed', onChange));
+    this.listeners.push(this.instance.addListener('dragstart', onChange));
+
+    this.listeners.push(
+      this.instance.addListener('idle', () => {
+        if (this.isUserInteraction) {
+          this.props.onIdle({
+            instance: this.instance,
+          });
+        }
+      })
+    );
+  };
+
+  lockUserInteration(functionThatAltersTheMapPosition) {
+    this.isUserInteraction = false;
+    functionThatAltersTheMapPosition();
+    this.isUserInteraction = true;
+  }
+
+  render() {
+    const { children } = this.props;
+    const { isMapReady } = this.state;
+
+    return (
+      <div className={cx('')}>
+        <div ref={c => (this.element = c)} className={cx('map')} />
+        {isMapReady && children}
+      </div>
+    );
+  }
+}
+
+export default GoogleMaps;

--- a/packages/react-instantsearch-dom-geo/src/GoogleMapsLoader.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMapsLoader.js
@@ -1,0 +1,49 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import injectScript from 'scriptjs';
+
+class GoogleMapsLoader extends Component {
+  static propTypes = {
+    apiKey: PropTypes.string.isRequired,
+    children: PropTypes.func.isRequired,
+    endpoint: PropTypes.string,
+  };
+
+  static defaultProps = {
+    endpoint: 'https://maps.googleapis.com/maps/api/js?v=3.31',
+  };
+
+  state = {
+    google: null,
+  };
+
+  isUnmounting = false;
+
+  componentDidMount() {
+    const { apiKey, endpoint } = this.props;
+    const operator = endpoint.indexOf('?') !== -1 ? '&' : '?';
+    const endpointWithCredentials = `${endpoint}${operator}key=${apiKey}`;
+
+    injectScript(endpointWithCredentials, () => {
+      if (!this.isUnmounting) {
+        this.setState(() => ({
+          google: window.google,
+        }));
+      }
+    });
+  }
+
+  componentWillUnmount() {
+    this.isUnmounting = true;
+  }
+
+  render() {
+    if (!this.state.google) {
+      return null;
+    }
+
+    return this.props.children(this.state.google);
+  }
+}
+
+export default GoogleMapsLoader;

--- a/packages/react-instantsearch-dom-geo/src/Marker.js
+++ b/packages/react-instantsearch-dom-geo/src/Marker.js
@@ -1,0 +1,72 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import {
+  registerEvents,
+  createListenersPropTypes,
+  createFilterProps,
+} from './utils';
+import { GeolocHitPropType } from './propTypes';
+import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+
+const eventTypes = {
+  onClick: 'click',
+  onDoubleClick: 'dblclick',
+  onMouseDown: 'mousedown',
+  onMouseOut: 'mouseout',
+  onMouseOver: 'mouseover',
+  onMouseUp: 'mouseup',
+};
+
+const excludes = ['children'].concat(Object.keys(eventTypes));
+const filterProps = createFilterProps(excludes);
+
+class Marker extends Component {
+  static propTypes = {
+    ...createListenersPropTypes(eventTypes),
+    hit: GeolocHitPropType.isRequired,
+  };
+
+  static contextTypes = {
+    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+      google: PropTypes.object,
+      instance: PropTypes.object,
+    }),
+  };
+
+  componentDidMount() {
+    const { hit, ...props } = this.props;
+    const { google, instance } = this.context[GOOGLE_MAPS_CONTEXT];
+
+    this.instance = new google.maps.Marker({
+      ...filterProps(props),
+      map: instance,
+      position: hit._geoloc,
+    });
+
+    this.removeEventsListeners = registerEvents(
+      eventTypes,
+      this.props,
+      this.instance
+    );
+  }
+
+  componentDidUpdate() {
+    this.removeEventsListeners();
+
+    this.removeEventsListeners = registerEvents(
+      eventTypes,
+      this.props,
+      this.instance
+    );
+  }
+
+  componentWillUnmount() {
+    this.instance.setMap(null);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default Marker;

--- a/packages/react-instantsearch-dom-geo/src/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/Provider.js
@@ -1,0 +1,149 @@
+import { isEqual } from 'lodash';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { LatLngPropType, BoundingBoxPropType } from './propTypes';
+
+export const STATE_CONTEXT = '__ais_geo_search__state__';
+
+class Provider extends Component {
+  static propTypes = {
+    google: PropTypes.object.isRequired,
+    hits: PropTypes.arrayOf(PropTypes.object).isRequired,
+    isRefineOnMapMove: PropTypes.bool.isRequired,
+    hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
+    refine: PropTypes.func.isRequired,
+    toggleRefineOnMapMove: PropTypes.func.isRequired,
+    setMapMoveSinceLastRefine: PropTypes.func.isRequired,
+    children: PropTypes.func.isRequired,
+    position: LatLngPropType,
+    currentRefinement: BoundingBoxPropType,
+  };
+
+  static childContextTypes = {
+    [STATE_CONTEXT]: PropTypes.shape({
+      isRefineOnMapMove: PropTypes.bool.isRequired,
+      hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
+      toggleRefineOnMapMove: PropTypes.func.isRequired,
+      setMapMoveSinceLastRefine: PropTypes.func.isRequired,
+      refineWithInstance: PropTypes.func.isRequired,
+    }).isRequired,
+  };
+
+  isPendingRefine = false;
+
+  getChildContext() {
+    const {
+      isRefineOnMapMove,
+      hasMapMoveSinceLastRefine,
+      toggleRefineOnMapMove,
+      setMapMoveSinceLastRefine,
+    } = this.props;
+
+    return {
+      [STATE_CONTEXT]: {
+        refineWithInstance: this.refineWithInstance,
+        toggleRefineOnMapMove,
+        setMapMoveSinceLastRefine,
+        isRefineOnMapMove,
+        hasMapMoveSinceLastRefine,
+      },
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    const {
+      position: previousPosition,
+      currentRefinement: previousCurrentRefinement,
+    } = prevProps;
+
+    const {
+      position,
+      currentRefinement,
+      setMapMoveSinceLastRefine,
+    } = this.props;
+
+    const positionChanged = !isEqual(previousPosition, position);
+    const currentRefinementChanged = !isEqual(
+      previousCurrentRefinement,
+      currentRefinement
+    );
+
+    if (positionChanged || currentRefinementChanged) {
+      setMapMoveSinceLastRefine(false);
+    }
+  }
+
+  createBoundingBoxFromHits(hits) {
+    const { google } = this.props;
+
+    const latLngBounds = hits.reduce(
+      (acc, hit) => acc.extend(hit._geoloc),
+      new google.maps.LatLngBounds()
+    );
+
+    return {
+      northEast: latLngBounds.getNorthEast().toJSON(),
+      southWest: latLngBounds.getSouthWest().toJSON(),
+    };
+  }
+
+  refineWithInstance = instance => {
+    const { refine } = this.props;
+
+    const bounds = instance.getBounds();
+
+    refine({
+      northEast: bounds.getNorthEast().toJSON(),
+      southWest: bounds.getSouthWest().toJSON(),
+    });
+  };
+
+  onChange = () => {
+    const { isRefineOnMapMove, setMapMoveSinceLastRefine } = this.props;
+
+    setMapMoveSinceLastRefine(true);
+
+    if (isRefineOnMapMove) {
+      this.isPendingRefine = true;
+    }
+  };
+
+  onIdle = ({ instance }) => {
+    if (this.isPendingRefine) {
+      this.isPendingRefine = false;
+
+      this.refineWithInstance(instance);
+    }
+  };
+
+  shouldUpdate = () => {
+    const { hasMapMoveSinceLastRefine } = this.props;
+
+    return !this.isPendingRefine && !hasMapMoveSinceLastRefine;
+  };
+
+  render() {
+    const { hits, currentRefinement, children } = this.props;
+
+    // We use this value for differentiate the padding to apply during
+    // fitBounds. When we don't have a currenRefinement (boundingBox)
+    // we let GoogleMaps compute the automatic padding. But when we
+    // provide the currentRefinement we explicitly set the padding
+    // to `0` otherwise the map will decrease the zoom on each refine.
+    const boundingBoxPadding = !currentRefinement ? undefined : 0;
+    const boundingBox =
+      !currentRefinement && Boolean(hits.length)
+        ? this.createBoundingBoxFromHits(hits)
+        : currentRefinement;
+
+    return children({
+      onChange: this.onChange,
+      onIdle: this.onIdle,
+      shouldUpdate: this.shouldUpdate,
+      boundingBox,
+      boundingBoxPadding,
+    });
+  }
+}
+
+export default Provider;

--- a/packages/react-instantsearch-dom-geo/src/Redo.js
+++ b/packages/react-instantsearch-dom-geo/src/Redo.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { createClassNames, translatable } from 'react-instantsearch-dom';
+import { STATE_CONTEXT } from './Provider';
+import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+
+const cx = createClassNames('GeoSearch');
+
+export class Redo extends Component {
+  static propTypes = {
+    translate: PropTypes.func.isRequired,
+  };
+
+  static contextTypes = {
+    [STATE_CONTEXT]: PropTypes.shape({
+      isRefineOnMapMove: PropTypes.bool.isRequired,
+      toggleRefineOnMapMove: PropTypes.func.isRequired,
+      hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
+      refineWithInstance: PropTypes.func.isRequired,
+    }).isRequired,
+    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+      instance: PropTypes.object.isRequired,
+    }).isRequired,
+  };
+
+  getStateContext() {
+    return this.context[STATE_CONTEXT];
+  }
+
+  getGoogleMapsContext() {
+    return this.context[GOOGLE_MAPS_CONTEXT];
+  }
+
+  componentDidMount() {
+    const { isRefineOnMapMove, toggleRefineOnMapMove } = this.getStateContext();
+
+    if (isRefineOnMapMove) {
+      toggleRefineOnMapMove();
+    }
+  }
+
+  render() {
+    const { translate } = this.props;
+    const { instance } = this.getGoogleMapsContext();
+    const {
+      hasMapMoveSinceLastRefine,
+      refineWithInstance,
+    } = this.getStateContext();
+
+    return (
+      <div className={cx('control')}>
+        <button
+          className={cx('redo', !hasMapMoveSinceLastRefine && 'redo--disabled')}
+          disabled={!hasMapMoveSinceLastRefine}
+          onClick={() => refineWithInstance(instance)}
+        >
+          {translate('redo')}
+        </button>
+      </div>
+    );
+  }
+}
+
+export default translatable({
+  redo: 'Redo search here',
+})(Redo);

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Connector.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Connector.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { Connector } from '../Connector';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Connector', () => {
+  const defaultProps = {
+    hits: [],
+    position: null,
+    currentRefinement: null,
+    isRefinedWithMap: false,
+    refine: () => {},
+  };
+
+  const lastRenderArgs = fn => fn.mock.calls[fn.mock.calls.length - 1][0];
+
+  it('expect to call children with props', () => {
+    const children = jest.fn(x => x);
+
+    const props = {
+      ...defaultProps,
+    };
+
+    shallow(<Connector {...props}>{children}</Connector>);
+
+    expect(children).toHaveBeenCalledTimes(1);
+    expect(children).toHaveBeenCalledWith({
+      hits: [],
+      position: null,
+      currentRefinement: null,
+      isRefinedWithMap: false,
+      isRefineOnMapMove: true,
+      toggleRefineOnMapMove: expect.any(Function),
+      hasMapMoveSinceLastRefine: false,
+      setMapMoveSinceLastRefine: expect.any(Function),
+      refine: expect.any(Function),
+    });
+  });
+
+  describe('setMapMoveSinceLastRefine', () => {
+    it('expect to update the state with the given value', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Connector {...props}>{children}</Connector>);
+
+      lastRenderArgs(children).setMapMoveSinceLastRefine(true);
+
+      expect(wrapper.state().hasMapMoveSinceLastRefine).toBe(true);
+    });
+
+    it('expect to only update the state when the given is different', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(<Connector {...props}>{children}</Connector>);
+
+      expect(children).toHaveBeenCalledTimes(1);
+      expect(children).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hasMapMoveSinceLastRefine: false,
+        })
+      );
+
+      lastRenderArgs(children).setMapMoveSinceLastRefine(true);
+
+      expect(children).toHaveBeenCalledTimes(2);
+      expect(children).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hasMapMoveSinceLastRefine: true,
+        })
+      );
+
+      lastRenderArgs(children).setMapMoveSinceLastRefine(true);
+
+      expect(children).toHaveBeenCalledTimes(2);
+      expect(children).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hasMapMoveSinceLastRefine: true,
+        })
+      );
+    });
+  });
+
+  describe('toggleRefineOnMapMove', () => {
+    it('expect to update the state with the invert of previous value (true)', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Connector {...props}>{children}</Connector>);
+
+      expect(wrapper.state().isRefineOnMapMove).toBe(true);
+
+      lastRenderArgs(children).toggleRefineOnMapMove();
+
+      expect(wrapper.state().isRefineOnMapMove).toBe(false);
+    });
+
+    it('expect to update the state with the invert of previous value (false)', () => {
+      const children = jest.fn();
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Connector {...props}>{children}</Connector>);
+
+      wrapper.setState({
+        isRefineOnMapMove: false,
+      });
+
+      expect(wrapper.state().isRefineOnMapMove).toBe(false);
+
+      lastRenderArgs(children).toggleRefineOnMapMove();
+
+      expect(wrapper.state().isRefineOnMapMove).toBe(true);
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Control.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Control.js
@@ -1,0 +1,214 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { createFakeMapInstance } from '../../test/mockGoogleMaps';
+import { STATE_CONTEXT } from '../Provider';
+import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+import { Control } from '../Control';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Control', () => {
+  const defaultProps = {
+    enableRefineOnMapMove: true,
+    translate: x => x,
+  };
+
+  const defaultContext = {
+    [STATE_CONTEXT]: {
+      isRefineOnMapMove: true,
+      hasMapMoveSinceLastRefine: false,
+      toggleRefineOnMapMove: () => {},
+      refineWithInstance: () => {},
+    },
+    [GOOGLE_MAPS_CONTEXT]: {
+      instance: createFakeMapInstance(),
+    },
+  };
+
+  const getStateContext = context => context[STATE_CONTEXT];
+  const getGoogleMapsContext = context => context[GOOGLE_MAPS_CONTEXT];
+
+  it('expect to render correctly with refine on map move', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('input').props().checked).toBe(true);
+  });
+
+  it('expect to render correctly without refine on map move', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('input').props().checked).toBe(false);
+  });
+
+  it('expect to render correctly without refine on map move when the map has moved', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+        hasMapMoveSinceLastRefine: true,
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to disable refine on map move onDidMount', () => {
+    const props = {
+      ...defaultProps,
+      enableRefineOnMapMove: false,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      disableLifecycleMethods: true,
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.instance().componentDidMount();
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('expect to only disable refine on map move when previous value is true onDidMount', () => {
+    const props = {
+      ...defaultProps,
+      enableRefineOnMapMove: false,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      disableLifecycleMethods: true,
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.instance().componentDidMount();
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+  });
+
+  it('expect to call toggleRefineOnMapMove on input change', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.find('input').simulate('change');
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('expect to call refineWithInstance on button click', () => {
+    const instance = createFakeMapInstance();
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+        hasMapMoveSinceLastRefine: true,
+        refineWithInstance: jest.fn(),
+      },
+      [GOOGLE_MAPS_CONTEXT]: {
+        ...getGoogleMapsContext(defaultContext),
+        instance,
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    const { refineWithInstance } = getStateContext(context);
+
+    expect(refineWithInstance).toHaveBeenCalledTimes(0);
+
+    wrapper.find('button').simulate('click');
+
+    expect(refineWithInstance).toHaveBeenCalledTimes(1);
+    expect(refineWithInstance).toHaveBeenCalledWith(instance);
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/CustomMarker.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/CustomMarker.js
@@ -1,0 +1,646 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Enzyme, { mount, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {
+  createFakeGoogleReference,
+  createFakeMapInstance,
+  createFakeHTMLMarkerInstance,
+} from '../../test/mockGoogleMaps';
+import createHTMLMarker from '../elements/createHTMLMarker';
+import * as utils from '../utils';
+import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+import CustomMarker from '../CustomMarker';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+jest.mock('../elements/createHTMLMarker', () => jest.fn());
+
+jest.mock('../utils');
+
+describe('CustomMarker', () => {
+  const defaultProps = {
+    hit: {
+      _geoloc: {
+        lat: 10,
+        lng: 12,
+      },
+    },
+  };
+
+  beforeEach(() => {
+    utils.registerEvents.mockClear();
+    utils.registerEvents.mockReset();
+  });
+
+  describe('creation', () => {
+    it('expect to create the marker on didMount with default options', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(createHTMLMarker).toHaveBeenCalledWith(google);
+      expect(wrapper.state('marker')).toBe(marker);
+
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(factory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          map: mapInstance,
+          position: {
+            lat: 10,
+            lng: 12,
+          },
+        })
+      );
+    });
+
+    it('expect to create the marker on didMount with given options', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+        className: 'my-marker',
+        anchor: {
+          x: 10,
+          y: 10,
+        },
+      };
+
+      shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(factory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          className: 'my-marker',
+          anchor: {
+            x: 10,
+            y: 10,
+          },
+        })
+      );
+    });
+
+    it('expect to register the listeners on didMount', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(1);
+      expect(utils.registerEvents).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        marker
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('expect to remove the listeners on didUpdate', () => {
+      const removeEventListeners = jest.fn();
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => removeEventListeners);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(removeEventListeners).toHaveBeenCalledTimes(0);
+
+      // Simulate the update
+      wrapper.instance().componentDidUpdate();
+
+      expect(removeEventListeners).toHaveBeenCalledTimes(1);
+    });
+
+    it('expect to register the listeners on didUpdate', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(1);
+
+      // Simulate the update
+      wrapper.instance().componentDidUpdate();
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(2);
+      expect(utils.registerEvents).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        marker
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('expect to remove the Marker on willUnmount', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      wrapper.unmount();
+
+      expect(marker.setMap).toHaveBeenCalledTimes(1);
+      expect(marker.setMap).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('with portal', () => {
+    it('expect to render correctly', () => {
+      const unstableRenderSubtreeIntoContainer = jest.spyOn(
+        ReactDOM,
+        'unstable_renderSubtreeIntoContainer'
+      );
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      // Use `mount` instead of `shallow` to trigger the render
+      // of createPortal otherwise the Snapshot is empty
+      const wrapper = mount(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(wrapper).toMatchSnapshot();
+
+      expect(unstableRenderSubtreeIntoContainer).not.toHaveBeenCalled();
+
+      unstableRenderSubtreeIntoContainer.mockReset();
+      unstableRenderSubtreeIntoContainer.mockRestore();
+    });
+
+    it('expect to render correctly without a marker', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          disableLifecycleMethods: true,
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(wrapper.type()).toBe(null);
+    });
+
+    it('expect to not render on didUpdate', () => {
+      const unstableRenderSubtreeIntoContainer = jest.spyOn(
+        ReactDOM,
+        'unstable_renderSubtreeIntoContainer'
+      );
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      // Use `mount` instead of `shallow` to trigger didUpdate
+      const wrapper = mount(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(unstableRenderSubtreeIntoContainer).not.toHaveBeenCalled();
+
+      wrapper.instance().componentDidUpdate();
+
+      expect(unstableRenderSubtreeIntoContainer).not.toHaveBeenCalled();
+
+      unstableRenderSubtreeIntoContainer.mockReset();
+      unstableRenderSubtreeIntoContainer.mockRestore();
+    });
+
+    it('expect to not call unmountComponentAtNode on willUnmount', () => {
+      const unmountComponentAtNode = jest.spyOn(
+        ReactDOM,
+        'unmountComponentAtNode'
+      );
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      wrapper.unmount();
+
+      expect(unmountComponentAtNode).not.toHaveBeenCalled();
+
+      unmountComponentAtNode.mockReset();
+      unmountComponentAtNode.mockRestore();
+    });
+  });
+
+  describe('with unstable_renderSubtreeIntoContainer', () => {
+    it('expect to render correctly', () => {
+      const unstableRenderSubtreeIntoContainer = jest.spyOn(
+        ReactDOM,
+        'unstable_renderSubtreeIntoContainer'
+      );
+
+      const isReact16 = jest
+        .spyOn(CustomMarker, 'isReact16')
+        .mockImplementation(() => false);
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = mount(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(wrapper).toMatchSnapshot();
+
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledTimes(1);
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledWith(
+        wrapper.instance(),
+        <span>This is the children.</span>,
+        marker.element
+      );
+
+      unstableRenderSubtreeIntoContainer.mockReset();
+      unstableRenderSubtreeIntoContainer.mockRestore();
+
+      isReact16.mockReset();
+      isReact16.mockRestore();
+    });
+
+    it('expect to render correctly without a marker', () => {
+      const isReact16 = jest
+        .spyOn(CustomMarker, 'isReact16')
+        .mockImplementation(() => false);
+
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          disableLifecycleMethods: true,
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(wrapper.type()).toBe(null);
+
+      isReact16.mockReset();
+      isReact16.mockRestore();
+    });
+
+    it('expect to render on didUpdate', () => {
+      const unstableRenderSubtreeIntoContainer = jest.spyOn(
+        ReactDOM,
+        'unstable_renderSubtreeIntoContainer'
+      );
+
+      const isReact16 = jest
+        .spyOn(CustomMarker, 'isReact16')
+        .mockImplementation(() => false);
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      // Use `mount` instead of `shallow` to trigger didUpdate
+      const wrapper = mount(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledTimes(1);
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledWith(
+        wrapper.instance(),
+        <span>This is the children.</span>,
+        marker.element
+      );
+
+      wrapper.instance().componentDidUpdate();
+
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledTimes(2);
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledWith(
+        wrapper.instance(),
+        <span>This is the children.</span>,
+        marker.element
+      );
+
+      unstableRenderSubtreeIntoContainer.mockReset();
+      unstableRenderSubtreeIntoContainer.mockRestore();
+
+      isReact16.mockReset();
+      isReact16.mockRestore();
+    });
+
+    it('expect to call unmountComponentAtNode on willUnmount', () => {
+      const unmountComponentAtNode = jest.spyOn(
+        ReactDOM,
+        'unmountComponentAtNode'
+      );
+
+      const isReact16 = jest
+        .spyOn(CustomMarker, 'isReact16')
+        .mockImplementation(() => false);
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      wrapper.unmount();
+
+      expect(unmountComponentAtNode).toHaveBeenCalledTimes(1);
+      expect(unmountComponentAtNode).toHaveBeenCalledWith(marker.element);
+
+      unmountComponentAtNode.mockReset();
+      unmountComponentAtNode.mockRestore();
+
+      isReact16.mockReset();
+      isReact16.mockRestore();
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
@@ -1,0 +1,426 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { createFakeGoogleReference } from '../../test/mockGoogleMaps';
+import GeoSearch from '../GeoSearch';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('GeoSearch', () => {
+  const ShallowWapper = ({ children }) => children;
+
+  const defaultProps = {
+    google: createFakeGoogleReference(),
+  };
+
+  const defaultConnectorProps = {
+    hits: [],
+    isRefineOnMapMove: true,
+    hasMapMoveSinceLastRefine: false,
+    refine: () => {},
+    toggleRefineOnMapMove: () => {},
+    setMapMoveSinceLastRefine: () => {},
+  };
+
+  const renderConnector = ({ props, connectorProps, children = () => null }) =>
+    shallow(<GeoSearch {...props}>{children}</GeoSearch>)
+      .find('[testID="Connector"]')
+      .props()
+      .children(connectorProps);
+
+  describe('Provider', () => {
+    it('expect to render', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const renderPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      expect(renderPropsWrapper).toMatchSnapshot();
+    });
+
+    it('expect to render with hits', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+        hits: [
+          { objectID: '0001' },
+          { objectID: '0002' },
+          { objectID: '0003' },
+        ],
+      };
+
+      const renderPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerProps = renderPropsWrapper
+        .find('[testID="Provider"]')
+        .props();
+
+      expect(providerProps.hits).toEqual([
+        { objectID: '0001' },
+        { objectID: '0002' },
+        { objectID: '0003' },
+      ]);
+    });
+
+    it('expect to render with position', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+        position: {
+          lat: 10,
+          lng: 12,
+        },
+      };
+
+      const renderConnectorWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerProps = renderConnectorWrapper
+        .find('[testID="Provider"]')
+        .props();
+
+      expect(providerProps.position).toEqual({
+        lat: 10,
+        lng: 12,
+      });
+    });
+
+    it('expect to render with currentRefinement', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+        currentRefinement: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      const renderConnectorWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerProps = renderConnectorWrapper
+        .find('[testID="Provider"]')
+        .props();
+
+      expect(providerProps.currentRefinement).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+    });
+  });
+
+  describe('GoogleMaps', () => {
+    const defaultProviderProps = {
+      onChange: () => {},
+      onIdle: () => {},
+      shouldUpdate: () => true,
+    };
+
+    const renderProvider = ({ connectorPropsWrapper, providerProps }) =>
+      connectorPropsWrapper
+        .find('[testID="Provider"]')
+        .props()
+        .children(providerProps);
+
+    it('expect to render', () => {
+      const children = jest.fn(() => <div>Hello this is the children</div>);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps, children })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      expect(providerPropsWrapper).toMatchSnapshot();
+      expect(children).toHaveBeenCalledWith({ hits: [] });
+    });
+
+    it('expect to render with initialZoom', () => {
+      const props = {
+        ...defaultProps,
+        initialZoom: 8,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
+        .find('[testID="GoogleMaps"]')
+        .props();
+
+      expect(googleMapProps.initialZoom).toBe(8);
+    });
+
+    it('expect to render with postiion', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+        position: {
+          lat: 10,
+          lng: 12,
+        },
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
+        .find('[testID="GoogleMaps"]')
+        .props();
+
+      expect(googleMapProps.initialPosition).toEqual({
+        lat: 10,
+        lng: 12,
+      });
+    });
+
+    it('expect to render with initialPosition', () => {
+      const props = {
+        ...defaultProps,
+        initialPosition: {
+          lat: 10,
+          lng: 12,
+        },
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
+        .find('[testID="GoogleMaps"]')
+        .props();
+
+      expect(googleMapProps.initialPosition).toEqual({
+        lat: 10,
+        lng: 12,
+      });
+    });
+
+    it('expect to render with map options', () => {
+      const props = {
+        ...defaultProps,
+        streetViewControl: true,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
+        .find('[testID="GoogleMaps"]')
+        .props();
+
+      expect(googleMapProps.mapOptions).toEqual({
+        streetViewControl: true,
+      });
+    });
+
+    it('expect to render with boundingBox', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+        boundingBox: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
+        .find('[testID="GoogleMaps"]')
+        .props();
+
+      expect(googleMapProps.boundingBox).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+    });
+
+    it('expect to render with boundingBoxPadding', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+        boundingBoxPadding: 10,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
+        .find('[testID="GoogleMaps"]')
+        .props();
+
+      expect(googleMapProps.boundingBoxPadding).toBe(10);
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
@@ -1,0 +1,556 @@
+import React from 'react';
+import Enzyme, { shallow, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {
+  createFakeGoogleReference,
+  createFakeMapInstance,
+} from '../../test/mockGoogleMaps';
+import GoogleMaps, { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('GoogleMaps', () => {
+  const defaultProps = {
+    google: createFakeGoogleReference(),
+    initialZoom: 1,
+    initialPosition: {
+      lat: 0,
+      lng: 0,
+    },
+    mapOptions: {},
+    onChange: () => {},
+    onIdle: () => {},
+    shouldUpdate: () => true,
+    position: null,
+    boundingBox: null,
+  };
+
+  const simulateMapReadyEvent = google => {
+    google.maps.event.addListenerOnce.mock.calls[0][2]();
+  };
+
+  const simulateEvent = (fn, eventName, event) => {
+    fn.addListener.mock.calls.find(call => call.includes(eventName))[1](event);
+  };
+
+  it('expect render correctly without the map rendered', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = shallow(
+      <GoogleMaps {...props}>
+        <div>This is the children</div>
+      </GoogleMaps>,
+      {
+        disableLifecycleMethods: true,
+      }
+    );
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.state()).toEqual({
+      isMapReady: false,
+    });
+  });
+
+  it('expect render correctly with the map rendered', () => {
+    const google = createFakeGoogleReference();
+
+    const props = {
+      ...defaultProps,
+      google,
+    };
+
+    const wrapper = shallow(
+      <GoogleMaps {...props}>
+        <div>This is the children</div>
+      </GoogleMaps>,
+      {
+        disableLifecycleMethods: true,
+      }
+    );
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.state()).toEqual({
+      isMapReady: false,
+    });
+
+    // Simulate didMount
+    wrapper.instance().componentDidMount();
+
+    simulateMapReadyEvent(google);
+
+    // Trigger the update
+    wrapper.update();
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.state()).toEqual({
+      isMapReady: true,
+    });
+  });
+
+  describe('creation', () => {
+    it('expect to create the GoogleMaps on didMount with the default options', () => {
+      const google = createFakeGoogleReference();
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      mount(<GoogleMaps {...props} />);
+
+      expect(google.maps.Map).toHaveBeenCalledTimes(1);
+      expect(google.maps.Map).toHaveBeenCalledWith(expect.any(HTMLDivElement), {
+        mapTypeControl: false,
+        fullscreenControl: false,
+        streetViewControl: false,
+        clickableIcons: false,
+        zoomControlOptions: {
+          position: 'left:top',
+        },
+      });
+    });
+
+    it('expect to create the GoogleMaps on didMount witht the given options', () => {
+      const google = createFakeGoogleReference();
+
+      const props = {
+        ...defaultProps,
+        mapOptions: {
+          streetViewControl: true,
+          otherOptionToPass: false,
+        },
+        google,
+      };
+
+      mount(<GoogleMaps {...props} />);
+
+      expect(google.maps.Map).toHaveBeenCalledTimes(1);
+      expect(google.maps.Map).toHaveBeenCalledWith(expect.any(HTMLDivElement), {
+        mapTypeControl: false,
+        fullscreenControl: false,
+        streetViewControl: true,
+        clickableIcons: false,
+        otherOptionToPass: false,
+        zoomControlOptions: {
+          position: 'left:top',
+        },
+      });
+    });
+
+    it('expect to listen "idle" event once to setup the rest of the listeners', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(<GoogleMaps {...props} />);
+
+      expect(google.maps.event.addListenerOnce).toHaveBeenCalledTimes(1);
+      expect(google.maps.event.addListenerOnce).toHaveBeenCalledWith(
+        mapInstance,
+        'idle',
+        expect.any(Function)
+      );
+
+      expect(wrapper.instance().listeners).toHaveLength(1);
+    });
+
+    it('expect to setup the rest of the listener when the map is ready', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(<GoogleMaps {...props} />);
+
+      simulateMapReadyEvent(google);
+
+      expect(mapInstance.addListener).toHaveBeenCalledWith(
+        'center_changed',
+        expect.any(Function)
+      );
+
+      expect(mapInstance.addListener).toHaveBeenCalledWith(
+        'zoom_changed',
+        expect.any(Function)
+      );
+
+      expect(mapInstance.addListener).toHaveBeenCalledWith(
+        'dragstart',
+        expect.any(Function)
+      );
+
+      expect(mapInstance.addListener).toHaveBeenCalledWith(
+        'idle',
+        expect.any(Function)
+      );
+
+      expect(wrapper.instance().listeners).toHaveLength(4);
+    });
+  });
+
+  describe('events', () => {
+    it('expect to trigger idle callback', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        onIdle: jest.fn(),
+        google,
+      };
+
+      shallow(<GoogleMaps {...props} />);
+
+      simulateMapReadyEvent(google);
+
+      expect(props.onIdle).toHaveBeenCalledTimes(0);
+
+      simulateEvent(mapInstance, 'idle');
+
+      expect(props.onIdle).toHaveBeenCalledTimes(1);
+      expect(props.onIdle).toHaveBeenCalledWith({
+        instance: mapInstance,
+      });
+    });
+
+    it('expect to not trigger idle callback on programmatic interaction', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        onIdle: jest.fn(),
+        google,
+      };
+
+      const wrapper = shallow(<GoogleMaps {...props} />);
+
+      simulateMapReadyEvent(google);
+
+      // Simulate fitBounds
+      wrapper.instance().isUserInteraction = false;
+
+      expect(props.onIdle).toHaveBeenCalledTimes(0);
+
+      simulateEvent(mapInstance, 'idle');
+
+      expect(props.onIdle).toHaveBeenCalledTimes(0);
+    });
+
+    ['center_changed', 'zoom_changed', 'dragstart'].forEach(eventName => {
+      it(`expect to call change callback on "${eventName}"`, () => {
+        const mapInstance = createFakeMapInstance();
+        const google = createFakeGoogleReference({
+          mapInstance,
+        });
+
+        const props = {
+          ...defaultProps,
+          onChange: jest.fn(),
+          google,
+        };
+
+        shallow(<GoogleMaps {...props} />);
+
+        simulateMapReadyEvent(google);
+
+        expect(props.onChange).toHaveBeenCalledTimes(0);
+
+        simulateEvent(mapInstance, eventName);
+
+        expect(props.onChange).toHaveBeenCalledTimes(1);
+      });
+
+      it(`expect to not call change callback on "${eventName}" with programmatic interaction`, () => {
+        const mapInstance = createFakeMapInstance();
+        const google = createFakeGoogleReference({
+          mapInstance,
+        });
+
+        const props = {
+          ...defaultProps,
+          onChange: jest.fn(),
+          google,
+        };
+
+        const wrapper = shallow(<GoogleMaps {...props} />);
+
+        simulateMapReadyEvent(google);
+
+        expect(props.onChange).toHaveBeenCalledTimes(0);
+
+        // Simulate fitBounds
+        wrapper.instance().isUserInteraction = false;
+
+        simulateEvent(mapInstance, eventName);
+
+        expect(props.onChange).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('context', () => {
+    it('expect to expose the google object through context', () => {
+      const google = createFakeGoogleReference();
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(<GoogleMaps {...props} />, {
+        disableLifecycleMethods: true,
+      });
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [GOOGLE_MAPS_CONTEXT]: expect.objectContaining({
+          google,
+        }),
+      });
+    });
+
+    it('expect to expose the map instance through context only when created', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(<GoogleMaps {...props} />, {
+        disableLifecycleMethods: true,
+      });
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [GOOGLE_MAPS_CONTEXT]: expect.objectContaining({
+          instance: undefined,
+        }),
+      });
+
+      // Simulate didMount
+      wrapper.instance().componentDidMount();
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [GOOGLE_MAPS_CONTEXT]: expect.objectContaining({
+          instance: mapInstance,
+        }),
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('expect to call fitBounds on didUpdate when boundingBox is provided', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      google.maps.LatLngBounds.mockImplementation((sw, ne) => ({
+        northEast: ne,
+        southWest: sw,
+      }));
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(
+        <GoogleMaps {...props}>
+          <div>This is the children</div>
+        </GoogleMaps>
+      );
+
+      simulateMapReadyEvent(google);
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps({
+        boundingBoxPadding: 0,
+        boundingBox: {
+          northEast: {
+            lat: 10,
+            lng: 10,
+          },
+          southWest: {
+            lat: 14,
+            lng: 14,
+          },
+        },
+      });
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenCalledWith(
+        {
+          northEast: {
+            lat: 10,
+            lng: 10,
+          },
+          southWest: {
+            lat: 14,
+            lng: 14,
+          },
+        },
+        0
+      );
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+    });
+
+    it('expect to call setCenter & setZoom when boundingBox is not provided', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      google.maps.LatLngBounds.mockImplementation((sw, ne) => ({
+        northEast: ne,
+        southWest: sw,
+      }));
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(
+        <GoogleMaps {...props}>
+          <div>This is the children</div>
+        </GoogleMaps>
+      );
+
+      simulateMapReadyEvent(google);
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps();
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledWith(1);
+      expect(mapInstance.setCenter).toHaveBeenCalledWith({
+        lat: 0,
+        lng: 0,
+      });
+    });
+
+    it('expect to prevent the update when the map is not ready', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(
+        <GoogleMaps {...props}>
+          <div>This is the children</div>
+        </GoogleMaps>
+      );
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps();
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+    });
+
+    it('expect to prevent the update shouldUpdate return false', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        shouldUpdate: () => false,
+        google,
+      };
+
+      const wrapper = shallow(
+        <GoogleMaps {...props}>
+          <div>This is the children</div>
+        </GoogleMaps>
+      );
+
+      simulateMapReadyEvent(google);
+      simulateEvent(mapInstance, 'center_changed');
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps();
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('delete', () => {
+    it('expect to remove all the listeners', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(<GoogleMaps {...props} />);
+
+      simulateMapReadyEvent(google);
+
+      expect(wrapper.instance().listeners).toHaveLength(4);
+
+      const internalListeners = wrapper.instance().listeners.slice();
+
+      wrapper.unmount();
+
+      internalListeners.forEach(listener => {
+        expect(listener.remove).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMapsLoader.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMapsLoader.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import injectScript from 'scriptjs';
+import GoogleMapsLoader from '../GoogleMapsLoader';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+jest.mock('scriptjs');
+
+describe('GoogleMapsLoader', () => {
+  const defaultProps = {
+    apiKey: 'API_KEY',
+  };
+
+  it('expect to call Google Maps API', () => {
+    const children = jest.fn(x => x);
+
+    const props = {
+      ...defaultProps,
+    };
+
+    shallow(<GoogleMapsLoader {...props}>{children}</GoogleMapsLoader>);
+
+    expect(injectScript).toHaveBeenLastCalledWith(
+      'https://maps.googleapis.com/maps/api/js?v=3.31&key=API_KEY',
+      expect.any(Function)
+    );
+  });
+
+  it('expect to call Google Maps API with a custom API Key', () => {
+    const children = jest.fn(x => x);
+
+    const props = {
+      ...defaultProps,
+      apiKey: 'CUSTOM_API_KEY',
+    };
+
+    shallow(<GoogleMapsLoader {...props}>{children}</GoogleMapsLoader>);
+
+    expect(injectScript).toHaveBeenLastCalledWith(
+      'https://maps.googleapis.com/maps/api/js?v=3.31&key=CUSTOM_API_KEY',
+      expect.any(Function)
+    );
+  });
+
+  it('expect to call Google Maps API with a custom endpoint', () => {
+    const children = jest.fn(x => x);
+
+    const props = {
+      ...defaultProps,
+      endpoint:
+        'https://maps.googleapis.com/maps/api/js?v=3.32&places,geometry',
+    };
+
+    shallow(<GoogleMapsLoader {...props}>{children}</GoogleMapsLoader>);
+
+    expect(injectScript).toHaveBeenLastCalledWith(
+      'https://maps.googleapis.com/maps/api/js?v=3.32&places,geometry&key=API_KEY',
+      expect.any(Function)
+    );
+  });
+
+  it("expect to render nothing when it's loading", () => {
+    const children = jest.fn(x => x);
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = shallow(
+      <GoogleMapsLoader {...props}>{children}</GoogleMapsLoader>
+    );
+
+    expect(wrapper.type()).toBe(null);
+    expect(children).not.toHaveBeenCalled();
+  });
+
+  it("expect to call children with the Google object when it's loaded", () => {
+    const children = jest.fn(x => x);
+
+    const google = {
+      version: '3.1.1',
+    };
+
+    const props = {
+      ...defaultProps,
+    };
+
+    injectScript.mockImplementationOnce((endpoint, callback) => {
+      global.google = google;
+      callback();
+    });
+
+    const wrapper = shallow(
+      <GoogleMapsLoader {...props}>{children}</GoogleMapsLoader>
+    );
+
+    expect(wrapper.type).not.toBe(null);
+    expect(children).toHaveBeenCalledTimes(1);
+    expect(children).toHaveBeenCalledWith(google);
+
+    delete global.google;
+  });
+
+  it('expect to not call setState when we unmount before loading is complete', () => {
+    const children = jest.fn(x => x);
+
+    const props = {
+      ...defaultProps,
+    };
+
+    let triggerLoadingComplete;
+    injectScript.mockImplementationOnce((endpoint, callback) => {
+      triggerLoadingComplete = callback;
+    });
+
+    const wrapper = shallow(
+      <GoogleMapsLoader {...props}>{children}</GoogleMapsLoader>
+    );
+
+    expect(wrapper.type).not.toBe(null);
+    expect(children).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+
+    triggerLoadingComplete();
+
+    expect(children).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Marker.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Marker.js
@@ -1,0 +1,273 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {
+  createFakeGoogleReference,
+  createFakeMapInstance,
+  createFakeMarkerInstance,
+} from '../../test/mockGoogleMaps';
+import * as utils from '../utils';
+import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+import Marker from '../Marker';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+jest.mock('../utils', () => {
+  const module = require.requireActual('../utils');
+
+  return {
+    registerEvents: jest.fn(),
+    createFilterProps: module.createFilterProps,
+    createListenersPropTypes: module.createListenersPropTypes,
+  };
+});
+
+describe('Marker', () => {
+  const defaultProps = {
+    hit: {
+      _geoloc: {
+        lat: 10,
+        lng: 12,
+      },
+    },
+  };
+
+  beforeEach(() => {
+    utils.registerEvents.mockClear();
+    utils.registerEvents.mockReset();
+  });
+
+  it('expect render correctly', () => {
+    const mapInstance = createFakeMapInstance();
+    const google = createFakeGoogleReference({
+      mapInstance,
+    });
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = shallow(<Marker {...props} />, {
+      context: {
+        [GOOGLE_MAPS_CONTEXT]: {
+          instance: mapInstance,
+          google,
+        },
+      },
+    });
+
+    expect(wrapper.type()).toBe(null);
+  });
+
+  describe('creation', () => {
+    it('expect to create the Marker on didMount with default options', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Marker {...props} />, {
+        disableLifecycleMethods: true,
+        context: {
+          [GOOGLE_MAPS_CONTEXT]: {
+            instance: mapInstance,
+            google,
+          },
+        },
+      });
+
+      expect(google.maps.Marker).not.toHaveBeenCalled();
+
+      // Simulate didMount
+      wrapper.instance().componentDidMount();
+
+      expect(google.maps.Marker).toHaveBeenCalledTimes(1);
+      expect(google.maps.Marker).toHaveBeenCalledWith({
+        map: mapInstance,
+        position: {
+          lat: 10,
+          lng: 12,
+        },
+      });
+    });
+
+    it('expect to create the Marker on didMount with given options', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        title: 'My Marker',
+        visible: false,
+        children: <span />,
+        onClick: () => {},
+      };
+
+      const wrapper = shallow(<Marker {...props} />, {
+        disableLifecycleMethods: true,
+        context: {
+          [GOOGLE_MAPS_CONTEXT]: {
+            instance: mapInstance,
+            google,
+          },
+        },
+      });
+
+      expect(google.maps.Marker).not.toHaveBeenCalled();
+
+      // Simulate didMount
+      wrapper.instance().componentDidMount();
+
+      expect(google.maps.Marker).toHaveBeenCalledTimes(1);
+      expect(google.maps.Marker).toHaveBeenCalledWith({
+        title: 'My Marker',
+        visible: false,
+        map: mapInstance,
+        position: {
+          lat: 10,
+          lng: 12,
+        },
+      });
+    });
+
+    it('expect to register the listeners on didMount', () => {
+      const mapInstance = createFakeMapInstance();
+      const markerInstance = createFakeMarkerInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+        markerInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Marker {...props} />, {
+        disableLifecycleMethods: true,
+        context: {
+          [GOOGLE_MAPS_CONTEXT]: {
+            instance: mapInstance,
+            google,
+          },
+        },
+      });
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(0);
+
+      // Simulate didMount
+      wrapper.instance().componentDidMount();
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(1);
+      expect(utils.registerEvents).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        markerInstance
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('expect to remove the listener on didUpdate', () => {
+      const removeEventListeners = jest.fn();
+      const mapInstance = createFakeMapInstance();
+      const markerInstance = createFakeMarkerInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+        markerInstance,
+      });
+
+      utils.registerEvents.mockImplementation(() => removeEventListeners);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Marker {...props} />, {
+        context: {
+          [GOOGLE_MAPS_CONTEXT]: {
+            instance: mapInstance,
+            google,
+          },
+        },
+      });
+
+      expect(removeEventListeners).toHaveBeenCalledTimes(0);
+
+      // Simulate the update
+      wrapper.instance().componentDidUpdate();
+
+      expect(removeEventListeners).toHaveBeenCalledTimes(1);
+    });
+
+    it('expect to register the listeners on didUpdate', () => {
+      const mapInstance = createFakeMapInstance();
+      const markerInstance = createFakeMarkerInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+        markerInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+      };
+
+      utils.registerEvents.mockImplementationOnce(() => () => {});
+
+      const wrapper = shallow(<Marker {...props} />, {
+        context: {
+          [GOOGLE_MAPS_CONTEXT]: {
+            instance: mapInstance,
+            google,
+          },
+        },
+      });
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(1);
+
+      // Simulate the update
+      wrapper.instance().componentDidUpdate();
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(2);
+      expect(utils.registerEvents).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        markerInstance
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('expect to remove the Marker on willUnmount', () => {
+      const mapInstance = createFakeMapInstance();
+      const markerInstance = createFakeMarkerInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+        markerInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Marker {...props} />, {
+        context: {
+          [GOOGLE_MAPS_CONTEXT]: {
+            instance: mapInstance,
+            google,
+          },
+        },
+      });
+
+      wrapper.unmount();
+
+      expect(markerInstance.setMap).toHaveBeenCalledTimes(1);
+      expect(markerInstance.setMap).toHaveBeenCalledWith(null);
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
@@ -1,0 +1,501 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {
+  createFakeGoogleReference,
+  createFakeMapInstance,
+} from '../../test/mockGoogleMaps';
+import Provider, { STATE_CONTEXT } from '../Provider';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Provider', () => {
+  const defaultProps = {
+    google: createFakeGoogleReference(),
+    hits: [],
+    initialPosition: { lat: 0, lng: 0 },
+    isRefineOnMapMove: true,
+    hasMapMoveSinceLastRefine: false,
+    refine: () => {},
+    toggleRefineOnMapMove: () => {},
+    setMapMoveSinceLastRefine: () => {},
+    children: () => {},
+  };
+
+  const lastRenderArgs = fn => fn.mock.calls[fn.mock.calls.length - 1][0];
+
+  it('expect to render with default props', () => {
+    const children = jest.fn(x => x);
+
+    const props = {
+      ...defaultProps,
+    };
+
+    shallow(<Provider {...props}>{children}</Provider>);
+
+    expect(children).toHaveBeenCalledTimes(1);
+    expect(children).toHaveBeenCalledWith({
+      boundingBox: undefined,
+      boundingBoxPadding: undefined,
+      onChange: expect.any(Function),
+      onIdle: expect.any(Function),
+      shouldUpdate: expect.any(Function),
+    });
+  });
+
+  describe('didUpdate', () => {
+    it('expect to call setMapMoveSinceLastRefine when position change', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        position: { lat: 10, lng: 12 },
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps({
+        position: { lat: 12, lng: 14 },
+      });
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(1);
+      expect(props.setMapMoveSinceLastRefine).toBeCalledWith(false);
+    });
+
+    it('expect to call setMapMoveSinceLastRefine when currentRefinement change', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        currentRefinement: {
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        },
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps({
+        currentRefinement: {
+          northEast: { lat: 12, lng: 14 },
+          southWest: { lat: 14, lng: 16 },
+        },
+      });
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(1);
+      expect(props.setMapMoveSinceLastRefine).toBeCalledWith(false);
+    });
+
+    it('expect to not call setMapMoveSinceLastRefine when nothing change', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(props.setMapMoveSinceLastRefine).not.toHaveBeenCalled();
+
+      wrapper.setProps();
+
+      expect(props.setMapMoveSinceLastRefine).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('boundingBox', () => {
+    it('expect to use hits when currentRefinement is not defined and hits are not empty', () => {
+      const children = jest.fn(x => x);
+      const google = createFakeGoogleReference();
+
+      google.maps.LatLngBounds.mockImplementation(() => ({
+        extend: jest.fn().mockReturnThis(),
+        getNorthEast: () => ({
+          toJSON: () => ({
+            lat: 10,
+            lng: 10,
+          }),
+        }),
+        getSouthWest: () => ({
+          toJSON: () => ({
+            lat: 14,
+            lng: 14,
+          }),
+        }),
+      }));
+
+      const props = {
+        ...defaultProps,
+        hits: [
+          { _geoloc: { lat: 10, lng: 12 } },
+          { _geoloc: { lat: 12, lng: 14 } },
+        ],
+        google,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(lastRenderArgs(children).boundingBox).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 10,
+        },
+        southWest: {
+          lat: 14,
+          lng: 14,
+        },
+      });
+    });
+
+    it("expect to use currentRefinement when it's defined and hits are empty", () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        currentRefinement: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(lastRenderArgs(children).boundingBox).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+    });
+
+    it("expect to use currentRefinement when it's defined and hits are not empty", () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        hits: [
+          { _geoloc: { lat: 10, lng: 12 } },
+          { _geoloc: { lat: 12, lng: 14 } },
+        ],
+        currentRefinement: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(lastRenderArgs(children).boundingBox).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+    });
+
+    it("expect to use currentRefinement when it's not defined and hits are empty", () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(lastRenderArgs(children).boundingBox).toBe(undefined);
+    });
+  });
+
+  describe('onChange', () => {
+    it('expect to call setMapMoveSinceLast refine', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(0);
+
+      lastRenderArgs(children).onChange();
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(1);
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledWith(true);
+    });
+
+    it('expect to schedule a refine call when refine on map move is enabled', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+
+      lastRenderArgs(children).onChange();
+
+      expect(wrapper.instance().isPendingRefine).toBe(true);
+    });
+
+    it('expect to not schedule a refine call when refine on map move is disabled', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        isRefineOnMapMove: false,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+
+      lastRenderArgs(children).onChange();
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+    });
+  });
+
+  describe('onIdle', () => {
+    it('expect to call refine when there is a pending refinement', () => {
+      const mapInstance = createFakeMapInstance();
+      const children = jest.fn(x => x);
+
+      mapInstance.getBounds.mockImplementation(() => ({
+        getNorthEast: () => ({
+          toJSON: () => ({
+            lat: 10,
+            lng: 12,
+          }),
+        }),
+        getSouthWest: () => ({
+          toJSON: () => ({
+            lat: 12,
+            lng: 14,
+          }),
+        }),
+      }));
+
+      const props = {
+        ...defaultProps,
+        refine: jest.fn(),
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      lastRenderArgs(children).onChange();
+      lastRenderArgs(children).onIdle({ instance: mapInstance });
+
+      expect(props.refine).toHaveBeenCalledTimes(1);
+      expect(props.refine).toHaveBeenCalledWith({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+    });
+
+    it('expect to reset the pending refinement when there is a pending refinement', () => {
+      const mapInstance = createFakeMapInstance();
+      const children = jest.fn(x => x);
+
+      mapInstance.getBounds.mockImplementation(() => ({
+        getNorthEast: () => ({
+          toJSON: () => {},
+        }),
+        getSouthWest: () => ({
+          toJSON: () => {},
+        }),
+      }));
+
+      const props = {
+        ...defaultProps,
+        refine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      lastRenderArgs(children).onChange();
+
+      expect(wrapper.instance().isPendingRefine).toBe(true);
+
+      lastRenderArgs(children).onIdle({ instance: mapInstance });
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+    });
+
+    it('expect to be a noop when there is no pending refinement', () => {
+      const mapInstance = createFakeMapInstance();
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        refine: jest.fn(),
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+
+      lastRenderArgs(children).onIdle({ instance: mapInstance });
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+      expect(props.refine).not.toHaveBeenCalled();
+      expect(props.setMapMoveSinceLastRefine).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('shouldUpdate', () => {
+    it('expect to return true when there is no pending refinement and the map has not moved', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      const actual = lastRenderArgs(children).shouldUpdate();
+
+      expect(actual).toBe(true);
+    });
+
+    it('expect to return false when there is a pending refinement', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      lastRenderArgs(children).onChange();
+
+      const actual = lastRenderArgs(children).shouldUpdate();
+
+      expect(actual).toBe(false);
+    });
+
+    it('expect to return false when the map has moved', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        hasMapMoveSinceLastRefine: true,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      const actual = lastRenderArgs(children).shouldUpdate();
+
+      expect(actual).toBe(false);
+    });
+  });
+
+  describe('context', () => {
+    it('expect to expose isRefineOnMapMove', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          isRefineOnMapMove: true,
+        }),
+      });
+    });
+
+    it('expect to expose hasMapMoveSinceLastRefine', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          hasMapMoveSinceLastRefine: false,
+        }),
+      });
+    });
+
+    it('expect to expose toggleRefineOnMapMove', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          toggleRefineOnMapMove: props.toggleRefineOnMapMove,
+        }),
+      });
+    });
+
+    it('expect to expose setMapMoveSinceLastRefine', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          setMapMoveSinceLastRefine: props.setMapMoveSinceLastRefine,
+        }),
+      });
+    });
+
+    it('expect to expose refineWithInstance', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          refineWithInstance: wrapper.instance().refineWithInstance,
+        }),
+      });
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Redo.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Redo.js
@@ -1,0 +1,160 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { createFakeMapInstance } from '../../test/mockGoogleMaps';
+import { STATE_CONTEXT } from '../Provider';
+import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+import { Redo } from '../Redo';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Redo', () => {
+  const defaultProps = {
+    translate: x => x,
+  };
+
+  const defaultContext = {
+    [STATE_CONTEXT]: {
+      isRefineOnMapMove: true,
+      hasMapMoveSinceLastRefine: false,
+      toggleRefineOnMapMove: () => {},
+      refineWithInstance: () => {},
+    },
+    [GOOGLE_MAPS_CONTEXT]: {
+      instance: createFakeMapInstance(),
+    },
+  };
+
+  const getStateContext = context => context[STATE_CONTEXT];
+  const getGoogleMapsContext = context => context[GOOGLE_MAPS_CONTEXT];
+
+  it('expect to render correctly', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      context,
+    });
+
+    expect(wrapper.find('button').prop('disabled')).toBe(true);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to render correctly when map has moved', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        hasMapMoveSinceLastRefine: true,
+      },
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      context,
+    });
+
+    expect(wrapper.find('button').prop('disabled')).toBe(false);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to disable refine on map move onDidMount', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      disableLifecycleMethods: true,
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.instance().componentDidMount();
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('expect to only disable refine on map move when value is true onDidMount', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      disableLifecycleMethods: true,
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.instance().componentDidMount();
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+  });
+
+  it('expect to call refineWithInstance on button click', () => {
+    const instance = createFakeMapInstance();
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        refineWithInstance: jest.fn(),
+      },
+      [GOOGLE_MAPS_CONTEXT]: {
+        ...getGoogleMapsContext(defaultContext),
+        instance,
+      },
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      context,
+    });
+
+    const { refineWithInstance } = getStateContext(context);
+
+    expect(refineWithInstance).toHaveBeenCalledTimes(0);
+
+    wrapper.find('button').simulate('click');
+
+    expect(refineWithInstance).toHaveBeenCalledTimes(1);
+    expect(refineWithInstance).toHaveBeenCalledWith(instance);
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/Control.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/Control.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Control expect to render correctly with refine on map move 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <label
+    className="ais-GeoSearch-label"
+  >
+    <input
+      checked={true}
+      className="ais-GeoSearch-input"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    control
+  </label>
+</div>
+`;
+
+exports[`Control expect to render correctly without refine on map move 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <label
+    className="ais-GeoSearch-label"
+  >
+    <input
+      checked={false}
+      className="ais-GeoSearch-input"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    control
+  </label>
+</div>
+`;
+
+exports[`Control expect to render correctly without refine on map move when the map has moved 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <button
+    className="ais-GeoSearch-redo"
+    onClick={[Function]}
+  >
+    redo
+  </button>
+</div>
+`;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/CustomMarker.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/CustomMarker.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomMarker with portal expect to render correctly 1`] = `
+<CustomMarker
+  anchor={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  className=""
+  hit={
+    Object {
+      "_geoloc": Object {
+        "lat": 10,
+        "lng": 12,
+      },
+    }
+  }
+>
+  <span>
+    This is the children.
+  </span>
+</CustomMarker>
+`;
+
+exports[`CustomMarker with unstable_renderSubtreeIntoContainer expect to render correctly 1`] = `
+<CustomMarker
+  anchor={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  className=""
+  hit={
+    Object {
+      "_geoloc": Object {
+        "lat": 10,
+        "lng": 12,
+      },
+    }
+  }
+/>
+`;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GeoSearch GoogleMaps expect to render 1`] = `
+<GoogleMaps
+  google={
+    Object {
+      "maps": Object {
+        "ControlPosition": Object {
+          "LEFT_TOP": "left:top",
+        },
+        "LatLng": [MockFunction],
+        "LatLngBounds": [MockFunction],
+        "Map": [MockFunction],
+        "Marker": [MockFunction],
+        "OverlayView": [Function],
+        "event": Object {
+          "addListenerOnce": [MockFunction],
+        },
+      },
+    }
+  }
+  initialPosition={
+    Object {
+      "lat": 0,
+      "lng": 0,
+    }
+  }
+  initialZoom={1}
+  mapOptions={Object {}}
+  onChange={[Function]}
+  onIdle={[Function]}
+  shouldUpdate={[Function]}
+  testID="GoogleMaps"
+>
+  <div>
+    Hello this is the children
+  </div>
+</GoogleMaps>
+`;
+
+exports[`GeoSearch Provider expect to render 1`] = `
+<Provider
+  google={
+    Object {
+      "maps": Object {
+        "ControlPosition": Object {
+          "LEFT_TOP": "left:top",
+        },
+        "LatLng": [MockFunction],
+        "LatLngBounds": [MockFunction],
+        "Map": [MockFunction],
+        "Marker": [MockFunction],
+        "OverlayView": [Function],
+        "event": Object {
+          "addListenerOnce": [MockFunction],
+        },
+      },
+    }
+  }
+  hasMapMoveSinceLastRefine={false}
+  hits={Array []}
+  isRefineOnMapMove={true}
+  refine={[Function]}
+  setMapMoveSinceLastRefine={[Function]}
+  testID="Provider"
+  toggleRefineOnMapMove={[Function]}
+/>
+`;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GoogleMaps.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GoogleMaps.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GoogleMaps expect render correctly with the map rendered 1`] = `
+<div
+  className="ais-GeoSearch"
+>
+  <div
+    className="ais-GeoSearch-map"
+  />
+</div>
+`;
+
+exports[`GoogleMaps expect render correctly with the map rendered 2`] = `
+<div
+  className="ais-GeoSearch"
+>
+  <div
+    className="ais-GeoSearch-map"
+  />
+  <div>
+    This is the children
+  </div>
+</div>
+`;
+
+exports[`GoogleMaps expect render correctly without the map rendered 1`] = `
+<div
+  className="ais-GeoSearch"
+>
+  <div
+    className="ais-GeoSearch-map"
+  />
+</div>
+`;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/Redo.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/Redo.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Redo expect to render correctly 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <button
+    className="ais-GeoSearch-redo ais-GeoSearch-redo--disabled"
+    disabled={true}
+    onClick={[Function]}
+  >
+    redo
+  </button>
+</div>
+`;
+
+exports[`Redo expect to render correctly when map has moved 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <button
+    className="ais-GeoSearch-redo"
+    disabled={false}
+    onClick={[Function]}
+  >
+    redo
+  </button>
+</div>
+`;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/utils.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/utils.js
@@ -1,0 +1,234 @@
+import PropTypes from 'prop-types';
+import { createFakeMarkerInstance } from '../../test/mockGoogleMaps';
+import * as utils from '../utils';
+
+describe('utils', () => {
+  describe('registerEvents', () => {
+    it('expect to add listeners from events', () => {
+      const onClick = () => {};
+      const onMouseMove = () => {};
+      const instance = createFakeMarkerInstance();
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+        onMouseMove,
+      };
+
+      utils.registerEvents(events, props, instance);
+
+      expect(instance.addListener).toHaveBeenCalledTimes(2);
+
+      expect(instance.addListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      );
+
+      expect(instance.addListener).toHaveBeenCalledWith(
+        'mousemove',
+        expect.any(Function)
+      );
+    });
+
+    it('expect to add listeners with event & marker', () => {
+      const onClick = jest.fn();
+      const onMouseMove = jest.fn();
+      const instance = createFakeMarkerInstance();
+      const listeners = [];
+
+      instance.addListener.mockImplementation((event, listener) =>
+        listeners.push(listener)
+      );
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+        onMouseMove,
+      };
+
+      utils.registerEvents(events, props, instance);
+
+      listeners.forEach(listener => listener({ type: 'event' }));
+
+      expect(onClick).toHaveBeenCalledWith({
+        event: { type: 'event' },
+        marker: instance,
+      });
+
+      expect(onMouseMove).toHaveBeenCalledWith({
+        event: { type: 'event' },
+        marker: instance,
+      });
+    });
+
+    it('expect to only add listeners listed from events', () => {
+      const onClick = () => {};
+      const onMouseEnter = () => {};
+      const instance = createFakeMarkerInstance();
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+        onMouseEnter,
+      };
+
+      utils.registerEvents(events, props, instance);
+
+      expect(instance.addListener).toHaveBeenCalledTimes(1);
+      expect(instance.addListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      );
+    });
+
+    it('expect to only add listeners listed from props', () => {
+      const onClick = () => {};
+      const instance = createFakeMarkerInstance();
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+      };
+
+      utils.registerEvents(events, props, instance);
+
+      expect(instance.addListener).toHaveBeenCalledTimes(1);
+      expect(instance.addListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      );
+    });
+
+    it('expect to return a function that remove the listeners', () => {
+      const onClick = () => {};
+      const onMouseMove = () => {};
+      const remove = jest.fn();
+      const instance = createFakeMarkerInstance();
+
+      instance.addListener.mockImplementation(() => ({
+        remove,
+      }));
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+        onMouseMove,
+      };
+
+      const removeEventListeners = utils.registerEvents(
+        events,
+        props,
+        instance
+      );
+
+      expect(remove).toHaveBeenCalledTimes(0);
+
+      removeEventListeners();
+
+      expect(remove).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('createListenersPropTypes', () => {
+    it('expect to return an object with listeners propType from event types', () => {
+      const events = {
+        onClick: '',
+        onMouseMove: '',
+      };
+
+      const expectation = {
+        onClick: PropTypes.func,
+        onMouseMove: PropTypes.func,
+      };
+
+      const actual = utils.createListenersPropTypes(events);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return an empty object from empty event types', () => {
+      const events = {};
+
+      const expectation = {};
+      const actual = utils.createListenersPropTypes(events);
+
+      expect(actual).toEqual(expectation);
+    });
+  });
+
+  describe('createFilterProps', () => {
+    it('expect to return an object without excluded keys', () => {
+      const excludes = ['children', 'onClick'];
+
+      const props = {
+        label: 'Title',
+        onClick: () => {},
+        children: '<div />',
+      };
+
+      const expectation = {
+        label: 'Title',
+      };
+
+      const filterProps = utils.createFilterProps(excludes);
+      const actual = filterProps(props);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return the given props when excluded keys is empty', () => {
+      const onClick = () => {};
+      const excludes = [];
+
+      const props = {
+        children: '<div />',
+        onClick,
+      };
+
+      const expectation = {
+        children: '<div />',
+        onClick,
+      };
+
+      const filterProps = utils.createFilterProps(excludes);
+      const actual = filterProps(props);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return an empty object when all keys are excluded', () => {
+      const excludes = ['children', 'onClick'];
+
+      const props = {
+        onClick: () => {},
+        children: '<div />',
+      };
+
+      const expectation = {};
+      const filterProps = utils.createFilterProps(excludes);
+      const actual = filterProps(props);
+
+      expect(actual).toEqual(expectation);
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/elements/__tests__/createHTMLMarker.js
+++ b/packages/react-instantsearch-dom-geo/src/elements/__tests__/createHTMLMarker.js
@@ -1,0 +1,257 @@
+import { createFakeGoogleReference } from '../../../test/mockGoogleMaps';
+import createHTMLMarker from '../createHTMLMarker';
+
+describe('createHTMLMarker', () => {
+  const createFakeParams = ({ ...rest }) => ({
+    position: {
+      lat: 10,
+      lng: 12,
+    },
+    map: 'map-instance-placeholder',
+    className: 'ais-geo-search-marker',
+    ...rest,
+  });
+
+  it('expect to create a marker', () => {
+    const googleReference = createFakeGoogleReference();
+    const HTMLMarker = createHTMLMarker(googleReference);
+    const params = createFakeParams();
+
+    const marker = new HTMLMarker(params);
+
+    expect(marker.anchor).toEqual({ x: 0, y: 0 });
+    expect(marker.subscriptions).toEqual([]);
+    expect(marker.latLng).toEqual({ lat: 10, lng: 12 });
+
+    expect(marker.element).toEqual(expect.any(HTMLDivElement));
+    expect(marker.element.className).toBe('ais-geo-search-marker');
+    expect(marker.element.style.position).toBe('absolute');
+    expect(marker.element.style.whiteSpace).toBe('nowrap');
+
+    expect(marker.setMap).toHaveBeenCalledWith('map-instance-placeholder');
+  });
+
+  it('expect to create a marker with a custom anchor', () => {
+    const googleReference = createFakeGoogleReference();
+    const HTMLMarker = createHTMLMarker(googleReference);
+    const params = createFakeParams({
+      anchor: {
+        x: 5,
+        y: 10,
+      },
+    });
+
+    const marker = new HTMLMarker(params);
+
+    expect(marker.anchor).toEqual({ x: 5, y: 10 });
+  });
+
+  it('expect to create a marker with a custom className', () => {
+    const googleReference = createFakeGoogleReference();
+    const HTMLMarker = createHTMLMarker(googleReference);
+    const params = createFakeParams({
+      className: 'my-custom-marker',
+    });
+
+    const marker = new HTMLMarker(params);
+
+    expect(marker.element.className).toBe('my-custom-marker');
+  });
+
+  describe('onAdd', () => {
+    it('expect to append the element to the overlay', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const overlayMouseTarget = {
+        appendChild: jest.fn(),
+      };
+
+      const marker = new HTMLMarker(params);
+
+      marker.getPanes.mockImplementation(() => ({ overlayMouseTarget }));
+
+      marker.onAdd();
+
+      expect(overlayMouseTarget.appendChild).toHaveBeenCalledWith(
+        marker.element
+      );
+    });
+
+    it('expect to not append the element to the overlay when panes are not available', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const overlayMouseTarget = {
+        appendChild: jest.fn(),
+      };
+
+      const marker = new HTMLMarker(params);
+
+      marker.getPanes.mockImplementation(() => null);
+
+      marker.onAdd();
+
+      expect(overlayMouseTarget.appendChild).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('draw', () => {
+    it('expect to set the correct position on the element', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const fromLatLngToDivPixel = jest.fn(() => ({
+        x: 100,
+        y: 50,
+      }));
+
+      const marker = new HTMLMarker(params);
+
+      marker.getProjection.mockImplementation(() => ({
+        fromLatLngToDivPixel,
+      }));
+
+      marker.draw();
+
+      expect(fromLatLngToDivPixel).toHaveBeenCalledWith({ lat: 10, lng: 12 });
+      expect(marker.element.style.left).toBe('100px');
+      expect(marker.element.style.top).toBe('50px');
+    });
+
+    it('expect to set the correct zIndex on the element', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const fromLatLngToDivPixel = jest.fn(() => ({
+        x: 100,
+        y: 50,
+      }));
+
+      const marker = new HTMLMarker(params);
+
+      marker.getProjection.mockImplementationOnce(() => ({
+        fromLatLngToDivPixel,
+      }));
+
+      marker.draw();
+
+      expect(marker.element.style.zIndex).toBe('0');
+    });
+
+    it('expect to not set the correct position when the projection is not available', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+
+      const marker = new HTMLMarker(params);
+
+      marker.getProjection.mockImplementation(() => null);
+
+      marker.draw();
+
+      expect(marker.element.style.left).toBe('');
+      expect(marker.element.style.top).toBe('');
+      expect(marker.element.style.zIndex).toBe('');
+    });
+  });
+
+  describe('onRemove', () => {
+    it('expect to remove the element', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+
+      const marker = new HTMLMarker(params);
+
+      // Simulate the parentNode
+      const parentNode = document.createElement('div');
+      parentNode.appendChild(marker.element);
+
+      expect(parentNode.childNodes).toHaveLength(1);
+
+      marker.onRemove();
+
+      expect(parentNode.childNodes).toHaveLength(0);
+      expect(marker.element).toBe(undefined);
+    });
+
+    it('expect to remove all the listeners', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const remove = jest.fn();
+
+      const marker = new HTMLMarker(params);
+
+      // Simulate the parentNode
+      const parentNode = document.createElement('div');
+      parentNode.appendChild(marker.element);
+
+      // Simulate the subscriptions
+      marker.subscriptions.push({ remove });
+      marker.subscriptions.push({ remove });
+
+      marker.onRemove();
+
+      expect(marker.subscriptions).toEqual([]);
+      expect(remove).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('addListener', () => {
+    it('expect to register listener', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const onClick = () => {};
+
+      const marker = new HTMLMarker(params);
+
+      const addEventListener = jest.spyOn(marker.element, 'addEventListener');
+
+      marker.addListener('click', onClick);
+
+      expect(addEventListener).toHaveBeenCalledTimes(1);
+      expect(addEventListener).toHaveBeenCalledWith('click', onClick);
+      expect(marker.subscriptions).toHaveLength(1);
+    });
+
+    it('expect to return a function to remove the listener', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const onClick = () => {};
+
+      const marker = new HTMLMarker(params);
+
+      const removeEventListener = jest.spyOn(
+        marker.element,
+        'removeEventListener'
+      );
+
+      const subscription = marker.addListener('click', onClick);
+
+      subscription.remove();
+
+      expect(removeEventListener).toHaveBeenCalledTimes(1);
+      expect(removeEventListener).toHaveBeenCalledWith('click', onClick);
+      expect(marker.subscriptions).toHaveLength(0);
+    });
+  });
+
+  describe('getPosition', () => {
+    it('expect to return the latLng', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+
+      const marker = new HTMLMarker(params);
+
+      const actual = marker.getPosition();
+      const expectation = { lat: 10, lng: 12 };
+
+      expect(actual).toEqual(expectation);
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/elements/createHTMLMarker.js
+++ b/packages/react-instantsearch-dom-geo/src/elements/createHTMLMarker.js
@@ -1,0 +1,88 @@
+const createHTMLMarker = google => {
+  class HTMLMarker extends google.maps.OverlayView {
+    constructor({
+      position,
+      map,
+      className,
+      anchor = {
+        x: 0,
+        y: 0,
+      },
+    }) {
+      super();
+
+      this.anchor = anchor;
+      this.subscriptions = [];
+      this.latLng = new google.maps.LatLng(position);
+
+      this.element = document.createElement('div');
+      this.element.className = className;
+      this.element.style.position = 'absolute';
+      // Force the "white-space" of the element will avoid the
+      // content to collapse when we move the map from center
+      this.element.style.whiteSpace = 'nowrap';
+
+      this.setMap(map);
+    }
+
+    onAdd() {
+      if (this.getPanes()) {
+        this.getPanes().overlayMouseTarget.appendChild(this.element);
+      }
+    }
+
+    draw() {
+      if (this.getProjection()) {
+        const position = this.getProjection().fromLatLngToDivPixel(this.latLng);
+
+        const offsetX = this.anchor.x + this.element.offsetWidth / 2;
+        const offsetY = this.anchor.y + this.element.offsetHeight;
+
+        this.element.style.left = `${Math.round(position.x - offsetX)}px`;
+        this.element.style.top = `${Math.round(position.y - offsetY)}px`;
+
+        // Markers to the south are in front of markers to the north
+        // This is the default behaviour of Google Maps
+        this.element.style.zIndex = parseInt(this.element.style.top, 10);
+      }
+    }
+
+    onRemove() {
+      if (this.element && this.element.parentNode) {
+        this.element.parentNode.removeChild(this.element);
+
+        this.subscriptions.forEach(subscription => subscription.remove());
+
+        delete this.element;
+
+        this.subscriptions = [];
+      }
+    }
+
+    addListener(eventName, listener) {
+      const subscription = {
+        remove: () => {
+          this.element.removeEventListener(eventName, listener);
+
+          this.subscriptions = this.subscriptions.filter(
+            _ => _ !== subscription
+          );
+        },
+      };
+
+      this.element.addEventListener(eventName, listener);
+
+      this.subscriptions = this.subscriptions.concat(subscription);
+
+      return subscription;
+    }
+
+    getPosition() {
+      return this.latLng;
+    }
+  }
+
+  return HTMLMarker;
+};
+
+export default createHTMLMarker;

--- a/packages/react-instantsearch-dom-geo/src/index.js
+++ b/packages/react-instantsearch-dom-geo/src/index.js
@@ -1,0 +1,6 @@
+export { default as GoogleMapsLoader } from './GoogleMapsLoader';
+export { default as GeoSearch } from './GeoSearch';
+export { default as Marker } from './Marker';
+export { default as CustomMarker } from './CustomMarker';
+export { default as Redo } from './Redo';
+export { default as Control } from './Control';

--- a/packages/react-instantsearch-dom-geo/src/propTypes.js
+++ b/packages/react-instantsearch-dom-geo/src/propTypes.js
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types';
+
+export const LatLngPropType = PropTypes.shape({
+  lat: PropTypes.number.isRequired,
+  lng: PropTypes.number.isRequired,
+});
+
+export const BoundingBoxPropType = PropTypes.shape({
+  northEast: LatLngPropType.isRequired,
+  southWest: LatLngPropType.isRequired,
+});
+
+export const GeolocHitPropType = PropTypes.shape({
+  _geoloc: LatLngPropType.isRequired,
+});

--- a/packages/react-instantsearch-dom-geo/src/utils.js
+++ b/packages/react-instantsearch-dom-geo/src/utils.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+
+export const registerEvents = (events, props, instance) => {
+  const eventsAvailable = Object.keys(events);
+  const listeners = Object.keys(props)
+    .filter(key => eventsAvailable.indexOf(key) !== -1)
+    .map(name =>
+      instance.addListener(events[name], event => {
+        props[name]({ event, marker: instance });
+      })
+    );
+
+  return () => {
+    listeners.forEach(listener => listener.remove());
+  };
+};
+
+export const createListenersPropTypes = eventTypes =>
+  Object.keys(eventTypes).reduce(
+    (acc, name) => ({ ...acc, [name]: PropTypes.func }),
+    {}
+  );
+
+export const createFilterProps = excludes => props =>
+  Object.keys(props)
+    .filter(name => excludes.indexOf(name) === -1)
+    .reduce(
+      (acc, name) => ({
+        ...acc,
+        [name]: props[name],
+      }),
+      {}
+    );

--- a/packages/react-instantsearch-dom-geo/test/mockGoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/test/mockGoogleMaps.js
@@ -1,0 +1,76 @@
+export class FakeOverlayView {
+  setMap = jest.fn();
+
+  getPanes = jest.fn(() => ({
+    overlayMouseTarget: {
+      appendChild: jest.fn(),
+    },
+  }));
+
+  getProjection = jest.fn(() => ({
+    fromLatLngToDivPixel: jest.fn(() => ({
+      x: 0,
+      y: 0,
+    })),
+  }));
+}
+
+export const createFakeMapInstance = () => ({
+  addListener: jest.fn(() => ({
+    remove: jest.fn(),
+  })),
+  getCenter: jest.fn(),
+  setCenter: jest.fn(),
+  getZoom: jest.fn(),
+  setZoom: jest.fn(),
+  getBounds: jest.fn(() => ({
+    getNorthEast: jest.fn(),
+    getSouthWest: jest.fn(),
+  })),
+  getProjection: jest.fn(() => ({
+    fromPointToLatLng: jest.fn(() => ({
+      lat: jest.fn(),
+      lng: jest.fn(),
+    })),
+    fromLatLngToPoint: jest.fn(() => ({
+      x: 0,
+      y: 0,
+    })),
+  })),
+  fitBounds: jest.fn(),
+});
+
+export const createFakeMarkerInstance = () => ({
+  setMap: jest.fn(),
+  getPosition: jest.fn(),
+  addListener: jest.fn(),
+});
+
+export const createFakeHTMLMarkerInstance = () => ({
+  element: document.createElement('div'),
+  setMap: jest.fn(),
+  draw: jest.fn(),
+});
+
+export const createFakeGoogleReference = ({
+  mapInstance = createFakeMapInstance(),
+  markerInstance = createFakeMarkerInstance(),
+} = {}) => ({
+  maps: {
+    LatLng: jest.fn(x => x),
+    LatLngBounds: jest.fn(() => ({
+      extend: jest.fn().mockReturnThis(),
+    })),
+    Map: jest.fn(() => mapInstance),
+    Marker: jest.fn(() => markerInstance),
+    ControlPosition: {
+      LEFT_TOP: 'left:top',
+    },
+    event: {
+      addListenerOnce: jest.fn(() => ({
+        remove: jest.fn(),
+      })),
+    },
+    OverlayView: FakeOverlayView,
+  },
+});

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -11,6 +11,7 @@ export { connectAutoComplete } from 'react-instantsearch-core';
 export { connectBreadcrumb } from 'react-instantsearch-core';
 export { connectConfigure } from 'react-instantsearch-core';
 export { connectCurrentRefinements } from 'react-instantsearch-core';
+export { connectGeoSearch } from 'react-instantsearch-core';
 export { connectHierarchicalMenu } from 'react-instantsearch-core';
 export { connectHighlight } from 'react-instantsearch-core';
 export { connectHits } from 'react-instantsearch-core';

--- a/packages/react-instantsearch-native/src/index.js
+++ b/packages/react-instantsearch-native/src/index.js
@@ -11,6 +11,7 @@ export { connectAutoComplete } from 'react-instantsearch-core';
 export { connectBreadcrumb } from 'react-instantsearch-core';
 export { connectConfigure } from 'react-instantsearch-core';
 export { connectCurrentRefinements } from 'react-instantsearch-core';
+export { connectGeoSearch } from 'react-instantsearch-core';
 export { connectHierarchicalMenu } from 'react-instantsearch-core';
 export { connectHighlight } from 'react-instantsearch-core';
 export { connectHits } from 'react-instantsearch-core';

--- a/packages/react-instantsearch/connectors.js
+++ b/packages/react-instantsearch/connectors.js
@@ -2,6 +2,7 @@ export { connectAutoComplete } from 'react-instantsearch-core';
 export { connectBreadcrumb } from 'react-instantsearch-core';
 export { connectConfigure } from 'react-instantsearch-core';
 export { connectCurrentRefinements } from 'react-instantsearch-core';
+export { connectGeoSearch } from 'react-instantsearch-core';
 export { connectHierarchicalMenu } from 'react-instantsearch-core';
 export { connectHighlight } from 'react-instantsearch-core';
 export { connectHits } from 'react-instantsearch-core';

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -1,0 +1,585 @@
+import React, { Fragment, Component } from 'react';
+import PropTypes from 'prop-types';
+import { setAddon, storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import JSXAddon from 'storybook-addon-jsx';
+import { Configure, Highlight, connectHits } from 'react-instantsearch-dom';
+import {
+  GoogleMapsLoader,
+  GeoSearch,
+  Marker,
+  CustomMarker,
+  Redo,
+  Control,
+} from 'react-instantsearch-dom-maps';
+import { displayName, filterProps, WrapWithHits } from './util';
+import Places from './places';
+
+setAddon(JSXAddon);
+
+const stories = storiesOf('GeoSearch', module);
+
+const Container = ({ children }) => (
+  <div style={{ height: 500 }}>{children}</div>
+);
+
+Container.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+const apiKey = 'AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ';
+const initialZoom = 12;
+const initialPosition = {
+  lat: 40.71,
+  lng: -74.01,
+};
+
+stories.addWithJSX(
+  'default',
+  () => (
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+      <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+      <Container>
+        <GoogleMapsLoader apiKey={apiKey}>
+          {google => (
+            <GeoSearch google={google}>
+              {({ hits }) => (
+                <Fragment>
+                  {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                </Fragment>
+              )}
+            </GeoSearch>
+          )}
+        </GoogleMapsLoader>
+      </Container>
+    </WrapWithHits>
+  ),
+  {
+    displayName,
+    filterProps,
+  }
+);
+
+// With Places
+stories.addWithJSX(
+  'with Places',
+  () => (
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+      <Configure hitsPerPage={20} aroundRadius={5000} />
+
+      <Places
+        defaultRefinement={{
+          lat: 37.7793,
+          lng: -122.419,
+        }}
+      />
+
+      <Container>
+        <GoogleMapsLoader apiKey={apiKey}>
+          {google => (
+            <GeoSearch google={google} initialZoom={12}>
+              {({ hits }) => (
+                <Fragment>
+                  <Control />
+
+                  {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                </Fragment>
+              )}
+            </GeoSearch>
+          )}
+        </GoogleMapsLoader>
+      </Container>
+    </WrapWithHits>
+  ),
+  {
+    displayName,
+    filterProps,
+  }
+);
+
+// Only UI
+stories
+  .addWithJSX(
+    'with zoom & center',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch
+                google={google}
+                initialZoom={initialZoom}
+                initialPosition={initialPosition}
+              >
+                {({ hits }) => (
+                  <Fragment>
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with map options',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google} streetViewControl>
+                {({ hits }) => (
+                  <Fragment>
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <Marker> options',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    {hits.map(hit => (
+                      <Marker
+                        key={hit.objectID}
+                        hit={hit}
+                        label={hit.price_formatted}
+                        onClick={() => {}}
+                      />
+                    ))}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <Marker> events',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    {hits.map(hit => (
+                      <Marker
+                        key={hit.objectID}
+                        hit={hit}
+                        onClick={action('click')}
+                      />
+                    ))}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <Redo> component',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Redo />
+
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <Control> component',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Control />
+
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <Control> component disabled',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Control enableRefineOnMapMove={false} />
+
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <CustomMarker>',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Control />
+
+                    {hits.map(hit => (
+                      <Fragment key={hit.objectID}>
+                        <CustomMarker
+                          hit={hit}
+                          className="my-custom-marker"
+                          anchor={{ x: 0, y: 5 }}
+                        >
+                          {hit.price_formatted}
+                        </CustomMarker>
+                      </Fragment>
+                    ))}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <CustomMarker> events',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Control />
+
+                    {hits.map(hit => (
+                      <Fragment key={hit.objectID}>
+                        <CustomMarker
+                          hit={hit}
+                          className="my-custom-marker"
+                          anchor={{ x: 0, y: 5 }}
+                          onClick={action('click')}
+                        >
+                          <span>{hit.price_formatted}</span>
+                        </CustomMarker>
+                      </Fragment>
+                    ))}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  );
+
+stories.addWithJSX('with InfoWindow', () => {
+  class Example extends Component {
+    static propTypes = {
+      google: PropTypes.object.isRequired,
+    };
+
+    InfoWindow = new this.props.google.maps.InfoWindow();
+
+    onClickMarker = ({ hit, marker }) => {
+      if (this.InfoWindow.getMap()) {
+        this.InfoWindow.close();
+      }
+
+      this.InfoWindow.setContent(hit.name);
+
+      this.InfoWindow.open(marker.getMap(), marker);
+    };
+
+    renderGeoHit = hit => (
+      <Marker
+        key={hit.objectID}
+        hit={hit}
+        anchor={{ x: 0, y: 5 }}
+        onClick={({ marker }) => {
+          this.onClickMarker({
+            hit,
+            marker,
+          });
+        }}
+      />
+    );
+
+    render() {
+      const { google } = this.props;
+
+      return (
+        <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+          <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+          <Container>
+            <GeoSearch google={google}>
+              {({ hits }) => <Fragment>{hits.map(this.renderGeoHit)}</Fragment>}
+            </GeoSearch>
+          </Container>
+        </WrapWithHits>
+      );
+    }
+  }
+
+  return (
+    <GoogleMapsLoader apiKey={apiKey}>
+      {google => <Example google={google} />}
+    </GoogleMapsLoader>
+  );
+});
+
+stories.addWithJSX('with hits communication (custom)', () => {
+  const CustomHits = connectHits(({ hits, selectedHit, onHitOver }) => (
+    <div className="hits">
+      {hits.map(hit => {
+        const classNames = [
+          'hit',
+          'hit--airbnb',
+          selectedHit && selectedHit.objectID === hit.objectID
+            ? 'hit--airbnb-active'
+            : '',
+        ];
+
+        return (
+          <div
+            key={hit.objectID}
+            className={classNames.join(' ').trim()}
+            onMouseEnter={() => onHitOver(hit)}
+            onMouseLeave={() => onHitOver(null)}
+          >
+            <div className="hit-content">
+              <div>
+                <Highlight attribute="name" hit={hit} />
+                <span> - ${hit.price}</span>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  ));
+
+  class Example extends Component {
+    state = {
+      selectedHit: null,
+    };
+
+    onHitOver = hit =>
+      this.setState(() => ({
+        selectedHit: hit,
+      }));
+
+    renderGeoHit = hit => {
+      const { selectedHit } = this.state;
+
+      const classNames = [
+        'my-custom-marker',
+        selectedHit && selectedHit.objectID === hit.objectID
+          ? 'my-custom-marker--active'
+          : '',
+      ];
+
+      return (
+        <CustomMarker
+          key={hit.objectID}
+          hit={hit}
+          anchor={{ x: 0, y: 5 }}
+          onMouseEnter={() => this.onHitOver(hit)}
+          onMouseLeave={() => this.onHitOver(null)}
+        >
+          <div className={classNames.join(' ').trim()}>
+            <span>{hit.price_formatted}</span>
+          </div>
+        </CustomMarker>
+      );
+    };
+
+    render() {
+      const { selectedHit } = this.state;
+
+      return (
+        <WrapWithHits
+          indexName="airbnb"
+          linkedStoryGroup="GeoSearch"
+          hitsElement={
+            <CustomHits selectedHit={selectedHit} onHitOver={this.onHitOver} />
+          }
+        >
+          <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+          <Container>
+            <GoogleMapsLoader apiKey={apiKey}>
+              {google => (
+                <GeoSearch google={google}>
+                  {({ hits }) => (
+                    <Fragment>{hits.map(this.renderGeoHit)}</Fragment>
+                  )}
+                </GeoSearch>
+              )}
+            </GoogleMapsLoader>
+          </Container>
+        </WrapWithHits>
+      );
+    }
+  }
+
+  return <Example />;
+});
+
+stories.addWithJSX('with unmount', () => {
+  class Example extends Component {
+    state = {
+      visible: true,
+    };
+
+    onToggle = () =>
+      this.setState(({ visible }) => ({
+        visible: !visible,
+      }));
+
+    render() {
+      const { visible } = this.state;
+
+      return (
+        <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+          <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+          <button onClick={this.onToggle} style={{ marginBottom: 15 }}>
+            {visible ? 'Unmout' : 'Mount'}
+          </button>
+
+          {visible && (
+            <Container>
+              <GoogleMapsLoader apiKey={apiKey}>
+                {google => (
+                  <GeoSearch google={google}>
+                    {({ hits }) => (
+                      <Fragment>
+                        {hits.map(hit => (
+                          <Marker key={hit.objectID} hit={hit} />
+                        ))}
+                      </Fragment>
+                    )}
+                  </GeoSearch>
+                )}
+              </GoogleMapsLoader>
+            </Container>
+          )}
+        </WrapWithHits>
+      );
+    }
+  }
+
+  return <Example />;
+});

--- a/stories/places/connector.js
+++ b/stories/places/connector.js
@@ -1,0 +1,31 @@
+import { createConnector } from 'react-instantsearch-dom';
+
+export default createConnector({
+  displayName: 'AlgoliaGeoSearch',
+
+  getProvidedProps() {
+    return {};
+  },
+
+  refine(props, searchState, nextValue) {
+    // eslint-disable-next-line no-unused-vars
+    const { boundingBox, ...sliceSearchState } = searchState;
+
+    return {
+      ...sliceSearchState,
+      aroundLatLng: nextValue,
+    };
+  },
+
+  getSearchParameters(searchParameters, props, searchState) {
+    const currentRefinement =
+      searchState.aroundLatLng || props.defaultRefinement;
+
+    return searchParameters
+      .setQueryParameter('insideBoundingBox')
+      .setQueryParameter(
+        'aroundLatLng',
+        `${currentRefinement.lat}, ${currentRefinement.lng}`
+      );
+  },
+});

--- a/stories/places/index.js
+++ b/stories/places/index.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import places from 'places.js';
+import connect from './connector';
+
+class Places extends Component {
+  static propTypes = {
+    refine: PropTypes.func.isRequired,
+    defaultRefinement: PropTypes.object.isRequired,
+  };
+
+  createRef = c => (this.element = c);
+
+  componentDidMount() {
+    const { refine, defaultRefinement } = this.props;
+
+    const autocomplete = places({
+      container: this.element,
+    });
+
+    autocomplete.on('change', event => {
+      refine(event.suggestion.latlng);
+    });
+
+    autocomplete.on('clear', () => {
+      refine(defaultRefinement);
+    });
+  }
+
+  render() {
+    return (
+      <div style={{ marginBottom: 20 }}>
+        <input
+          ref={this.createRef}
+          type="search"
+          id="address-input"
+          placeholder="Where are we going?"
+        />
+      </div>
+    );
+  }
+}
+
+export default connect(Places);

--- a/stories/util.js
+++ b/stories/util.js
@@ -18,7 +18,7 @@ export const CustomHits = connectHits(({ hits }) => (
   <div className="hits">
     {hits.map(hit => (
       <div key={hit.objectID} className="hit">
-        <div>
+        {hit.image && (
           <div className="hit-picture">
             <img
               src={`https://res.cloudinary.com/hilnmyskv/image/fetch/h_100,q_100,f_auto/${
@@ -26,7 +26,7 @@ export const CustomHits = connectHits(({ hits }) => (
               }`}
             />
           </div>
-        </div>
+        )}
         <div className="hit-content">
           <div>
             <Highlight attribute="name" hit={hit} />
@@ -74,6 +74,7 @@ export const WrapWithHits = ({
   appId,
   apiKey,
   indexName,
+  hitsElement,
 }) => {
   const sourceCodeUrl = `https://github.com/algolia/react-instantsearch/tree/master/stories/${linkedStoryGroup}.stories.js`;
   const playgroundLink = hasPlayground ? (
@@ -93,6 +94,8 @@ export const WrapWithHits = ({
       </a>
     </div>
   ) : null;
+
+  const hits = hitsElement || <CustomHits />;
 
   const searchParameters = {
     hitsPerPage: 3,
@@ -120,7 +123,7 @@ export const WrapWithHits = ({
               ) : null}
               <ClearRefinements translations={{ reset: 'Clear all filters' }} />
             </div>
-            <CustomHits />
+            {hits}
             <div className="hit-pagination">
               {pagination ? <Pagination showLast={true} /> : null}
             </div>
@@ -142,6 +145,7 @@ WrapWithHits.propTypes = {
   hasPlayground: PropTypes.bool,
   pagination: PropTypes.bool,
   searchParameters: PropTypes.object,
+  hitsElement: PropTypes.element,
 };
 
 // defaultProps added so that they're displayed in the JSX addon

--- a/storybook/public/util.css
+++ b/storybook/public/util.css
@@ -17,8 +17,8 @@
   padding: 4px 6px;
   line-height: 1em;
   position: absolute;
-  background-color: #F3F3F3;
-  border: solid 1px #E4E4E4;
+  background-color: #f3f3f3;
+  border: solid 1px #e4e4e4;
   border-width: 0 1px 1px 0;
 }
 
@@ -28,10 +28,10 @@
   justify-content: space-around;
   overflow-x: hidden;
   clear: left;
-  border-bottom: solid 1px #E4E4E4;
-  border-left: solid 1px #E4E4E4;
-  border-right: solid 1px #E4E4E4;
-  background-color: #F3F3F3;
+  border-bottom: solid 1px #e4e4e4;
+  border-left: solid 1px #e4e4e4;
+  border-right: solid 1px #e4e4e4;
+  background-color: #f3f3f3;
 }
 
 .playground-url,
@@ -43,7 +43,7 @@
   color: #999999;
   padding: 4px 6px;
   line-height: 1em;
-  background-color: #F3F3F3;
+  background-color: #f3f3f3;
   border: none;
 }
 
@@ -52,12 +52,12 @@
  */
 
 .widget-container {
-  border: solid 1px #E4E4E4;
+  border: solid 1px #e4e4e4;
   border-radius: 5px 5px 0px 0px;
 }
 
 .widget-container:after {
-  content: "Widget display";
+  content: 'Widget display';
   border-radius: 5px 0 3px;
 }
 
@@ -66,15 +66,15 @@
  */
 
 .hits-container {
-  border-left: solid 1px #E4E4E4;
-  border-right: solid 1px #E4E4E4;
-  border-bottom: solid 1px #E4E4E4;
+  border-left: solid 1px #e4e4e4;
+  border-right: solid 1px #e4e4e4;
+  border-bottom: solid 1px #e4e4e4;
   display: flex;
   flex-direction: column;
 }
 
 .hits-container:after {
-  content: "Results";
+  content: 'Results';
 }
 
 /**
@@ -99,9 +99,15 @@
 }
 
 .hit {
-  margin: 10px 10px;
+  padding: 5px 5px;
   display: flex;
   align-items: center;
+}
+
+.hit--airbnb:hover,
+.hit--airbnb-active {
+  background-color: #3369e7;
+  color: #ffffff;
 }
 
 .ais-SearchBox__root {
@@ -142,4 +148,46 @@
 
 .multi-index_hit .multi-index_hit-content {
   padding-left: 10px;
+}
+
+/* GeoSearch */
+
+.my-custom-marker {
+  position: relative;
+  background-color: white;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  padding: 3px 5px;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.15);
+}
+
+.my-custom-marker:hover,
+.my-custom-marker--active {
+  background-color: #3369e7;
+  color: white;
+  cursor: pointer;
+}
+
+.my-custom-marker::after {
+  content: '';
+  display: block;
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  bottom: -5px;
+  background-color: white;
+  border-color: rgba(0, 0, 0, 0.2);
+  border-width: 0 1px 1px 0;
+  border-style: solid;
+  left: 50%;
+  margin-left: -4px;
+  transform: rotate(45deg);
+}
+
+.my-custom-marker:hover::after,
+.my-custom-marker--active::after {
+  background-color: #3369e7;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,7 +991,7 @@ ajv@^6.1.0:
     json-schema-traverse "^0.3.0"
     uri-js "^3.0.2"
 
-algolia-aerial@1.3.4:
+algolia-aerial@1.3.4, algolia-aerial@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/algolia-aerial/-/algolia-aerial-1.3.4.tgz#161d11120f96de56933442eb78bc74adfeb7c582"
   dependencies:
@@ -1435,6 +1435,12 @@ atoa@1.0.0:
 atob@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.0.tgz#ab2b150e51d7b122b9efc8d7340c06b6c41076bc"
+
+autocomplete.js@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.30.0.tgz#e7a1425474291d255911499cee2a3c5624c9ccc5"
+  dependencies:
+    immediate "^3.2.3"
 
 autoprefixer@8.6.3:
   version "8.6.3"
@@ -5761,6 +5767,10 @@ events@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/events/-/events-2.0.0.tgz#cbbb56bf3ab1ac18d71c43bb32c86255062769f2"
 
+events@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+
 eventsource@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-0.1.6.tgz#0acede849ed7dd1ccc32c811bb11b944d4f29232"
@@ -7471,6 +7481,10 @@ iltorb@^1.0.9:
 image-size@^0.6.0:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.2.tgz#8ee316d4298b028b965091b673d5f1537adee5b4"
+
+immediate@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
 
 immediate@~3.0.5:
   version "3.0.6"
@@ -10847,6 +10861,16 @@ pkginfo@0.x.x:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
 
+places.js@1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/places.js/-/places.js-1.7.3.tgz#70d9791fc6e6e7f3359a1cadcc8876914cdfdd65"
+  dependencies:
+    algolia-aerial "^1.3.4"
+    algoliasearch "^3.27.1"
+    autocomplete.js "^0.30.0"
+    events "^3.0.0"
+    insert-css "^2.0.0"
+
 plist@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-2.0.1.tgz#0a32ca9481b1c364e92e18dc55c876de9d01da8b"
@@ -12888,7 +12912,7 @@ schema-utils@^0.4.0, schema-utils@^0.4.5:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
-scriptjs@^2.5.7:
+scriptjs@^2.5.7, scriptjs@^2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.8.tgz#d0c43955c2e6bad33b6e4edf7b53b8965aa7ca5f"
 


### PR DESCRIPTION
This is the first part of the work for the GeoSearch widget. The second part will be the widget itself implemented (with Google Maps) with this connector. Most of the API is fixed but I will update the PR if something is missing during the widget implementation.

At the end in this version we don't support all the APIs that InstantSearch support. It's because with the current implementation of React InstantSearch it's very complicated to update the internal state of the widget from the outside. So we only manage the state of the search in the connector.

**Issue:**

The part that might change is the one where we compute the current position. This position is used (mainly) to move the map to the correct bounds when we don't have results. It might change because with the current implementation we can only read the position from the path `aroundLatLng` in the `searchState`. It's perfect for a custom widget (like Places for example), the widget needs to write the position at this path (an example will be built in Storybook). But when the position is set by `Configure` we need to look at a different path `configure.aroundLatLng`. We have some solutions:

- allow to configure the path where we want to find the value as prop
- search at multiple paths stop on the first match `aroundLatLng` → `configure.aroundLatLng`
- implement the position, radius & precision as props of the connector (like InstantSearch). This solution remove the needs to look at different paths, we can only keep the top level one

**Update**: 

- I updated the PR to be able to override the `shouldComponentUpdate` hook of `createConnector` from the connector definition. To enable a full customisation we should be able to re-render the content of the marker. But the `createConnector` prevent this update based on his props & state. Now we can bypass this limitation by implementing the `shouldUpdate` function on the connector.