### PR TITLE
feat(geo): add refine on interaction [PART-3]

### DIFF
--- a/docgen/src/stylesheets/components/_documentation.sass
+++ b/docgen/src/stylesheets/components/_documentation.sass
@@ -3,7 +3,7 @@ $offset-height: 60px
 
 .documentation-section,
 .examples-section
-  padding-bottom: 300px
+  padding-bottom: 320px
 
   .container
     article
@@ -136,7 +136,6 @@ $offset-height: 60px
       background: #fff
       border: 1px solid #d8d8d8
       border-radius: 2px 2px 0 0
-      margin: -8px 0 0
       padding: 0.75em 1em
       font-family: $paragraphs-font-family
       border-radius: 6px 6px 0 0
@@ -201,6 +200,10 @@ $offset-height: 60px
         display: block
         height: $offset-height
         // margin: (-$offset-height) 0 0
+
+    .sub-component-title
+      &:before
+        height: 10px
 
     .anchor
       margin-left: .2em

--- a/docgen/src/widgets/GeoSearch.md
+++ b/docgen/src/widgets/GeoSearch.md
@@ -1,0 +1,735 @@
+---
+mainTitle: Widgets
+title: GeoSearch
+layout: widget.pug
+category: widget
+showInNav: true
+navWeight: 0
+external: true
+---
+
+## Description
+
+The `GeoSearch` widget displays the list of results from the search on a Google Maps. It also provides a way to search for results based on their position. The widget provides some of the common GeoSearch patterns like search on map interaction.
+
+<div class="storybook-section">
+  <a class="btn btn-cta" href="https://community.algolia.com/react-instantsearch/storybook?selectedKind=GeoSearch&selectedStory=default" target="_blank">
+    See live example
+  </a>
+</div>
+
+## Requirements
+
+The API of this widget is a bit different than the others that you can find in React InstantSearch. The API is component driven rather than options driven. We chose the former because it brings more flexibility to the widget. Since the geo search pattern is not a use case for every applications we decided to ship the widget in a separate package. Be sure to install it before using it:
+
+```shell
+yarn add react-instantsearch-dom-maps
+```
+
+The GeoSearch widget uses the [geo search](https://www.algolia.com/doc/guides/searching/geo-search) capabilities of Algolia. Your hits **must** have a `_geoloc` attribute in order to be available in the render prop.
+
+Currently, the feature is not compatible with multiple values in the `_geoloc` attribute (e.g. a restaurant with multiple locations). In that case you can duplicate your records and use the [distinct](https://www.algolia.com/doc/guides/ranking/distinct) feature of Algolia to only retrieve unique results.
+
+You are also responsible for loading the Google Maps library. We provide a component to load the library ([`<GoogleMapsLoader />`](/widgets/GeoSearch.html#googlemapsloader)) but its usage **is not required to use the geo widget**. You can use any strategy you want to load Google Maps. You can find more informations about that in [the Google Maps documentation](https://developers.google.com/maps/documentation/javascript/tutorial).
+
+Don’t forget to explicitly set the `height` of the map container, otherwise it won’t be shown (it’s a requirement of Google Maps).
+
+## Example
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GoogleMapsLoader, GeoSearch, Control, Marker } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <div style={{ height: 500 }}>
+      <GoogleMapsLoader apiKey="GOOGLE_MAPS_API_KEY">
+        {google => (
+          <GeoSearch google={google}>
+            {({ hits }) => (
+              <div>
+                <Control />
+
+                {hits.map(hit => (
+                  <Marker key={hit.objectID} hit={hit} />
+                ))}
+              </div>
+            )}
+          </GeoSearch>
+        )}
+      </GoogleMapsLoader>
+    </div>
+  </InstantSearch>
+);
+```
+
+## `<GeoSearch />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component provides the `hits` to display. All the other geo components need to be nested under it.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        // render the hits
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>google*</td>
+      <td>Type: <code>object</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Reference to the global window.google object. See <a href="https://developers.google.com/maps/documentation/javascript/tutorial" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>children*</td>
+      <td>Type: <code>({ hits: object[] }) => React.ReactNode</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          The render function takes an object as argument with the <code>hits</code> inside.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>initialZoom</td>
+      <td>Type: <code>number</code></td>
+      <td>Default: <code>1</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>By default the map will set the zoom accordingly to the markers displayed on it. When we refine it may happen that the results are empty. For those situations we need to provide a zoom to render the map.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>initialPosition</td>
+      <td>Type: <code>{ lat: number, lng: number }</code></td>
+      <td>Default: <code>{ lat: 0, lng: 0 }</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>By default the map will set the position accordingly to the markers displayed on it. When we refine it may happen that the results are empty. For those situations we need to provide a position to render the map.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+This component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+This component has no translations.
+
+## `<Marker />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component is a wapper around [`google.maps.Marker`](https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#MarkerOptions), all the options avaible on the Marker class can be provided as props. This component cannot render any children components. See [`<CustomMarker />`](/widgets/GeoSearch.html#custommarker) for this behaviour.
+
+Currently the component does not support the update of the options. Once the component is rendered changing the props won't update the marker options.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, Marker } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <div>
+          {hits.map(hit => (
+            <Marker key={hit.objectID} hit={hit} />
+          ))}
+        </div>
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>hit*</td>
+      <td>Type: <code>object</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Hit to attach on the marker.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the marker icon was clicked, see <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.click" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onDoubleClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the marker icon was double clicked, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.dblclick" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseDown</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired for a mousedown on the marker, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mousedown" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOut</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the mouse leaves the area of the marker icon, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mouseout" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOver</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the mouse enters the area of the marker icon, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mouseover" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseUp</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired for a mouseup on the marker, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mouseup" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+This component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+This component has no translations.
+
+## `<CustomMarker />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component is an alternative to [`<Marker />`](/widgets/GeoSearch.html#marker). In some cases you may want to have the full control of the marker rendering. You can provide any React components to design your custom marker.
+
+Currently the component does not support the update of the options. Once the component is rendered changing the props won't update the marker options.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, CustomMarker } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <div>
+          {hits.map(hit => (
+            <CustomMarker key={hit.objectID} hit={hit}>
+              <span>{hit.price}</span>
+            </CustomMarker>
+          ))}
+        </div>
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>hit*</td>
+      <td>Type: <code>object</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Hit to attach on the marker.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>className</td>
+      <td>Type: <code>string</code></td>
+      <td><code>''</<code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>The className to add on the marker wrapper element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>anchor</td>
+      <td>Type: <code>{ x: number, y: number }</code></td>
+      <td><code>{ x: 0, y: 0 }</<code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Offset for the marker element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onDoubleClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseDown</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseEnter</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseLeave</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseMove</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOut</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOver</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseUp</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+This component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+This component has no translations.
+
+## `<Control />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component allows the user to control the different strategy for the refinement (enable / disable refine on map move).
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, Control } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <Control />
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>enableRefineOnMapMove</td>
+      <td>Type: <code>boolean</code></td>
+      <td>Default: <code>true</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>If true, refine will be triggered as you move the map.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>.ais-GeoSearch-control {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The control element of the widget.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-label {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the control element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-input {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The input of the control element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-redo {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The redo search button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>control</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the radio button.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>redo</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the redo button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## `<Redo />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component disable the refine on map move behaviour.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, Redo } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <Redo />
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+The component has no props.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>.ais-GeoSearch-control {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The control element of the widget.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-redo {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The redo search button.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-redo--disabled {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The disabled redo search button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>redo</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the redo button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## `<GoogleMapsLoader />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component provide a built-in solution to load the `google.maps` library in your application. Its usage is completely optional. You can use any strategy you want to load the library. You can find more informations about that in [the Google Maps documentation](https://developers.google.com/maps/documentation/javascript/tutorial).
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GoogleMapsLoader, GeoSearch } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GoogleMapsLoader apiKey="GOOGLE_MAPS_API_KEY">
+      {google => (
+        <GeoSearch google={google}>
+          {({ hits }) => (
+            <Redo />
+          )}
+        </GeoSearch>
+      )}
+    </GoogleMapsLoader>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>apiKey*</td>
+      <td>Type: <code>string</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          Your Google API Key in case you don't have one you can create it on <a href="https://developers.google.com/maps/documentation/javascript/get-api-key" target="_blank" rel="noopener">the Google documentation</a>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>children*</td>
+      <td>Type: <code>(google: object) => React.ReactNode</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          The render function that takes the <code>google</code> object as argument.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>endpoint</td>
+      <td>Type: <code>string</code></td>
+      <td>Default: <code>https://maps.googleapis.com/maps/api/js?v=3.31</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          Endpoint that will be used to fetch the Google Maps library, can be used to load a different version, libraries, ... You can find more inforamtion <a href="https://developers.google.com/maps/documentation/javascript/libraries" target="_blank" rel="noopener">in the Google documentation</a>.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+The component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+The component has no translations keys.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "lodash.orderby": "4.6.0",
     "mversion": "1.10.1",
     "netlify-cli": "1.2.2",
+    "places.js": "1.7.3",
     "prettier": "1.13.5",
     "prop-types": "15.6.1",
     "react": "16.4.1",

--- a/packages/react-instantsearch-dom-geo/.babelrc
+++ b/packages/react-instantsearch-dom-geo/.babelrc
@@ -15,6 +15,9 @@
         ],
         "react",
         "stage-2"
+      ],
+      "plugins": [
+        "lodash"
       ]
     },
     "test": {
@@ -32,6 +35,9 @@
         ],
         "react",
         "stage-2"
+      ],
+      "plugins": [
+        "lodash"
       ]
     },
     "production": {
@@ -49,6 +55,9 @@
         ],
         "react",
         "stage-2"
+      ],
+      "plugins": [
+        "lodash"
       ]
     },
     "es": {
@@ -67,6 +76,9 @@
         ],
         "react",
         "stage-2"
+      ],
+      "plugins": [
+        "lodash"
       ]
     }
   }

--- a/packages/react-instantsearch-dom-geo/package.json
+++ b/packages/react-instantsearch-dom-geo/package.json
@@ -2,7 +2,7 @@
   "name": "react-instantsearch-dom-maps",
   "private": true,
   "version": "5.2.0-beta.2",
-  "description": "⚡ Lightning-fast search for Google Maps, by Algolia",
+  "description": "⚡ Lightning-fast search for React DOM & Google Maps, by Algolia",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "sideEffects": false,
@@ -43,6 +43,7 @@
     "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
   },
   "dependencies": {
+    "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "scriptjs": "^2.5.8"
   },
@@ -50,6 +51,7 @@
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",
     "babel-plugin-external-helpers": "6.22.0",
+    "babel-plugin-lodash": "3.3.4",
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-2": "6.24.1",

--- a/packages/react-instantsearch-dom-geo/src/Connector.js
+++ b/packages/react-instantsearch-dom-geo/src/Connector.js
@@ -1,0 +1,66 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connectGeoSearch } from 'react-instantsearch-dom';
+import { LatLngPropType, BoundingBoxPropType } from './propTypes';
+
+export const STATE_CONTEXT = '__ais_geo_search__state__';
+
+export class Connector extends Component {
+  static propTypes = {
+    hits: PropTypes.arrayOf(PropTypes.object).isRequired,
+    isRefinedWithMap: PropTypes.bool.isRequired,
+    refine: PropTypes.func.isRequired,
+    children: PropTypes.func.isRequired,
+    position: LatLngPropType,
+    currentRefinement: BoundingBoxPropType,
+  };
+
+  state = {
+    isRefineOnMapMove: true,
+    hasMapMoveSinceLastRefine: false,
+  };
+
+  toggleRefineOnMapMove = () =>
+    this.setState(({ isRefineOnMapMove }) => ({
+      isRefineOnMapMove: !isRefineOnMapMove,
+    }));
+
+  setMapMoveSinceLastRefine = next => {
+    const { hasMapMoveSinceLastRefine } = this.state;
+
+    if (hasMapMoveSinceLastRefine === next) {
+      return;
+    }
+
+    this.setState(() => ({
+      hasMapMoveSinceLastRefine: next,
+    }));
+  };
+
+  render() {
+    const {
+      hits,
+      isRefinedWithMap,
+      position,
+      currentRefinement,
+      refine,
+      children,
+    } = this.props;
+
+    const { isRefineOnMapMove, hasMapMoveSinceLastRefine } = this.state;
+
+    return children({
+      toggleRefineOnMapMove: this.toggleRefineOnMapMove,
+      setMapMoveSinceLastRefine: this.setMapMoveSinceLastRefine,
+      hits,
+      isRefinedWithMap,
+      isRefineOnMapMove,
+      hasMapMoveSinceLastRefine,
+      position,
+      currentRefinement,
+      refine,
+    });
+  }
+}
+
+export default connectGeoSearch(Connector);

--- a/packages/react-instantsearch-dom-geo/src/Control.js
+++ b/packages/react-instantsearch-dom-geo/src/Control.js
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { createClassNames, translatable } from 'react-instantsearch-dom';
+import { STATE_CONTEXT } from './Provider';
+import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+
+const cx = createClassNames('GeoSearch');
+
+export class Control extends Component {
+  static propTypes = {
+    translate: PropTypes.func.isRequired,
+    enableRefineOnMapMove: PropTypes.bool,
+  };
+
+  static contextTypes = {
+    [STATE_CONTEXT]: PropTypes.shape({
+      isRefineOnMapMove: PropTypes.bool.isRequired,
+      toggleRefineOnMapMove: PropTypes.func.isRequired,
+      hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
+      refineWithInstance: PropTypes.func.isRequired,
+    }).isRequired,
+    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+      instance: PropTypes.object.isRequired,
+    }).isRequired,
+  };
+
+  static defaultProps = {
+    enableRefineOnMapMove: true,
+  };
+
+  getStateContext() {
+    return this.context[STATE_CONTEXT];
+  }
+
+  getGoogleMapsContext() {
+    return this.context[GOOGLE_MAPS_CONTEXT];
+  }
+
+  componentDidMount() {
+    const { enableRefineOnMapMove } = this.props;
+    const { isRefineOnMapMove, toggleRefineOnMapMove } = this.getStateContext();
+
+    if (!enableRefineOnMapMove && isRefineOnMapMove) {
+      toggleRefineOnMapMove();
+    }
+  }
+
+  render() {
+    const { translate } = this.props;
+    const { instance } = this.getGoogleMapsContext();
+    const {
+      isRefineOnMapMove,
+      hasMapMoveSinceLastRefine,
+      toggleRefineOnMapMove,
+      refineWithInstance,
+    } = this.getStateContext();
+
+    return (
+      <div className={cx('control')}>
+        {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
+          <label className={cx('label')}>
+            <input
+              className={cx('input')}
+              type="checkbox"
+              checked={isRefineOnMapMove}
+              onChange={toggleRefineOnMapMove}
+            />
+            {translate('control')}
+          </label>
+        ) : (
+          <button
+            className={cx('redo')}
+            onClick={() => refineWithInstance(instance)}
+          >
+            {translate('redo')}
+          </button>
+        )}
+      </div>
+    );
+  }
+}
+
+export default translatable({
+  control: 'Search as I move the map',
+  redo: 'Redo search here',
+})(Control);

--- a/packages/react-instantsearch-dom-geo/src/CustomMarker.js
+++ b/packages/react-instantsearch-dom-geo/src/CustomMarker.js
@@ -1,0 +1,117 @@
+import { Component } from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import createHTMLMarker from './elements/createHTMLMarker';
+import { registerEvents, createListenersPropTypes } from './utils';
+import { GeolocHitPropType } from './propTypes';
+import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+
+const eventTypes = {
+  onClick: 'click',
+  onDoubleClick: 'dblclick',
+  onMouseDown: 'mousedown',
+  onMouseEnter: 'mouseenter',
+  onMouseLeave: 'mouseleave',
+  onMouseMove: 'mousemove',
+  onMouseOut: 'mouseout',
+  onMouseOver: 'mouseover',
+  onMouseUp: 'mouseup',
+};
+
+class CustomMarker extends Component {
+  static propTypes = {
+    ...createListenersPropTypes(eventTypes),
+    hit: GeolocHitPropType.isRequired,
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    anchor: PropTypes.shape({
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
+    }),
+  };
+
+  static contextTypes = {
+    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+      google: PropTypes.object,
+      instance: PropTypes.object,
+    }),
+  };
+
+  static defaultProps = {
+    className: '',
+    anchor: {
+      x: 0,
+      y: 0,
+    },
+  };
+
+  static isReact16() {
+    return typeof ReactDOM.createPortal === 'function';
+  }
+
+  state = {
+    marker: null,
+  };
+
+  componentDidMount() {
+    const { hit, className, anchor } = this.props;
+    const { google, instance } = this.context[GOOGLE_MAPS_CONTEXT];
+    // Not the best way to create the reference of the CustomMarker
+    // but since the Google object is required didn't find another
+    // solution. Ideas?
+    const Marker = createHTMLMarker(google);
+
+    const marker = new Marker({
+      map: instance,
+      position: hit._geoloc,
+      className,
+      anchor,
+    });
+
+    this.removeListeners = registerEvents(eventTypes, this.props, marker);
+
+    this.setState(() => ({
+      marker,
+    }));
+  }
+
+  componentDidUpdate() {
+    const { children } = this.props;
+    const { marker } = this.state;
+
+    this.removeListeners();
+
+    this.removeListeners = registerEvents(eventTypes, this.props, marker);
+
+    if (!CustomMarker.isReact16()) {
+      ReactDOM.unstable_renderSubtreeIntoContainer(
+        this,
+        children,
+        marker.element
+      );
+    }
+  }
+
+  componentWillUnmount() {
+    const { marker } = this.state;
+
+    if (!CustomMarker.isReact16()) {
+      ReactDOM.unmountComponentAtNode(marker.element);
+    }
+
+    marker.setMap(null);
+  }
+
+  render() {
+    const { children } = this.props;
+    const { marker } = this.state;
+
+    if (!marker || !CustomMarker.isReact16()) {
+      return null;
+    }
+
+    return ReactDOM.createPortal(children, marker.element);
+  }
+}
+
+export default CustomMarker;

--- a/packages/react-instantsearch-dom-geo/src/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/GeoSearch.js
@@ -39,7 +39,7 @@ class GeoSearch extends Component {
     };
   }
 
-  renderProviderChildren = ({ hits, currentRefinement, position }) => {
+  renderProviderChildren = ({ hits, currentRefinement, position, refine }) => {
     const {
       google,
       initialZoom,
@@ -63,6 +63,7 @@ class GeoSearch extends Component {
         mapOptions={mapOptions}
         boundingBox={boundingBox}
         position={position}
+        refine={refine}
       >
         {children({ hits })}
       </GoogleMaps>

--- a/packages/react-instantsearch-dom-geo/src/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/GeoSearch.js
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createClassNames } from 'react-instantsearch-dom';
 import { LatLngPropType } from './propTypes';
+import Connector from './Connector';
 import Provider from './Provider';
 import GoogleMaps from './GoogleMaps';
-
-const cx = createClassNames('GeoSearch');
 
 class GeoSearch extends Component {
   static propTypes = {
@@ -13,7 +11,6 @@ class GeoSearch extends Component {
     children: PropTypes.func.isRequired,
     initialZoom: PropTypes.number,
     initialPosition: LatLngPropType,
-    mapOptions: PropTypes.object,
   };
 
   static defaultProps = {
@@ -22,56 +19,57 @@ class GeoSearch extends Component {
       lat: 0,
       lng: 0,
     },
-    mapOptions: {},
   };
 
-  createBoundingBoxFromHits(hits) {
-    const { google } = this.props;
-
-    const latLngBounds = hits.reduce(
-      (acc, hit) => acc.extend(hit._geoloc),
-      new google.maps.LatLngBounds()
-    );
-
-    return {
-      northEast: latLngBounds.getNorthEast().toJSON(),
-      southWest: latLngBounds.getSouthWest().toJSON(),
-    };
-  }
-
-  renderProviderChildren = ({ hits, currentRefinement, position, refine }) => {
+  renderChildrenWithBoundFunction = ({ hits, position, ...rest }) => {
     const {
       google,
+      children,
       initialZoom,
       initialPosition,
-      mapOptions,
-      children,
+      ...mapOptions
     } = this.props;
 
-    const boundingBox =
-      !currentRefinement && Boolean(hits.length)
-        ? this.createBoundingBoxFromHits(hits)
-        : currentRefinement;
-
     return (
-      <GoogleMaps
-        testID="GoogleMaps"
-        cx={cx}
+      <Provider
+        {...rest}
+        testID="Provider"
         google={google}
-        initialZoom={initialZoom}
-        initialPosition={initialPosition}
-        mapOptions={mapOptions}
-        boundingBox={boundingBox}
+        hits={hits}
         position={position}
-        refine={refine}
       >
-        {children({ hits })}
-      </GoogleMaps>
+        {({
+          boundingBox,
+          boundingBoxPadding,
+          onChange,
+          onIdle,
+          shouldUpdate,
+        }) => (
+          <GoogleMaps
+            testID="GoogleMaps"
+            google={google}
+            initialZoom={initialZoom}
+            initialPosition={position || initialPosition}
+            mapOptions={mapOptions}
+            boundingBox={boundingBox}
+            boundingBoxPadding={boundingBoxPadding}
+            onChange={onChange}
+            onIdle={onIdle}
+            shouldUpdate={shouldUpdate}
+          >
+            {children({ hits })}
+          </GoogleMaps>
+        )}
+      </Provider>
     );
   };
 
   render() {
-    return <Provider testID="Provider">{this.renderProviderChildren}</Provider>;
+    return (
+      <Connector testID="Connector">
+        {this.renderChildrenWithBoundFunction}
+      </Connector>
+    );
   }
 }
 

--- a/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
@@ -89,6 +89,8 @@ class GoogleMaps extends Component {
           0
         );
       });
+
+      return;
     }
 
     if (!boundingBox) {
@@ -98,6 +100,8 @@ class GoogleMaps extends Component {
         this.instance.setZoom(initialZoom);
         this.instance.setCenter(initialMapPosition);
       });
+
+      return;
     }
   }
 

--- a/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
@@ -139,9 +139,9 @@ class GoogleMaps extends Component {
     );
   };
 
-  lockUserInteration(functionThatAlterTheMapPosition) {
+  lockUserInteration(functionThatAltersTheMapPosition) {
     this.isUserInteraction = false;
-    functionThatAlterTheMapPosition();
+    functionThatAltersTheMapPosition();
     this.isUserInteraction = true;
   }
 

--- a/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
@@ -62,10 +62,6 @@ class GoogleMaps extends Component {
       'idle',
       this.setupListenersWhenMapIsReady
     );
-
-    this.setState(() => ({
-      isMapReady: true,
-    }));
   }
 
   componentDidUpdate() {
@@ -109,6 +105,10 @@ class GoogleMaps extends Component {
 
   setupListenersWhenMapIsReady = () => {
     const { refine } = this.props;
+
+    this.setState(() => ({
+      isMapReady: true,
+    }));
 
     const onChange = () => {
       if (this.isUserInteraction) {

--- a/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
@@ -73,6 +73,12 @@ class GoogleMaps extends Component {
       position,
     } = this.props;
 
+    const { isMapReady } = this.state;
+
+    if (!isMapReady || this.isPendingRefine) {
+      return;
+    }
+
     if (boundingBox) {
       this.lockUserInteration(() => {
         this.instance.fitBounds(

--- a/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
@@ -57,10 +57,12 @@ class GoogleMaps extends Component {
       ...mapOptions,
     });
 
-    google.maps.event.addListenerOnce(
-      this.instance,
-      'idle',
-      this.setupListenersWhenMapIsReady
+    this.listeners.push(
+      google.maps.event.addListenerOnce(
+        this.instance,
+        'idle',
+        this.setupListenersWhenMapIsReady
+      )
     );
   }
 
@@ -114,6 +116,8 @@ class GoogleMaps extends Component {
   }
 
   setupListenersWhenMapIsReady = () => {
+    this.listeners = [];
+
     this.setState(() => ({
       isMapReady: true,
     }));

--- a/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
@@ -104,8 +104,6 @@ class GoogleMaps extends Component {
   }
 
   setupListenersWhenMapIsReady = () => {
-    const { refine } = this.props;
-
     this.setState(() => ({
       isMapReady: true,
     }));
@@ -125,12 +123,7 @@ class GoogleMaps extends Component {
         if (this.isUserInteraction && this.isPendingRefine) {
           this.isPendingRefine = false;
 
-          const bounds = this.instance.getBounds();
-
-          refine({
-            northEast: bounds.getNorthEast().toJSON(),
-            southWest: bounds.getSouthWest().toJSON(),
-          });
+          this.refineWithBoundingBox();
         }
       })
     );
@@ -140,6 +133,17 @@ class GoogleMaps extends Component {
     this.isUserInteraction = false;
     functionThatAlterTheMapPosition();
     this.isUserInteraction = true;
+  }
+
+  refineWithBoundingBox() {
+    const { refine } = this.props;
+
+    const bounds = this.instance.getBounds();
+
+    refine({
+      northEast: bounds.getNorthEast().toJSON(),
+      southWest: bounds.getSouthWest().toJSON(),
+    });
   }
 
   render() {

--- a/packages/react-instantsearch-dom-geo/src/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/Provider.js
@@ -7,6 +7,7 @@ export class Provider extends Component {
   static propTypes = {
     hits: PropTypes.arrayOf(PropTypes.object).isRequired,
     isRefinedWithMap: PropTypes.bool.isRequired,
+    refine: PropTypes.func.isRequired,
     children: PropTypes.func.isRequired,
     position: LatLngPropType,
     currentRefinement: BoundingBoxPropType,
@@ -18,6 +19,7 @@ export class Provider extends Component {
       isRefinedWithMap,
       position,
       currentRefinement,
+      refine,
       children,
     } = this.props;
 
@@ -26,6 +28,7 @@ export class Provider extends Component {
       isRefinedWithMap,
       position,
       currentRefinement,
+      refine,
     });
   }
 }

--- a/packages/react-instantsearch-dom-geo/src/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/Provider.js
@@ -1,36 +1,149 @@
+import { isEqual } from 'lodash';
 import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connectGeoSearch } from 'react-instantsearch-dom';
 import { LatLngPropType, BoundingBoxPropType } from './propTypes';
 
-export class Provider extends Component {
+export const STATE_CONTEXT = '__ais_geo_search__state__';
+
+class Provider extends Component {
   static propTypes = {
+    google: PropTypes.object.isRequired,
     hits: PropTypes.arrayOf(PropTypes.object).isRequired,
-    isRefinedWithMap: PropTypes.bool.isRequired,
+    isRefineOnMapMove: PropTypes.bool.isRequired,
+    hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
     refine: PropTypes.func.isRequired,
+    toggleRefineOnMapMove: PropTypes.func.isRequired,
+    setMapMoveSinceLastRefine: PropTypes.func.isRequired,
     children: PropTypes.func.isRequired,
     position: LatLngPropType,
     currentRefinement: BoundingBoxPropType,
   };
 
-  render() {
+  static childContextTypes = {
+    [STATE_CONTEXT]: PropTypes.shape({
+      isRefineOnMapMove: PropTypes.bool.isRequired,
+      hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
+      toggleRefineOnMapMove: PropTypes.func.isRequired,
+      setMapMoveSinceLastRefine: PropTypes.func.isRequired,
+      refineWithInstance: PropTypes.func.isRequired,
+    }).isRequired,
+  };
+
+  isPendingRefine = false;
+
+  getChildContext() {
     const {
-      hits,
-      isRefinedWithMap,
-      position,
-      currentRefinement,
-      refine,
-      children,
+      isRefineOnMapMove,
+      hasMapMoveSinceLastRefine,
+      toggleRefineOnMapMove,
+      setMapMoveSinceLastRefine,
     } = this.props;
 
-    return children({
-      hits,
-      isRefinedWithMap,
+    return {
+      [STATE_CONTEXT]: {
+        refineWithInstance: this.refineWithInstance,
+        toggleRefineOnMapMove,
+        setMapMoveSinceLastRefine,
+        isRefineOnMapMove,
+        hasMapMoveSinceLastRefine,
+      },
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    const {
+      position: previousPosition,
+      currentRefinement: previousCurrentRefinement,
+    } = prevProps;
+
+    const {
       position,
       currentRefinement,
-      refine,
+      setMapMoveSinceLastRefine,
+    } = this.props;
+
+    const positionChanged = !isEqual(previousPosition, position);
+    const currentRefinementChanged = !isEqual(
+      previousCurrentRefinement,
+      currentRefinement
+    );
+
+    if (positionChanged || currentRefinementChanged) {
+      setMapMoveSinceLastRefine(false);
+    }
+  }
+
+  createBoundingBoxFromHits(hits) {
+    const { google } = this.props;
+
+    const latLngBounds = hits.reduce(
+      (acc, hit) => acc.extend(hit._geoloc),
+      new google.maps.LatLngBounds()
+    );
+
+    return {
+      northEast: latLngBounds.getNorthEast().toJSON(),
+      southWest: latLngBounds.getSouthWest().toJSON(),
+    };
+  }
+
+  refineWithInstance = instance => {
+    const { refine } = this.props;
+
+    const bounds = instance.getBounds();
+
+    refine({
+      northEast: bounds.getNorthEast().toJSON(),
+      southWest: bounds.getSouthWest().toJSON(),
+    });
+  };
+
+  onChange = () => {
+    const { isRefineOnMapMove, setMapMoveSinceLastRefine } = this.props;
+
+    setMapMoveSinceLastRefine(true);
+
+    if (isRefineOnMapMove) {
+      this.isPendingRefine = true;
+    }
+  };
+
+  onIdle = ({ instance }) => {
+    if (this.isPendingRefine) {
+      this.isPendingRefine = false;
+
+      this.refineWithInstance(instance);
+    }
+  };
+
+  shouldUpdate = () => {
+    const { hasMapMoveSinceLastRefine } = this.props;
+
+    return !this.isPendingRefine && !hasMapMoveSinceLastRefine;
+  };
+
+  render() {
+    const { hits, currentRefinement, children } = this.props;
+
+    // We use this value for differentiate the padding to apply during
+    // fitBounds. When we don't have a currenRefinement (boundingBox)
+    // we let GoogleMaps compute the automatic padding. But when we
+    // provide the currentRefinement we explicitly set the padding
+    // to `0` otherwise the map will decrease the zoom on each refine.
+    const boundingBoxPadding = !currentRefinement ? undefined : 0;
+    const boundingBox =
+      !currentRefinement && Boolean(hits.length)
+        ? this.createBoundingBoxFromHits(hits)
+        : currentRefinement;
+
+    return children({
+      onChange: this.onChange,
+      onIdle: this.onIdle,
+      shouldUpdate: this.shouldUpdate,
+      boundingBox,
+      boundingBoxPadding,
     });
   }
 }
 
-export default connectGeoSearch(Provider);
+export default Provider;

--- a/packages/react-instantsearch-dom-geo/src/Redo.js
+++ b/packages/react-instantsearch-dom-geo/src/Redo.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { createClassNames, translatable } from 'react-instantsearch-dom';
+import { STATE_CONTEXT } from './Provider';
+import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+
+const cx = createClassNames('GeoSearch');
+
+export class Redo extends Component {
+  static propTypes = {
+    translate: PropTypes.func.isRequired,
+  };
+
+  static contextTypes = {
+    [STATE_CONTEXT]: PropTypes.shape({
+      isRefineOnMapMove: PropTypes.bool.isRequired,
+      toggleRefineOnMapMove: PropTypes.func.isRequired,
+      hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
+      refineWithInstance: PropTypes.func.isRequired,
+    }).isRequired,
+    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+      instance: PropTypes.object.isRequired,
+    }).isRequired,
+  };
+
+  getStateContext() {
+    return this.context[STATE_CONTEXT];
+  }
+
+  getGoogleMapsContext() {
+    return this.context[GOOGLE_MAPS_CONTEXT];
+  }
+
+  componentDidMount() {
+    const { isRefineOnMapMove, toggleRefineOnMapMove } = this.getStateContext();
+
+    if (isRefineOnMapMove) {
+      toggleRefineOnMapMove();
+    }
+  }
+
+  render() {
+    const { translate } = this.props;
+    const { instance } = this.getGoogleMapsContext();
+    const {
+      hasMapMoveSinceLastRefine,
+      refineWithInstance,
+    } = this.getStateContext();
+
+    return (
+      <div className={cx('control')}>
+        <button
+          className={cx('redo', !hasMapMoveSinceLastRefine && 'redo--disabled')}
+          disabled={!hasMapMoveSinceLastRefine}
+          onClick={() => refineWithInstance(instance)}
+        >
+          {translate('redo')}
+        </button>
+      </div>
+    );
+  }
+}
+
+export default translatable({
+  redo: 'Redo search here',
+})(Redo);

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Connector.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Connector.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { Connector } from '../Connector';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Connector', () => {
+  const defaultProps = {
+    hits: [],
+    position: null,
+    currentRefinement: null,
+    isRefinedWithMap: false,
+    refine: () => {},
+  };
+
+  const lastRenderArgs = fn => fn.mock.calls[fn.mock.calls.length - 1][0];
+
+  it('expect to call children with props', () => {
+    const children = jest.fn(x => x);
+
+    const props = {
+      ...defaultProps,
+    };
+
+    shallow(<Connector {...props}>{children}</Connector>);
+
+    expect(children).toHaveBeenCalledTimes(1);
+    expect(children).toHaveBeenCalledWith({
+      hits: [],
+      position: null,
+      currentRefinement: null,
+      isRefinedWithMap: false,
+      isRefineOnMapMove: true,
+      toggleRefineOnMapMove: expect.any(Function),
+      hasMapMoveSinceLastRefine: false,
+      setMapMoveSinceLastRefine: expect.any(Function),
+      refine: expect.any(Function),
+    });
+  });
+
+  describe('setMapMoveSinceLastRefine', () => {
+    it('expect to update the state with the given value', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Connector {...props}>{children}</Connector>);
+
+      lastRenderArgs(children).setMapMoveSinceLastRefine(true);
+
+      expect(wrapper.state().hasMapMoveSinceLastRefine).toBe(true);
+    });
+
+    it('expect to only update the state when the given is different', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(<Connector {...props}>{children}</Connector>);
+
+      expect(children).toHaveBeenCalledTimes(1);
+      expect(children).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hasMapMoveSinceLastRefine: false,
+        })
+      );
+
+      lastRenderArgs(children).setMapMoveSinceLastRefine(true);
+
+      expect(children).toHaveBeenCalledTimes(2);
+      expect(children).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hasMapMoveSinceLastRefine: true,
+        })
+      );
+
+      lastRenderArgs(children).setMapMoveSinceLastRefine(true);
+
+      expect(children).toHaveBeenCalledTimes(2);
+      expect(children).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hasMapMoveSinceLastRefine: true,
+        })
+      );
+    });
+  });
+
+  describe('toggleRefineOnMapMove', () => {
+    it('expect to update the state with the invert of previous value (true)', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Connector {...props}>{children}</Connector>);
+
+      expect(wrapper.state().isRefineOnMapMove).toBe(true);
+
+      lastRenderArgs(children).toggleRefineOnMapMove();
+
+      expect(wrapper.state().isRefineOnMapMove).toBe(false);
+    });
+
+    it('expect to update the state with the invert of previous value (false)', () => {
+      const children = jest.fn();
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Connector {...props}>{children}</Connector>);
+
+      wrapper.setState({
+        isRefineOnMapMove: false,
+      });
+
+      expect(wrapper.state().isRefineOnMapMove).toBe(false);
+
+      lastRenderArgs(children).toggleRefineOnMapMove();
+
+      expect(wrapper.state().isRefineOnMapMove).toBe(true);
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Control.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Control.js
@@ -1,0 +1,214 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { createFakeMapInstance } from '../../test/mockGoogleMaps';
+import { STATE_CONTEXT } from '../Provider';
+import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+import { Control } from '../Control';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Control', () => {
+  const defaultProps = {
+    enableRefineOnMapMove: true,
+    translate: x => x,
+  };
+
+  const defaultContext = {
+    [STATE_CONTEXT]: {
+      isRefineOnMapMove: true,
+      hasMapMoveSinceLastRefine: false,
+      toggleRefineOnMapMove: () => {},
+      refineWithInstance: () => {},
+    },
+    [GOOGLE_MAPS_CONTEXT]: {
+      instance: createFakeMapInstance(),
+    },
+  };
+
+  const getStateContext = context => context[STATE_CONTEXT];
+  const getGoogleMapsContext = context => context[GOOGLE_MAPS_CONTEXT];
+
+  it('expect to render correctly with refine on map move', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('input').props().checked).toBe(true);
+  });
+
+  it('expect to render correctly without refine on map move', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('input').props().checked).toBe(false);
+  });
+
+  it('expect to render correctly without refine on map move when the map has moved', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+        hasMapMoveSinceLastRefine: true,
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to disable refine on map move onDidMount', () => {
+    const props = {
+      ...defaultProps,
+      enableRefineOnMapMove: false,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      disableLifecycleMethods: true,
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.instance().componentDidMount();
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('expect to only disable refine on map move when previous value is true onDidMount', () => {
+    const props = {
+      ...defaultProps,
+      enableRefineOnMapMove: false,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      disableLifecycleMethods: true,
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.instance().componentDidMount();
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+  });
+
+  it('expect to call toggleRefineOnMapMove on input change', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.find('input').simulate('change');
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('expect to call refineWithInstance on button click', () => {
+    const instance = createFakeMapInstance();
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+        hasMapMoveSinceLastRefine: true,
+        refineWithInstance: jest.fn(),
+      },
+      [GOOGLE_MAPS_CONTEXT]: {
+        ...getGoogleMapsContext(defaultContext),
+        instance,
+      },
+    };
+
+    const wrapper = shallow(<Control {...props} />, {
+      context,
+    });
+
+    const { refineWithInstance } = getStateContext(context);
+
+    expect(refineWithInstance).toHaveBeenCalledTimes(0);
+
+    wrapper.find('button').simulate('click');
+
+    expect(refineWithInstance).toHaveBeenCalledTimes(1);
+    expect(refineWithInstance).toHaveBeenCalledWith(instance);
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/CustomMarker.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/CustomMarker.js
@@ -1,0 +1,646 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Enzyme, { mount, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {
+  createFakeGoogleReference,
+  createFakeMapInstance,
+  createFakeHTMLMarkerInstance,
+} from '../../test/mockGoogleMaps';
+import createHTMLMarker from '../elements/createHTMLMarker';
+import * as utils from '../utils';
+import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+import CustomMarker from '../CustomMarker';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+jest.mock('../elements/createHTMLMarker', () => jest.fn());
+
+jest.mock('../utils');
+
+describe('CustomMarker', () => {
+  const defaultProps = {
+    hit: {
+      _geoloc: {
+        lat: 10,
+        lng: 12,
+      },
+    },
+  };
+
+  beforeEach(() => {
+    utils.registerEvents.mockClear();
+    utils.registerEvents.mockReset();
+  });
+
+  describe('creation', () => {
+    it('expect to create the marker on didMount with default options', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(createHTMLMarker).toHaveBeenCalledWith(google);
+      expect(wrapper.state('marker')).toBe(marker);
+
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(factory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          map: mapInstance,
+          position: {
+            lat: 10,
+            lng: 12,
+          },
+        })
+      );
+    });
+
+    it('expect to create the marker on didMount with given options', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+        className: 'my-marker',
+        anchor: {
+          x: 10,
+          y: 10,
+        },
+      };
+
+      shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(factory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          className: 'my-marker',
+          anchor: {
+            x: 10,
+            y: 10,
+          },
+        })
+      );
+    });
+
+    it('expect to register the listeners on didMount', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(1);
+      expect(utils.registerEvents).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        marker
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('expect to remove the listeners on didUpdate', () => {
+      const removeEventListeners = jest.fn();
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => removeEventListeners);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(removeEventListeners).toHaveBeenCalledTimes(0);
+
+      // Simulate the update
+      wrapper.instance().componentDidUpdate();
+
+      expect(removeEventListeners).toHaveBeenCalledTimes(1);
+    });
+
+    it('expect to register the listeners on didUpdate', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(1);
+
+      // Simulate the update
+      wrapper.instance().componentDidUpdate();
+
+      expect(utils.registerEvents).toHaveBeenCalledTimes(2);
+      expect(utils.registerEvents).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        marker
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('expect to remove the Marker on willUnmount', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      wrapper.unmount();
+
+      expect(marker.setMap).toHaveBeenCalledTimes(1);
+      expect(marker.setMap).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('with portal', () => {
+    it('expect to render correctly', () => {
+      const unstableRenderSubtreeIntoContainer = jest.spyOn(
+        ReactDOM,
+        'unstable_renderSubtreeIntoContainer'
+      );
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      // Use `mount` instead of `shallow` to trigger the render
+      // of createPortal otherwise the Snapshot is empty
+      const wrapper = mount(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(wrapper).toMatchSnapshot();
+
+      expect(unstableRenderSubtreeIntoContainer).not.toHaveBeenCalled();
+
+      unstableRenderSubtreeIntoContainer.mockReset();
+      unstableRenderSubtreeIntoContainer.mockRestore();
+    });
+
+    it('expect to render correctly without a marker', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          disableLifecycleMethods: true,
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(wrapper.type()).toBe(null);
+    });
+
+    it('expect to not render on didUpdate', () => {
+      const unstableRenderSubtreeIntoContainer = jest.spyOn(
+        ReactDOM,
+        'unstable_renderSubtreeIntoContainer'
+      );
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      // Use `mount` instead of `shallow` to trigger didUpdate
+      const wrapper = mount(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(unstableRenderSubtreeIntoContainer).not.toHaveBeenCalled();
+
+      wrapper.instance().componentDidUpdate();
+
+      expect(unstableRenderSubtreeIntoContainer).not.toHaveBeenCalled();
+
+      unstableRenderSubtreeIntoContainer.mockReset();
+      unstableRenderSubtreeIntoContainer.mockRestore();
+    });
+
+    it('expect to not call unmountComponentAtNode on willUnmount', () => {
+      const unmountComponentAtNode = jest.spyOn(
+        ReactDOM,
+        'unmountComponentAtNode'
+      );
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      wrapper.unmount();
+
+      expect(unmountComponentAtNode).not.toHaveBeenCalled();
+
+      unmountComponentAtNode.mockReset();
+      unmountComponentAtNode.mockRestore();
+    });
+  });
+
+  describe('with unstable_renderSubtreeIntoContainer', () => {
+    it('expect to render correctly', () => {
+      const unstableRenderSubtreeIntoContainer = jest.spyOn(
+        ReactDOM,
+        'unstable_renderSubtreeIntoContainer'
+      );
+
+      const isReact16 = jest
+        .spyOn(CustomMarker, 'isReact16')
+        .mockImplementation(() => false);
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = mount(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(wrapper).toMatchSnapshot();
+
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledTimes(1);
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledWith(
+        wrapper.instance(),
+        <span>This is the children.</span>,
+        marker.element
+      );
+
+      unstableRenderSubtreeIntoContainer.mockReset();
+      unstableRenderSubtreeIntoContainer.mockRestore();
+
+      isReact16.mockReset();
+      isReact16.mockRestore();
+    });
+
+    it('expect to render correctly without a marker', () => {
+      const isReact16 = jest
+        .spyOn(CustomMarker, 'isReact16')
+        .mockImplementation(() => false);
+
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          disableLifecycleMethods: true,
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(wrapper.type()).toBe(null);
+
+      isReact16.mockReset();
+      isReact16.mockRestore();
+    });
+
+    it('expect to render on didUpdate', () => {
+      const unstableRenderSubtreeIntoContainer = jest.spyOn(
+        ReactDOM,
+        'unstable_renderSubtreeIntoContainer'
+      );
+
+      const isReact16 = jest
+        .spyOn(CustomMarker, 'isReact16')
+        .mockImplementation(() => false);
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      utils.registerEvents.mockImplementation(() => () => {});
+
+      const props = {
+        ...defaultProps,
+      };
+
+      // Use `mount` instead of `shallow` to trigger didUpdate
+      const wrapper = mount(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledTimes(1);
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledWith(
+        wrapper.instance(),
+        <span>This is the children.</span>,
+        marker.element
+      );
+
+      wrapper.instance().componentDidUpdate();
+
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledTimes(2);
+      expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledWith(
+        wrapper.instance(),
+        <span>This is the children.</span>,
+        marker.element
+      );
+
+      unstableRenderSubtreeIntoContainer.mockReset();
+      unstableRenderSubtreeIntoContainer.mockRestore();
+
+      isReact16.mockReset();
+      isReact16.mockRestore();
+    });
+
+    it('expect to call unmountComponentAtNode on willUnmount', () => {
+      const unmountComponentAtNode = jest.spyOn(
+        ReactDOM,
+        'unmountComponentAtNode'
+      );
+
+      const isReact16 = jest
+        .spyOn(CustomMarker, 'isReact16')
+        .mockImplementation(() => false);
+
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(
+        <CustomMarker {...props}>
+          <span>This is the children.</span>
+        </CustomMarker>,
+        {
+          context: {
+            [GOOGLE_MAPS_CONTEXT]: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      wrapper.unmount();
+
+      expect(unmountComponentAtNode).toHaveBeenCalledTimes(1);
+      expect(unmountComponentAtNode).toHaveBeenCalledWith(marker.element);
+
+      unmountComponentAtNode.mockReset();
+      unmountComponentAtNode.mockRestore();
+
+      isReact16.mockReset();
+      isReact16.mockRestore();
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
@@ -15,6 +15,7 @@ describe('GeoSearch', () => {
 
   const defaultRenderProvidedProps = {
     hits: [],
+    refine: () => {},
   };
 
   const renderProps = ({ props, renderProvidedProps, children = () => null }) =>

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
@@ -13,191 +13,344 @@ describe('GeoSearch', () => {
     google: createFakeGoogleReference(),
   };
 
-  const defaultRenderProvidedProps = {
+  const defaultConnectorProps = {
     hits: [],
+    isRefineOnMapMove: true,
+    hasMapMoveSinceLastRefine: false,
     refine: () => {},
+    toggleRefineOnMapMove: () => {},
+    setMapMoveSinceLastRefine: () => {},
   };
 
-  const renderProps = ({ props, renderProvidedProps, children = () => null }) =>
+  const renderConnector = ({ props, connectorProps, children = () => null }) =>
     shallow(<GeoSearch {...props}>{children}</GeoSearch>)
-      .find('[testID="Provider"]')
+      .find('[testID="Connector"]')
       .props()
-      .children(renderProvidedProps);
+      .children(connectorProps);
 
-  it('expect to render', () => {
-    const children = jest.fn(() => <div>Hello this is the children</div>);
+  describe('Provider', () => {
+    it('expect to render', () => {
+      const props = {
+        ...defaultProps,
+      };
 
-    const props = {
-      ...defaultProps,
-    };
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
 
-    const renderProvidedProps = {
-      ...defaultRenderProvidedProps,
-    };
+      const renderPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
 
-    const renderPropsWrapper = shallow(
-      <ShallowWapper>
-        {renderProps({ props, renderProvidedProps, children })}
-      </ShallowWapper>
-    );
-
-    expect(renderPropsWrapper).toMatchSnapshot();
-    expect(children).toHaveBeenCalledTimes(1);
-    expect(children).toHaveBeenCalledWith({
-      hits: [],
+      expect(renderPropsWrapper).toMatchSnapshot();
     });
-  });
 
-  it('expect to render with initialZoom & initialPosition', () => {
-    const props = {
-      ...defaultProps,
-      initialZoom: 8,
-      initialPosition: {
+    it('expect to render with hits', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+        hits: [
+          { objectID: '0001' },
+          { objectID: '0002' },
+          { objectID: '0003' },
+        ],
+      };
+
+      const renderPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerProps = renderPropsWrapper
+        .find('[testID="Provider"]')
+        .props();
+
+      expect(providerProps.hits).toEqual([
+        { objectID: '0001' },
+        { objectID: '0002' },
+        { objectID: '0003' },
+      ]);
+    });
+
+    it('expect to render with position', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+        position: {
+          lat: 10,
+          lng: 12,
+        },
+      };
+
+      const renderConnectorWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerProps = renderConnectorWrapper
+        .find('[testID="Provider"]')
+        .props();
+
+      expect(providerProps.position).toEqual({
         lat: 10,
         lng: 12,
-      },
-    };
+      });
+    });
 
-    const renderProvidedProps = {
-      ...defaultRenderProvidedProps,
-    };
+    it('expect to render with currentRefinement', () => {
+      const props = {
+        ...defaultProps,
+      };
 
-    const renderPropsWrapper = shallow(
-      <ShallowWapper>
-        {renderProps({ props, renderProvidedProps })}
-      </ShallowWapper>
-    );
+      const connectorProps = {
+        ...defaultConnectorProps,
+        currentRefinement: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
 
-    const googleMapProps = renderPropsWrapper
-      .find('[testID="GoogleMaps"]')
-      .props();
+      const renderConnectorWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
 
-    expect(googleMapProps.initialZoom).toBe(8);
-    expect(googleMapProps.initialPosition).toEqual({
-      lat: 10,
-      lng: 12,
+      const providerProps = renderConnectorWrapper
+        .find('[testID="Provider"]')
+        .props();
+
+      expect(providerProps.currentRefinement).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
     });
   });
 
-  it('expect to render with mapOptions', () => {
-    const props = {
-      ...defaultProps,
-      mapOptions: {
+  describe('GoogleMaps', () => {
+    const defaultProviderProps = {
+      onChange: () => {},
+      onIdle: () => {},
+      shouldUpdate: () => true,
+    };
+
+    const renderProvider = ({ connectorPropsWrapper, providerProps }) =>
+      connectorPropsWrapper
+        .find('[testID="Provider"]')
+        .props()
+        .children(providerProps);
+
+    it('expect to render', () => {
+      const children = jest.fn(() => <div>Hello this is the children</div>);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps, children })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      expect(providerPropsWrapper).toMatchSnapshot();
+      expect(children).toHaveBeenCalledWith({ hits: [] });
+    });
+
+    it('expect to render with initialZoom', () => {
+      const props = {
+        ...defaultProps,
+        initialZoom: 8,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
+        .find('[testID="GoogleMaps"]')
+        .props();
+
+      expect(googleMapProps.initialZoom).toBe(8);
+    });
+
+    it('expect to render with postiion', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+        position: {
+          lat: 10,
+          lng: 12,
+        },
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
+        .find('[testID="GoogleMaps"]')
+        .props();
+
+      expect(googleMapProps.initialPosition).toEqual({
+        lat: 10,
+        lng: 12,
+      });
+    });
+
+    it('expect to render with initialPosition', () => {
+      const props = {
+        ...defaultProps,
+        initialPosition: {
+          lat: 10,
+          lng: 12,
+        },
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
+        .find('[testID="GoogleMaps"]')
+        .props();
+
+      expect(googleMapProps.initialPosition).toEqual({
+        lat: 10,
+        lng: 12,
+      });
+    });
+
+    it('expect to render with map options', () => {
+      const props = {
+        ...defaultProps,
         streetViewControl: true,
-      },
-    };
-
-    const renderProvidedProps = {
-      ...defaultRenderProvidedProps,
-    };
-
-    const renderPropsWrapper = shallow(
-      <ShallowWapper>
-        {renderProps({ props, renderProvidedProps })}
-      </ShallowWapper>
-    );
-
-    const googleMapProps = renderPropsWrapper
-      .find('[testID="GoogleMaps"]')
-      .props();
-
-    expect(googleMapProps.mapOptions).toEqual({
-      streetViewControl: true,
-    });
-  });
-
-  it('expect to render with position', () => {
-    const props = {
-      ...defaultProps,
-    };
-
-    const renderProvidedProps = {
-      ...defaultRenderProvidedProps,
-      position: {
-        lat: 10,
-        lng: 12,
-      },
-    };
-
-    const renderPropsWrapper = shallow(
-      <ShallowWapper>
-        {renderProps({ props, renderProvidedProps })}
-      </ShallowWapper>
-    );
-
-    const googleMapProps = renderPropsWrapper
-      .find('[testID="GoogleMaps"]')
-      .props();
-
-    expect(googleMapProps.position).toEqual({
-      lat: 10,
-      lng: 12,
-    });
-  });
-
-  describe('boundingBox', () => {
-    it('expect to use hits when currentRefinement is not defined and hits are not empty', () => {
-      const google = createFakeGoogleReference();
-
-      google.maps.LatLngBounds.mockImplementation(() => ({
-        extend: jest.fn().mockReturnThis(),
-        getNorthEast: () => ({
-          toJSON: () => ({
-            lat: 10,
-            lng: 10,
-          }),
-        }),
-        getSouthWest: () => ({
-          toJSON: () => ({
-            lat: 14,
-            lng: 14,
-          }),
-        }),
-      }));
-
-      const props = {
-        ...defaultProps,
-        google,
       };
 
-      const renderProvidedProps = {
-        ...defaultRenderProvidedProps,
-        hits: [
-          { _geoloc: { lat: 10, lng: 12 } },
-          { _geoloc: { lat: 12, lng: 14 } },
-        ],
+      const connectorProps = {
+        ...defaultConnectorProps,
       };
 
-      const renderPropsWrapper = shallow(
+      const providerProps = {
+        ...defaultProviderProps,
+      };
+
+      const connectorPropsWrapper = shallow(
         <ShallowWapper>
-          {renderProps({ props, renderProvidedProps })}
+          {renderConnector({ props, connectorProps })}
         </ShallowWapper>
       );
 
-      const googleMapProps = renderPropsWrapper
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
         .find('[testID="GoogleMaps"]')
         .props();
 
-      expect(googleMapProps.boundingBox).toEqual({
-        northEast: {
-          lat: 10,
-          lng: 10,
-        },
-        southWest: {
-          lat: 14,
-          lng: 14,
-        },
+      expect(googleMapProps.mapOptions).toEqual({
+        streetViewControl: true,
       });
     });
 
-    it("expect to use currentRefinement when it's defined and hits are empty", () => {
+    it('expect to render with boundingBox', () => {
       const props = {
         ...defaultProps,
       };
 
-      const renderProvidedProps = {
-        ...defaultRenderProvidedProps,
-        currentRefinement: {
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const providerProps = {
+        ...defaultProviderProps,
+        boundingBox: {
           northEast: {
             lat: 10,
             lng: 12,
@@ -209,13 +362,19 @@ describe('GeoSearch', () => {
         },
       };
 
-      const renderPropsWrapper = shallow(
+      const connectorPropsWrapper = shallow(
         <ShallowWapper>
-          {renderProps({ props, renderProvidedProps })}
+          {renderConnector({ props, connectorProps })}
         </ShallowWapper>
       );
 
-      const googleMapProps = renderPropsWrapper
+      const providerPropsWrapper = shallow(
+        <ShallowWapper>
+          {renderProvider({ connectorPropsWrapper, providerProps })}
+        </ShallowWapper>
+      );
+
+      const googleMapProps = providerPropsWrapper
         .find('[testID="GoogleMaps"]')
         .props();
 
@@ -231,71 +390,37 @@ describe('GeoSearch', () => {
       });
     });
 
-    it("expect to use currentRefinement when it's defined and hits are not empty", () => {
+    it('expect to render with boundingBoxPadding', () => {
       const props = {
         ...defaultProps,
       };
 
-      const renderProvidedProps = {
-        ...defaultRenderProvidedProps,
-        hits: [
-          { _geoloc: { lat: 10, lng: 12 } },
-          { _geoloc: { lat: 12, lng: 14 } },
-        ],
-        currentRefinement: {
-          northEast: {
-            lat: 10,
-            lng: 12,
-          },
-          southWest: {
-            lat: 12,
-            lng: 14,
-          },
-        },
+      const connectorProps = {
+        ...defaultConnectorProps,
       };
 
-      const renderPropsWrapper = shallow(
+      const providerProps = {
+        ...defaultProviderProps,
+        boundingBoxPadding: 10,
+      };
+
+      const connectorPropsWrapper = shallow(
         <ShallowWapper>
-          {renderProps({ props, renderProvidedProps })}
+          {renderConnector({ props, connectorProps })}
         </ShallowWapper>
       );
 
-      const googleMapProps = renderPropsWrapper
-        .find('[testID="GoogleMaps"]')
-        .props();
-
-      expect(googleMapProps.boundingBox).toEqual({
-        northEast: {
-          lat: 10,
-          lng: 12,
-        },
-        southWest: {
-          lat: 12,
-          lng: 14,
-        },
-      });
-    });
-
-    it("expect to use currentRefinement when it's not defined and hits are empty", () => {
-      const props = {
-        ...defaultProps,
-      };
-
-      const renderProvidedProps = {
-        ...defaultRenderProvidedProps,
-      };
-
-      const renderPropsWrapper = shallow(
+      const providerPropsWrapper = shallow(
         <ShallowWapper>
-          {renderProps({ props, renderProvidedProps })}
+          {renderProvider({ connectorPropsWrapper, providerProps })}
         </ShallowWapper>
       );
 
-      const googleMapProps = renderPropsWrapper
+      const googleMapProps = providerPropsWrapper
         .find('[testID="GoogleMaps"]')
         .props();
 
-      expect(googleMapProps.boundingBox).toBe(undefined);
+      expect(googleMapProps.boundingBoxPadding).toBe(10);
     });
   });
 });

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
@@ -407,6 +407,8 @@ describe('GoogleMaps', () => {
         </GoogleMaps>
       );
 
+      simulateMapReadyEvent(google);
+
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
 
       expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
@@ -466,6 +468,8 @@ describe('GoogleMaps', () => {
         </GoogleMaps>
       );
 
+      simulateMapReadyEvent(google);
+
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
 
       expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
@@ -480,6 +484,69 @@ describe('GoogleMaps', () => {
         lat: 0,
         lng: 0,
       });
+    });
+
+    it('expect to prevent the update when the map is not ready', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(
+        <GoogleMaps {...props}>
+          <div>This is the children</div>
+        </GoogleMaps>
+      );
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps();
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+    });
+
+    it('expect to prevent the update when there is a pending refinement', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(
+        <GoogleMaps {...props}>
+          <div>This is the children</div>
+        </GoogleMaps>
+      );
+
+      simulateMapReadyEvent(google);
+      simulateEvent(mapInstance, 'center_changed');
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps();
+
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
@@ -158,6 +158,22 @@ describe('GoogleMaps', () => {
         expect.any(Function)
       );
 
+      expect(wrapper.instance().listeners).toHaveLength(1);
+    });
+
+    it('expect to setup the rest of the listener when the map is ready', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        google,
+      };
+
+      const wrapper = shallow(<GoogleMaps {...props} />);
+
       simulateMapReadyEvent(google);
 
       expect(mapInstance.addListener).toHaveBeenCalledWith(

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
@@ -53,8 +53,11 @@ describe('GoogleMaps', () => {
   });
 
   it('expect render correctly with the map rendered', () => {
+    const google = createFakeGoogleReference();
+
     const props = {
       ...defaultProps,
+      google,
     };
 
     const wrapper = shallow(
@@ -73,6 +76,8 @@ describe('GoogleMaps', () => {
 
     // Simulate didMount
     wrapper.instance().componentDidMount();
+
+    simulateMapReadyEvent(google);
 
     // Trigger the update
     wrapper.update();

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
@@ -11,6 +11,7 @@ describe('Provider', () => {
     position: null,
     currentRefinement: null,
     isRefinedWithMap: false,
+    refine: () => {},
   };
 
   it('expect to call children with props', () => {
@@ -28,6 +29,7 @@ describe('Provider', () => {
       position: null,
       currentRefinement: null,
       isRefinedWithMap: false,
+      refine: expect.any(Function),
     });
   });
 });

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
@@ -1,20 +1,30 @@
 import React from 'react';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { Provider } from '../Provider';
+import {
+  createFakeGoogleReference,
+  createFakeMapInstance,
+} from '../../test/mockGoogleMaps';
+import Provider, { STATE_CONTEXT } from '../Provider';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('Provider', () => {
   const defaultProps = {
+    google: createFakeGoogleReference(),
     hits: [],
-    position: null,
-    currentRefinement: null,
-    isRefinedWithMap: false,
+    initialPosition: { lat: 0, lng: 0 },
+    isRefineOnMapMove: true,
+    hasMapMoveSinceLastRefine: false,
     refine: () => {},
+    toggleRefineOnMapMove: () => {},
+    setMapMoveSinceLastRefine: () => {},
+    children: () => {},
   };
 
-  it('expect to call children with props', () => {
+  const lastRenderArgs = fn => fn.mock.calls[fn.mock.calls.length - 1][0];
+
+  it('expect to render with default props', () => {
     const children = jest.fn(x => x);
 
     const props = {
@@ -25,11 +35,467 @@ describe('Provider', () => {
 
     expect(children).toHaveBeenCalledTimes(1);
     expect(children).toHaveBeenCalledWith({
-      hits: [],
-      position: null,
-      currentRefinement: null,
-      isRefinedWithMap: false,
-      refine: expect.any(Function),
+      boundingBox: undefined,
+      boundingBoxPadding: undefined,
+      onChange: expect.any(Function),
+      onIdle: expect.any(Function),
+      shouldUpdate: expect.any(Function),
+    });
+  });
+
+  describe('didUpdate', () => {
+    it('expect to call setMapMoveSinceLastRefine when position change', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        position: { lat: 10, lng: 12 },
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps({
+        position: { lat: 12, lng: 14 },
+      });
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(1);
+      expect(props.setMapMoveSinceLastRefine).toBeCalledWith(false);
+    });
+
+    it('expect to call setMapMoveSinceLastRefine when currentRefinement change', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        currentRefinement: {
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        },
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps({
+        currentRefinement: {
+          northEast: { lat: 12, lng: 14 },
+          southWest: { lat: 14, lng: 16 },
+        },
+      });
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(1);
+      expect(props.setMapMoveSinceLastRefine).toBeCalledWith(false);
+    });
+
+    it('expect to not call setMapMoveSinceLastRefine when nothing change', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(props.setMapMoveSinceLastRefine).not.toHaveBeenCalled();
+
+      wrapper.setProps();
+
+      expect(props.setMapMoveSinceLastRefine).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('boundingBox', () => {
+    it('expect to use hits when currentRefinement is not defined and hits are not empty', () => {
+      const children = jest.fn(x => x);
+      const google = createFakeGoogleReference();
+
+      google.maps.LatLngBounds.mockImplementation(() => ({
+        extend: jest.fn().mockReturnThis(),
+        getNorthEast: () => ({
+          toJSON: () => ({
+            lat: 10,
+            lng: 10,
+          }),
+        }),
+        getSouthWest: () => ({
+          toJSON: () => ({
+            lat: 14,
+            lng: 14,
+          }),
+        }),
+      }));
+
+      const props = {
+        ...defaultProps,
+        hits: [
+          { _geoloc: { lat: 10, lng: 12 } },
+          { _geoloc: { lat: 12, lng: 14 } },
+        ],
+        google,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(lastRenderArgs(children).boundingBox).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 10,
+        },
+        southWest: {
+          lat: 14,
+          lng: 14,
+        },
+      });
+    });
+
+    it("expect to use currentRefinement when it's defined and hits are empty", () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        currentRefinement: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(lastRenderArgs(children).boundingBox).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+    });
+
+    it("expect to use currentRefinement when it's defined and hits are not empty", () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        hits: [
+          { _geoloc: { lat: 10, lng: 12 } },
+          { _geoloc: { lat: 12, lng: 14 } },
+        ],
+        currentRefinement: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(lastRenderArgs(children).boundingBox).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+    });
+
+    it("expect to use currentRefinement when it's not defined and hits are empty", () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(lastRenderArgs(children).boundingBox).toBe(undefined);
+    });
+  });
+
+  describe('onChange', () => {
+    it('expect to call setMapMoveSinceLast refine', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(0);
+
+      lastRenderArgs(children).onChange();
+
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledTimes(1);
+      expect(props.setMapMoveSinceLastRefine).toHaveBeenCalledWith(true);
+    });
+
+    it('expect to schedule a refine call when refine on map move is enabled', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+
+      lastRenderArgs(children).onChange();
+
+      expect(wrapper.instance().isPendingRefine).toBe(true);
+    });
+
+    it('expect to not schedule a refine call when refine on map move is disabled', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        isRefineOnMapMove: false,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+
+      lastRenderArgs(children).onChange();
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+    });
+  });
+
+  describe('onIdle', () => {
+    it('expect to call refine when there is a pending refinement', () => {
+      const mapInstance = createFakeMapInstance();
+      const children = jest.fn(x => x);
+
+      mapInstance.getBounds.mockImplementation(() => ({
+        getNorthEast: () => ({
+          toJSON: () => ({
+            lat: 10,
+            lng: 12,
+          }),
+        }),
+        getSouthWest: () => ({
+          toJSON: () => ({
+            lat: 12,
+            lng: 14,
+          }),
+        }),
+      }));
+
+      const props = {
+        ...defaultProps,
+        refine: jest.fn(),
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      lastRenderArgs(children).onChange();
+      lastRenderArgs(children).onIdle({ instance: mapInstance });
+
+      expect(props.refine).toHaveBeenCalledTimes(1);
+      expect(props.refine).toHaveBeenCalledWith({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+    });
+
+    it('expect to reset the pending refinement when there is a pending refinement', () => {
+      const mapInstance = createFakeMapInstance();
+      const children = jest.fn(x => x);
+
+      mapInstance.getBounds.mockImplementation(() => ({
+        getNorthEast: () => ({
+          toJSON: () => {},
+        }),
+        getSouthWest: () => ({
+          toJSON: () => {},
+        }),
+      }));
+
+      const props = {
+        ...defaultProps,
+        refine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      lastRenderArgs(children).onChange();
+
+      expect(wrapper.instance().isPendingRefine).toBe(true);
+
+      lastRenderArgs(children).onIdle({ instance: mapInstance });
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+    });
+
+    it('expect to be a noop when there is no pending refinement', () => {
+      const mapInstance = createFakeMapInstance();
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        refine: jest.fn(),
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+
+      lastRenderArgs(children).onIdle({ instance: mapInstance });
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+      expect(props.refine).not.toHaveBeenCalled();
+      expect(props.setMapMoveSinceLastRefine).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('shouldUpdate', () => {
+    it('expect to return true when there is no pending refinement and the map has not moved', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      const actual = lastRenderArgs(children).shouldUpdate();
+
+      expect(actual).toBe(true);
+    });
+
+    it('expect to return false when there is a pending refinement', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      lastRenderArgs(children).onChange();
+
+      const actual = lastRenderArgs(children).shouldUpdate();
+
+      expect(actual).toBe(false);
+    });
+
+    it('expect to return false when the map has moved', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        hasMapMoveSinceLastRefine: true,
+      };
+
+      shallow(<Provider {...props}>{children}</Provider>);
+
+      const actual = lastRenderArgs(children).shouldUpdate();
+
+      expect(actual).toBe(false);
+    });
+  });
+
+  describe('context', () => {
+    it('expect to expose isRefineOnMapMove', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          isRefineOnMapMove: true,
+        }),
+      });
+    });
+
+    it('expect to expose hasMapMoveSinceLastRefine', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          hasMapMoveSinceLastRefine: false,
+        }),
+      });
+    });
+
+    it('expect to expose toggleRefineOnMapMove', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          toggleRefineOnMapMove: props.toggleRefineOnMapMove,
+        }),
+      });
+    });
+
+    it('expect to expose setMapMoveSinceLastRefine', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          setMapMoveSinceLastRefine: props.setMapMoveSinceLastRefine,
+        }),
+      });
+    });
+
+    it('expect to expose refineWithInstance', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{x => x}</Provider>);
+
+      expect(wrapper.instance().getChildContext()).toEqual({
+        [STATE_CONTEXT]: expect.objectContaining({
+          refineWithInstance: wrapper.instance().refineWithInstance,
+        }),
+      });
     });
   });
 });

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Redo.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Redo.js
@@ -1,0 +1,160 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { createFakeMapInstance } from '../../test/mockGoogleMaps';
+import { STATE_CONTEXT } from '../Provider';
+import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+import { Redo } from '../Redo';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Redo', () => {
+  const defaultProps = {
+    translate: x => x,
+  };
+
+  const defaultContext = {
+    [STATE_CONTEXT]: {
+      isRefineOnMapMove: true,
+      hasMapMoveSinceLastRefine: false,
+      toggleRefineOnMapMove: () => {},
+      refineWithInstance: () => {},
+    },
+    [GOOGLE_MAPS_CONTEXT]: {
+      instance: createFakeMapInstance(),
+    },
+  };
+
+  const getStateContext = context => context[STATE_CONTEXT];
+  const getGoogleMapsContext = context => context[GOOGLE_MAPS_CONTEXT];
+
+  it('expect to render correctly', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      context,
+    });
+
+    expect(wrapper.find('button').prop('disabled')).toBe(true);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to render correctly when map has moved', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        hasMapMoveSinceLastRefine: true,
+      },
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      context,
+    });
+
+    expect(wrapper.find('button').prop('disabled')).toBe(false);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to disable refine on map move onDidMount', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      disableLifecycleMethods: true,
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.instance().componentDidMount();
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('expect to only disable refine on map move when value is true onDidMount', () => {
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        isRefineOnMapMove: false,
+        toggleRefineOnMapMove: jest.fn(),
+      },
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      disableLifecycleMethods: true,
+      context,
+    });
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+
+    wrapper.instance().componentDidMount();
+
+    expect(
+      getStateContext(context).toggleRefineOnMapMove
+    ).toHaveBeenCalledTimes(0);
+  });
+
+  it('expect to call refineWithInstance on button click', () => {
+    const instance = createFakeMapInstance();
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const context = {
+      ...defaultContext,
+      [STATE_CONTEXT]: {
+        ...getStateContext(defaultContext),
+        refineWithInstance: jest.fn(),
+      },
+      [GOOGLE_MAPS_CONTEXT]: {
+        ...getGoogleMapsContext(defaultContext),
+        instance,
+      },
+    };
+
+    const wrapper = shallow(<Redo {...props} />, {
+      context,
+    });
+
+    const { refineWithInstance } = getStateContext(context);
+
+    expect(refineWithInstance).toHaveBeenCalledTimes(0);
+
+    wrapper.find('button').simulate('click');
+
+    expect(refineWithInstance).toHaveBeenCalledTimes(1);
+    expect(refineWithInstance).toHaveBeenCalledWith(instance);
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/Control.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/Control.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Control expect to render correctly with refine on map move 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <label
+    className="ais-GeoSearch-label"
+  >
+    <input
+      checked={true}
+      className="ais-GeoSearch-input"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    control
+  </label>
+</div>
+`;
+
+exports[`Control expect to render correctly without refine on map move 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <label
+    className="ais-GeoSearch-label"
+  >
+    <input
+      checked={false}
+      className="ais-GeoSearch-input"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    control
+  </label>
+</div>
+`;
+
+exports[`Control expect to render correctly without refine on map move when the map has moved 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <button
+    className="ais-GeoSearch-redo"
+    onClick={[Function]}
+  >
+    redo
+  </button>
+</div>
+`;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/CustomMarker.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/CustomMarker.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomMarker with portal expect to render correctly 1`] = `
+<CustomMarker
+  anchor={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  className=""
+  hit={
+    Object {
+      "_geoloc": Object {
+        "lat": 10,
+        "lng": 12,
+      },
+    }
+  }
+>
+  <span>
+    This is the children.
+  </span>
+</CustomMarker>
+`;
+
+exports[`CustomMarker with unstable_renderSubtreeIntoContainer expect to render correctly 1`] = `
+<CustomMarker
+  anchor={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  className=""
+  hit={
+    Object {
+      "_geoloc": Object {
+        "lat": 10,
+        "lng": 12,
+      },
+    }
+  }
+/>
+`;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
@@ -32,6 +32,7 @@ exports[`GeoSearch expect to render 1`] = `
   }
   initialZoom={1}
   mapOptions={Object {}}
+  refine={[Function]}
   testID="GoogleMaps"
 >
   <div>

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GeoSearch expect to render 1`] = `
+exports[`GeoSearch GoogleMaps expect to render 1`] = `
 <GoogleMaps
-  cx={[Function]}
   google={
     Object {
       "maps": Object {
@@ -13,11 +12,7 @@ exports[`GeoSearch expect to render 1`] = `
         "LatLngBounds": [MockFunction],
         "Map": [MockFunction],
         "Marker": [MockFunction],
-        "OverlayView": Object {
-          "getPanes": [MockFunction],
-          "getProjection": [MockFunction],
-          "setMap": [MockFunction],
-        },
+        "OverlayView": [Function],
         "event": Object {
           "addListenerOnce": [MockFunction],
         },
@@ -32,11 +27,42 @@ exports[`GeoSearch expect to render 1`] = `
   }
   initialZoom={1}
   mapOptions={Object {}}
-  refine={[Function]}
+  onChange={[Function]}
+  onIdle={[Function]}
+  shouldUpdate={[Function]}
   testID="GoogleMaps"
 >
   <div>
     Hello this is the children
   </div>
 </GoogleMaps>
+`;
+
+exports[`GeoSearch Provider expect to render 1`] = `
+<Provider
+  google={
+    Object {
+      "maps": Object {
+        "ControlPosition": Object {
+          "LEFT_TOP": "left:top",
+        },
+        "LatLng": [MockFunction],
+        "LatLngBounds": [MockFunction],
+        "Map": [MockFunction],
+        "Marker": [MockFunction],
+        "OverlayView": [Function],
+        "event": Object {
+          "addListenerOnce": [MockFunction],
+        },
+      },
+    }
+  }
+  hasMapMoveSinceLastRefine={false}
+  hits={Array []}
+  isRefineOnMapMove={true}
+  refine={[Function]}
+  setMapMoveSinceLastRefine={[Function]}
+  testID="Provider"
+  toggleRefineOnMapMove={[Function]}
+/>
 `;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GoogleMaps.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GoogleMaps.js.snap
@@ -2,20 +2,20 @@
 
 exports[`GoogleMaps expect render correctly with the map rendered 1`] = `
 <div
-  className="geo"
+  className="ais-GeoSearch"
 >
   <div
-    className="geo map"
+    className="ais-GeoSearch-map"
   />
 </div>
 `;
 
 exports[`GoogleMaps expect render correctly with the map rendered 2`] = `
 <div
-  className="geo"
+  className="ais-GeoSearch"
 >
   <div
-    className="geo map"
+    className="ais-GeoSearch-map"
   />
   <div>
     This is the children
@@ -25,10 +25,10 @@ exports[`GoogleMaps expect render correctly with the map rendered 2`] = `
 
 exports[`GoogleMaps expect render correctly without the map rendered 1`] = `
 <div
-  className="geo"
+  className="ais-GeoSearch"
 >
   <div
-    className="geo map"
+    className="ais-GeoSearch-map"
   />
 </div>
 `;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/Redo.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/Redo.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Redo expect to render correctly 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <button
+    className="ais-GeoSearch-redo ais-GeoSearch-redo--disabled"
+    disabled={true}
+    onClick={[Function]}
+  >
+    redo
+  </button>
+</div>
+`;
+
+exports[`Redo expect to render correctly when map has moved 1`] = `
+<div
+  className="ais-GeoSearch-control"
+>
+  <button
+    className="ais-GeoSearch-redo"
+    disabled={false}
+    onClick={[Function]}
+  >
+    redo
+  </button>
+</div>
+`;

--- a/packages/react-instantsearch-dom-geo/src/__tests__/utils.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/utils.js
@@ -1,0 +1,234 @@
+import PropTypes from 'prop-types';
+import { createFakeMarkerInstance } from '../../test/mockGoogleMaps';
+import * as utils from '../utils';
+
+describe('utils', () => {
+  describe('registerEvents', () => {
+    it('expect to add listeners from events', () => {
+      const onClick = () => {};
+      const onMouseMove = () => {};
+      const instance = createFakeMarkerInstance();
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+        onMouseMove,
+      };
+
+      utils.registerEvents(events, props, instance);
+
+      expect(instance.addListener).toHaveBeenCalledTimes(2);
+
+      expect(instance.addListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      );
+
+      expect(instance.addListener).toHaveBeenCalledWith(
+        'mousemove',
+        expect.any(Function)
+      );
+    });
+
+    it('expect to add listeners with event & marker', () => {
+      const onClick = jest.fn();
+      const onMouseMove = jest.fn();
+      const instance = createFakeMarkerInstance();
+      const listeners = [];
+
+      instance.addListener.mockImplementation((event, listener) =>
+        listeners.push(listener)
+      );
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+        onMouseMove,
+      };
+
+      utils.registerEvents(events, props, instance);
+
+      listeners.forEach(listener => listener({ type: 'event' }));
+
+      expect(onClick).toHaveBeenCalledWith({
+        event: { type: 'event' },
+        marker: instance,
+      });
+
+      expect(onMouseMove).toHaveBeenCalledWith({
+        event: { type: 'event' },
+        marker: instance,
+      });
+    });
+
+    it('expect to only add listeners listed from events', () => {
+      const onClick = () => {};
+      const onMouseEnter = () => {};
+      const instance = createFakeMarkerInstance();
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+        onMouseEnter,
+      };
+
+      utils.registerEvents(events, props, instance);
+
+      expect(instance.addListener).toHaveBeenCalledTimes(1);
+      expect(instance.addListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      );
+    });
+
+    it('expect to only add listeners listed from props', () => {
+      const onClick = () => {};
+      const instance = createFakeMarkerInstance();
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+      };
+
+      utils.registerEvents(events, props, instance);
+
+      expect(instance.addListener).toHaveBeenCalledTimes(1);
+      expect(instance.addListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      );
+    });
+
+    it('expect to return a function that remove the listeners', () => {
+      const onClick = () => {};
+      const onMouseMove = () => {};
+      const remove = jest.fn();
+      const instance = createFakeMarkerInstance();
+
+      instance.addListener.mockImplementation(() => ({
+        remove,
+      }));
+
+      const events = {
+        onClick: 'click',
+        onMouseMove: 'mousemove',
+      };
+
+      const props = {
+        onClick,
+        onMouseMove,
+      };
+
+      const removeEventListeners = utils.registerEvents(
+        events,
+        props,
+        instance
+      );
+
+      expect(remove).toHaveBeenCalledTimes(0);
+
+      removeEventListeners();
+
+      expect(remove).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('createListenersPropTypes', () => {
+    it('expect to return an object with listeners propType from event types', () => {
+      const events = {
+        onClick: '',
+        onMouseMove: '',
+      };
+
+      const expectation = {
+        onClick: PropTypes.func,
+        onMouseMove: PropTypes.func,
+      };
+
+      const actual = utils.createListenersPropTypes(events);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return an empty object from empty event types', () => {
+      const events = {};
+
+      const expectation = {};
+      const actual = utils.createListenersPropTypes(events);
+
+      expect(actual).toEqual(expectation);
+    });
+  });
+
+  describe('createFilterProps', () => {
+    it('expect to return an object without excluded keys', () => {
+      const excludes = ['children', 'onClick'];
+
+      const props = {
+        label: 'Title',
+        onClick: () => {},
+        children: '<div />',
+      };
+
+      const expectation = {
+        label: 'Title',
+      };
+
+      const filterProps = utils.createFilterProps(excludes);
+      const actual = filterProps(props);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return the given props when excluded keys is empty', () => {
+      const onClick = () => {};
+      const excludes = [];
+
+      const props = {
+        children: '<div />',
+        onClick,
+      };
+
+      const expectation = {
+        children: '<div />',
+        onClick,
+      };
+
+      const filterProps = utils.createFilterProps(excludes);
+      const actual = filterProps(props);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return an empty object when all keys are excluded', () => {
+      const excludes = ['children', 'onClick'];
+
+      const props = {
+        onClick: () => {},
+        children: '<div />',
+      };
+
+      const expectation = {};
+      const filterProps = utils.createFilterProps(excludes);
+      const actual = filterProps(props);
+
+      expect(actual).toEqual(expectation);
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/elements/__tests__/createHTMLMarker.js
+++ b/packages/react-instantsearch-dom-geo/src/elements/__tests__/createHTMLMarker.js
@@ -1,0 +1,257 @@
+import { createFakeGoogleReference } from '../../../test/mockGoogleMaps';
+import createHTMLMarker from '../createHTMLMarker';
+
+describe('createHTMLMarker', () => {
+  const createFakeParams = ({ ...rest }) => ({
+    position: {
+      lat: 10,
+      lng: 12,
+    },
+    map: 'map-instance-placeholder',
+    className: 'ais-geo-search-marker',
+    ...rest,
+  });
+
+  it('expect to create a marker', () => {
+    const googleReference = createFakeGoogleReference();
+    const HTMLMarker = createHTMLMarker(googleReference);
+    const params = createFakeParams();
+
+    const marker = new HTMLMarker(params);
+
+    expect(marker.anchor).toEqual({ x: 0, y: 0 });
+    expect(marker.subscriptions).toEqual([]);
+    expect(marker.latLng).toEqual({ lat: 10, lng: 12 });
+
+    expect(marker.element).toEqual(expect.any(HTMLDivElement));
+    expect(marker.element.className).toBe('ais-geo-search-marker');
+    expect(marker.element.style.position).toBe('absolute');
+    expect(marker.element.style.whiteSpace).toBe('nowrap');
+
+    expect(marker.setMap).toHaveBeenCalledWith('map-instance-placeholder');
+  });
+
+  it('expect to create a marker with a custom anchor', () => {
+    const googleReference = createFakeGoogleReference();
+    const HTMLMarker = createHTMLMarker(googleReference);
+    const params = createFakeParams({
+      anchor: {
+        x: 5,
+        y: 10,
+      },
+    });
+
+    const marker = new HTMLMarker(params);
+
+    expect(marker.anchor).toEqual({ x: 5, y: 10 });
+  });
+
+  it('expect to create a marker with a custom className', () => {
+    const googleReference = createFakeGoogleReference();
+    const HTMLMarker = createHTMLMarker(googleReference);
+    const params = createFakeParams({
+      className: 'my-custom-marker',
+    });
+
+    const marker = new HTMLMarker(params);
+
+    expect(marker.element.className).toBe('my-custom-marker');
+  });
+
+  describe('onAdd', () => {
+    it('expect to append the element to the overlay', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const overlayMouseTarget = {
+        appendChild: jest.fn(),
+      };
+
+      const marker = new HTMLMarker(params);
+
+      marker.getPanes.mockImplementation(() => ({ overlayMouseTarget }));
+
+      marker.onAdd();
+
+      expect(overlayMouseTarget.appendChild).toHaveBeenCalledWith(
+        marker.element
+      );
+    });
+
+    it('expect to not append the element to the overlay when panes are not available', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const overlayMouseTarget = {
+        appendChild: jest.fn(),
+      };
+
+      const marker = new HTMLMarker(params);
+
+      marker.getPanes.mockImplementation(() => null);
+
+      marker.onAdd();
+
+      expect(overlayMouseTarget.appendChild).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('draw', () => {
+    it('expect to set the correct position on the element', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const fromLatLngToDivPixel = jest.fn(() => ({
+        x: 100,
+        y: 50,
+      }));
+
+      const marker = new HTMLMarker(params);
+
+      marker.getProjection.mockImplementation(() => ({
+        fromLatLngToDivPixel,
+      }));
+
+      marker.draw();
+
+      expect(fromLatLngToDivPixel).toHaveBeenCalledWith({ lat: 10, lng: 12 });
+      expect(marker.element.style.left).toBe('100px');
+      expect(marker.element.style.top).toBe('50px');
+    });
+
+    it('expect to set the correct zIndex on the element', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const fromLatLngToDivPixel = jest.fn(() => ({
+        x: 100,
+        y: 50,
+      }));
+
+      const marker = new HTMLMarker(params);
+
+      marker.getProjection.mockImplementationOnce(() => ({
+        fromLatLngToDivPixel,
+      }));
+
+      marker.draw();
+
+      expect(marker.element.style.zIndex).toBe('0');
+    });
+
+    it('expect to not set the correct position when the projection is not available', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+
+      const marker = new HTMLMarker(params);
+
+      marker.getProjection.mockImplementation(() => null);
+
+      marker.draw();
+
+      expect(marker.element.style.left).toBe('');
+      expect(marker.element.style.top).toBe('');
+      expect(marker.element.style.zIndex).toBe('');
+    });
+  });
+
+  describe('onRemove', () => {
+    it('expect to remove the element', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+
+      const marker = new HTMLMarker(params);
+
+      // Simulate the parentNode
+      const parentNode = document.createElement('div');
+      parentNode.appendChild(marker.element);
+
+      expect(parentNode.childNodes).toHaveLength(1);
+
+      marker.onRemove();
+
+      expect(parentNode.childNodes).toHaveLength(0);
+      expect(marker.element).toBe(undefined);
+    });
+
+    it('expect to remove all the listeners', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const remove = jest.fn();
+
+      const marker = new HTMLMarker(params);
+
+      // Simulate the parentNode
+      const parentNode = document.createElement('div');
+      parentNode.appendChild(marker.element);
+
+      // Simulate the subscriptions
+      marker.subscriptions.push({ remove });
+      marker.subscriptions.push({ remove });
+
+      marker.onRemove();
+
+      expect(marker.subscriptions).toEqual([]);
+      expect(remove).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('addListener', () => {
+    it('expect to register listener', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const onClick = () => {};
+
+      const marker = new HTMLMarker(params);
+
+      const addEventListener = jest.spyOn(marker.element, 'addEventListener');
+
+      marker.addListener('click', onClick);
+
+      expect(addEventListener).toHaveBeenCalledTimes(1);
+      expect(addEventListener).toHaveBeenCalledWith('click', onClick);
+      expect(marker.subscriptions).toHaveLength(1);
+    });
+
+    it('expect to return a function to remove the listener', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+      const onClick = () => {};
+
+      const marker = new HTMLMarker(params);
+
+      const removeEventListener = jest.spyOn(
+        marker.element,
+        'removeEventListener'
+      );
+
+      const subscription = marker.addListener('click', onClick);
+
+      subscription.remove();
+
+      expect(removeEventListener).toHaveBeenCalledTimes(1);
+      expect(removeEventListener).toHaveBeenCalledWith('click', onClick);
+      expect(marker.subscriptions).toHaveLength(0);
+    });
+  });
+
+  describe('getPosition', () => {
+    it('expect to return the latLng', () => {
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = createHTMLMarker(googleReference);
+      const params = createFakeParams();
+
+      const marker = new HTMLMarker(params);
+
+      const actual = marker.getPosition();
+      const expectation = { lat: 10, lng: 12 };
+
+      expect(actual).toEqual(expectation);
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-geo/src/elements/createHTMLMarker.js
+++ b/packages/react-instantsearch-dom-geo/src/elements/createHTMLMarker.js
@@ -1,0 +1,88 @@
+const createHTMLMarker = google => {
+  class HTMLMarker extends google.maps.OverlayView {
+    constructor({
+      position,
+      map,
+      className,
+      anchor = {
+        x: 0,
+        y: 0,
+      },
+    }) {
+      super();
+
+      this.anchor = anchor;
+      this.subscriptions = [];
+      this.latLng = new google.maps.LatLng(position);
+
+      this.element = document.createElement('div');
+      this.element.className = className;
+      this.element.style.position = 'absolute';
+      // Force the "white-space" of the element will avoid the
+      // content to collapse when we move the map from center
+      this.element.style.whiteSpace = 'nowrap';
+
+      this.setMap(map);
+    }
+
+    onAdd() {
+      if (this.getPanes()) {
+        this.getPanes().overlayMouseTarget.appendChild(this.element);
+      }
+    }
+
+    draw() {
+      if (this.getProjection()) {
+        const position = this.getProjection().fromLatLngToDivPixel(this.latLng);
+
+        const offsetX = this.anchor.x + this.element.offsetWidth / 2;
+        const offsetY = this.anchor.y + this.element.offsetHeight;
+
+        this.element.style.left = `${Math.round(position.x - offsetX)}px`;
+        this.element.style.top = `${Math.round(position.y - offsetY)}px`;
+
+        // Markers to the south are in front of markers to the north
+        // This is the default behaviour of Google Maps
+        this.element.style.zIndex = parseInt(this.element.style.top, 10);
+      }
+    }
+
+    onRemove() {
+      if (this.element && this.element.parentNode) {
+        this.element.parentNode.removeChild(this.element);
+
+        this.subscriptions.forEach(subscription => subscription.remove());
+
+        delete this.element;
+
+        this.subscriptions = [];
+      }
+    }
+
+    addListener(eventName, listener) {
+      const subscription = {
+        remove: () => {
+          this.element.removeEventListener(eventName, listener);
+
+          this.subscriptions = this.subscriptions.filter(
+            _ => _ !== subscription
+          );
+        },
+      };
+
+      this.element.addEventListener(eventName, listener);
+
+      this.subscriptions = this.subscriptions.concat(subscription);
+
+      return subscription;
+    }
+
+    getPosition() {
+      return this.latLng;
+    }
+  }
+
+  return HTMLMarker;
+};
+
+export default createHTMLMarker;

--- a/packages/react-instantsearch-dom-geo/src/index.js
+++ b/packages/react-instantsearch-dom-geo/src/index.js
@@ -1,3 +1,6 @@
 export { default as GoogleMapsLoader } from './GoogleMapsLoader';
 export { default as GeoSearch } from './GeoSearch';
 export { default as Marker } from './Marker';
+export { default as CustomMarker } from './CustomMarker';
+export { default as Redo } from './Redo';
+export { default as Control } from './Control';

--- a/packages/react-instantsearch-dom-geo/src/propTypes.js
+++ b/packages/react-instantsearch-dom-geo/src/propTypes.js
@@ -9,3 +9,7 @@ export const BoundingBoxPropType = PropTypes.shape({
   northEast: LatLngPropType.isRequired,
   southWest: LatLngPropType.isRequired,
 });
+
+export const GeolocHitPropType = PropTypes.shape({
+  _geoloc: LatLngPropType.isRequired,
+});

--- a/packages/react-instantsearch-dom-geo/src/utils.js
+++ b/packages/react-instantsearch-dom-geo/src/utils.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+
+export const registerEvents = (events, props, instance) => {
+  const eventsAvailable = Object.keys(events);
+  const listeners = Object.keys(props)
+    .filter(key => eventsAvailable.indexOf(key) !== -1)
+    .map(name =>
+      instance.addListener(events[name], event => {
+        props[name]({ event, marker: instance });
+      })
+    );
+
+  return () => {
+    listeners.forEach(listener => listener.remove());
+  };
+};
+
+export const createListenersPropTypes = eventTypes =>
+  Object.keys(eventTypes).reduce(
+    (acc, name) => ({ ...acc, [name]: PropTypes.func }),
+    {}
+  );
+
+export const createFilterProps = excludes => props =>
+  Object.keys(props)
+    .filter(name => excludes.indexOf(name) === -1)
+    .reduce(
+      (acc, name) => ({
+        ...acc,
+        [name]: props[name],
+      }),
+      {}
+    );

--- a/packages/react-instantsearch-dom-geo/test/mockGoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/test/mockGoogleMaps.js
@@ -47,7 +47,9 @@ export const createFakeGoogleReference = ({
       LEFT_TOP: 'left:top',
     },
     event: {
-      addListenerOnce: jest.fn(),
+      addListenerOnce: jest.fn(() => ({
+        remove: jest.fn(),
+      })),
     },
     OverlayView: {
       setMap: jest.fn(),

--- a/packages/react-instantsearch-dom-geo/test/mockGoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/test/mockGoogleMaps.js
@@ -1,5 +1,7 @@
 export const createFakeMapInstance = () => ({
-  addListener: jest.fn(),
+  addListener: jest.fn(() => ({
+    remove: jest.fn(),
+  })),
   getCenter: jest.fn(),
   setCenter: jest.fn(),
   getZoom: jest.fn(),

--- a/packages/react-instantsearch-dom-geo/test/mockGoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/test/mockGoogleMaps.js
@@ -1,3 +1,20 @@
+export class FakeOverlayView {
+  setMap = jest.fn();
+
+  getPanes = jest.fn(() => ({
+    overlayMouseTarget: {
+      appendChild: jest.fn(),
+    },
+  }));
+
+  getProjection = jest.fn(() => ({
+    fromLatLngToDivPixel: jest.fn(() => ({
+      x: 0,
+      y: 0,
+    })),
+  }));
+}
+
 export const createFakeMapInstance = () => ({
   addListener: jest.fn(() => ({
     remove: jest.fn(),
@@ -29,20 +46,23 @@ export const createFakeMarkerInstance = () => ({
   addListener: jest.fn(),
 });
 
+export const createFakeHTMLMarkerInstance = () => ({
+  element: document.createElement('div'),
+  setMap: jest.fn(),
+  draw: jest.fn(),
+});
+
 export const createFakeGoogleReference = ({
   mapInstance = createFakeMapInstance(),
   markerInstance = createFakeMarkerInstance(),
 } = {}) => ({
   maps: {
-    LatLng: jest.fn(),
+    LatLng: jest.fn(x => x),
     LatLngBounds: jest.fn(() => ({
       extend: jest.fn().mockReturnThis(),
     })),
     Map: jest.fn(() => mapInstance),
-    Marker: jest.fn(args => ({
-      ...args,
-      ...markerInstance,
-    })),
+    Marker: jest.fn(() => markerInstance),
     ControlPosition: {
       LEFT_TOP: 'left:top',
     },
@@ -51,19 +71,6 @@ export const createFakeGoogleReference = ({
         remove: jest.fn(),
       })),
     },
-    OverlayView: {
-      setMap: jest.fn(),
-      getPanes: jest.fn(() => ({
-        overlayMouseTarget: {
-          appendChild: jest.fn(),
-        },
-      })),
-      getProjection: jest.fn(() => ({
-        fromLatLngToDivPixel: jest.fn(() => ({
-          x: 0,
-          y: 0,
-        })),
-      })),
-    },
+    OverlayView: FakeOverlayView,
   },
 });

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, Component } from 'react';
 import PropTypes from 'prop-types';
 import { setAddon, storiesOf } from '@storybook/react';
 import JSXAddon from 'storybook-addon-jsx';
@@ -130,3 +130,54 @@ stories
       filterProps,
     }
   );
+
+stories.addWithJSX('with unmount', () => {
+  class Example extends Component {
+    state = {
+      visible: true,
+    };
+
+    onToggle = () =>
+      this.setState(({ visible }) => ({
+        visible: !visible,
+      }));
+
+    render() {
+      const { visible } = this.state;
+
+      return (
+        <WrapWithHits
+          indexName="airbnb"
+          linkedStoryGroup="GeoSearch"
+          searchParameters={{ hitsPerPage: 20 }}
+        >
+          <Configure aroundLatLngViaIP />
+
+          <button onClick={this.onToggle} style={{ marginBottom: 15 }}>
+            {visible ? 'Unmout' : 'Mount'}
+          </button>
+
+          {visible && (
+            <Container>
+              <GoogleMapsLoader apiKey="AIzaSyCl2TTJXpwxGuuc2zQZkAlIkWhpYbyjjP8">
+                {google => (
+                  <GeoSearch google={google}>
+                    {({ hits }) => (
+                      <Fragment>
+                        {hits.map(hit => (
+                          <Marker key={hit.objectID} hit={hit} />
+                        ))}
+                      </Fragment>
+                    )}
+                  </GeoSearch>
+                )}
+              </GoogleMapsLoader>
+            </Container>
+          )}
+        </WrapWithHits>
+      );
+    }
+  }
+
+  return <Example />;
+});

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -1,14 +1,19 @@
 import React, { Fragment, Component } from 'react';
 import PropTypes from 'prop-types';
 import { setAddon, storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import JSXAddon from 'storybook-addon-jsx';
-import { Configure } from 'react-instantsearch-dom';
+import { Configure, Highlight, connectHits } from 'react-instantsearch-dom';
 import {
   GoogleMapsLoader,
   GeoSearch,
   Marker,
+  CustomMarker,
+  Redo,
+  Control,
 } from 'react-instantsearch-dom-maps';
 import { displayName, filterProps, WrapWithHits } from './util';
+import Places from './places';
 
 setAddon(JSXAddon);
 
@@ -22,6 +27,7 @@ Container.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
+const apiKey = 'AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ';
 const initialZoom = 12;
 const initialPosition = {
   lat: 40.71,
@@ -31,19 +37,52 @@ const initialPosition = {
 stories.addWithJSX(
   'default',
   () => (
-    <WrapWithHits
-      indexName="airbnb"
-      linkedStoryGroup="GeoSearch"
-      searchParameters={{ hitsPerPage: 20 }}
-    >
-      <Configure aroundLatLngViaIP />
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+      <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
-        <GoogleMapsLoader apiKey="AIzaSyCl2TTJXpwxGuuc2zQZkAlIkWhpYbyjjP8">
+        <GoogleMapsLoader apiKey={apiKey}>
           {google => (
             <GeoSearch google={google}>
               {({ hits }) => (
                 <Fragment>
+                  {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                </Fragment>
+              )}
+            </GeoSearch>
+          )}
+        </GoogleMapsLoader>
+      </Container>
+    </WrapWithHits>
+  ),
+  {
+    displayName,
+    filterProps,
+  }
+);
+
+// With Places
+stories.addWithJSX(
+  'with Places',
+  () => (
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+      <Configure hitsPerPage={20} aroundRadius={5000} />
+
+      <Places
+        defaultRefinement={{
+          lat: 37.7793,
+          lng: -122.419,
+        }}
+      />
+
+      <Container>
+        <GoogleMapsLoader apiKey={apiKey}>
+          {google => (
+            <GeoSearch google={google} initialZoom={12}>
+              {({ hits }) => (
+                <Fragment>
+                  <Control />
+
                   {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
                 </Fragment>
               )}
@@ -64,15 +103,11 @@ stories
   .addWithJSX(
     'with zoom & center',
     () => (
-      <WrapWithHits
-        indexName="airbnb"
-        linkedStoryGroup="GeoSearch"
-        searchParameters={{ hitsPerPage: 20 }}
-      >
-        <Configure aroundLatLngViaIP />
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
 
         <Container>
-          <GoogleMapsLoader apiKey="AIzaSyCl2TTJXpwxGuuc2zQZkAlIkWhpYbyjjP8">
+          <GoogleMapsLoader apiKey={apiKey}>
             {google => (
               <GeoSearch
                 google={google}
@@ -98,22 +133,13 @@ stories
   .addWithJSX(
     'with map options',
     () => (
-      <WrapWithHits
-        indexName="airbnb"
-        linkedStoryGroup="GeoSearch"
-        searchParameters={{ hitsPerPage: 20 }}
-      >
-        <Configure aroundLatLngViaIP />
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
 
         <Container>
-          <GoogleMapsLoader apiKey="AIzaSyCl2TTJXpwxGuuc2zQZkAlIkWhpYbyjjP8">
+          <GoogleMapsLoader apiKey={apiKey}>
             {google => (
-              <GeoSearch
-                google={google}
-                mapOptions={{
-                  streetViewControl: true,
-                }}
-              >
+              <GeoSearch google={google} streetViewControl>
                 {({ hits }) => (
                   <Fragment>
                     {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
@@ -129,7 +155,387 @@ stories
       displayName,
       filterProps,
     }
+  )
+  .addWithJSX(
+    'with <Marker> options',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    {hits.map(hit => (
+                      <Marker
+                        key={hit.objectID}
+                        hit={hit}
+                        label={hit.price_formatted}
+                        onClick={() => {}}
+                      />
+                    ))}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <Marker> events',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    {hits.map(hit => (
+                      <Marker
+                        key={hit.objectID}
+                        hit={hit}
+                        onClick={action('click')}
+                      />
+                    ))}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <Redo> component',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Redo />
+
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <Control> component',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Control />
+
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <Control> component disabled',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Control enableRefineOnMapMove={false} />
+
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <CustomMarker>',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Control />
+
+                    {hits.map(hit => (
+                      <Fragment key={hit.objectID}>
+                        <CustomMarker
+                          hit={hit}
+                          className="my-custom-marker"
+                          anchor={{ x: 0, y: 5 }}
+                        >
+                          {hit.price_formatted}
+                        </CustomMarker>
+                      </Fragment>
+                    ))}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with <CustomMarker> events',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    <Control />
+
+                    {hits.map(hit => (
+                      <Fragment key={hit.objectID}>
+                        <CustomMarker
+                          hit={hit}
+                          className="my-custom-marker"
+                          anchor={{ x: 0, y: 5 }}
+                          onClick={action('click')}
+                        >
+                          <span>{hit.price_formatted}</span>
+                        </CustomMarker>
+                      </Fragment>
+                    ))}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
   );
+
+stories.addWithJSX('with InfoWindow', () => {
+  class Example extends Component {
+    static propTypes = {
+      google: PropTypes.object.isRequired,
+    };
+
+    InfoWindow = new this.props.google.maps.InfoWindow();
+
+    onClickMarker = ({ hit, marker }) => {
+      if (this.InfoWindow.getMap()) {
+        this.InfoWindow.close();
+      }
+
+      this.InfoWindow.setContent(hit.name);
+
+      this.InfoWindow.open(marker.getMap(), marker);
+    };
+
+    renderGeoHit = hit => (
+      <Marker
+        key={hit.objectID}
+        hit={hit}
+        anchor={{ x: 0, y: 5 }}
+        onClick={({ marker }) => {
+          this.onClickMarker({
+            hit,
+            marker,
+          });
+        }}
+      />
+    );
+
+    render() {
+      const { google } = this.props;
+
+      return (
+        <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+          <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+          <Container>
+            <GeoSearch google={google}>
+              {({ hits }) => <Fragment>{hits.map(this.renderGeoHit)}</Fragment>}
+            </GeoSearch>
+          </Container>
+        </WrapWithHits>
+      );
+    }
+  }
+
+  return (
+    <GoogleMapsLoader apiKey={apiKey}>
+      {google => <Example google={google} />}
+    </GoogleMapsLoader>
+  );
+});
+
+stories.addWithJSX('with hits communication (custom)', () => {
+  const CustomHits = connectHits(({ hits, selectedHit, onHitOver }) => (
+    <div className="hits">
+      {hits.map(hit => {
+        const classNames = [
+          'hit',
+          'hit--airbnb',
+          selectedHit && selectedHit.objectID === hit.objectID
+            ? 'hit--airbnb-active'
+            : '',
+        ];
+
+        return (
+          <div
+            key={hit.objectID}
+            className={classNames.join(' ').trim()}
+            onMouseEnter={() => onHitOver(hit)}
+            onMouseLeave={() => onHitOver(null)}
+          >
+            <div className="hit-content">
+              <div>
+                <Highlight attribute="name" hit={hit} />
+                <span> - ${hit.price}</span>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  ));
+
+  class Example extends Component {
+    state = {
+      selectedHit: null,
+    };
+
+    onHitOver = hit =>
+      this.setState(() => ({
+        selectedHit: hit,
+      }));
+
+    renderGeoHit = hit => {
+      const { selectedHit } = this.state;
+
+      const classNames = [
+        'my-custom-marker',
+        selectedHit && selectedHit.objectID === hit.objectID
+          ? 'my-custom-marker--active'
+          : '',
+      ];
+
+      return (
+        <CustomMarker
+          key={hit.objectID}
+          hit={hit}
+          anchor={{ x: 0, y: 5 }}
+          onMouseEnter={() => this.onHitOver(hit)}
+          onMouseLeave={() => this.onHitOver(null)}
+        >
+          <div className={classNames.join(' ').trim()}>
+            <span>{hit.price_formatted}</span>
+          </div>
+        </CustomMarker>
+      );
+    };
+
+    render() {
+      const { selectedHit } = this.state;
+
+      return (
+        <WrapWithHits
+          indexName="airbnb"
+          linkedStoryGroup="GeoSearch"
+          hitsElement={
+            <CustomHits selectedHit={selectedHit} onHitOver={this.onHitOver} />
+          }
+        >
+          <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+          <Container>
+            <GoogleMapsLoader apiKey={apiKey}>
+              {google => (
+                <GeoSearch google={google}>
+                  {({ hits }) => (
+                    <Fragment>{hits.map(this.renderGeoHit)}</Fragment>
+                  )}
+                </GeoSearch>
+              )}
+            </GoogleMapsLoader>
+          </Container>
+        </WrapWithHits>
+      );
+    }
+  }
+
+  return <Example />;
+});
 
 stories.addWithJSX('with unmount', () => {
   class Example extends Component {
@@ -146,12 +552,8 @@ stories.addWithJSX('with unmount', () => {
       const { visible } = this.state;
 
       return (
-        <WrapWithHits
-          indexName="airbnb"
-          linkedStoryGroup="GeoSearch"
-          searchParameters={{ hitsPerPage: 20 }}
-        >
-          <Configure aroundLatLngViaIP />
+        <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+          <Configure aroundLatLngViaIP hitsPerPage={20} />
 
           <button onClick={this.onToggle} style={{ marginBottom: 15 }}>
             {visible ? 'Unmout' : 'Mount'}
@@ -159,7 +561,7 @@ stories.addWithJSX('with unmount', () => {
 
           {visible && (
             <Container>
-              <GoogleMapsLoader apiKey="AIzaSyCl2TTJXpwxGuuc2zQZkAlIkWhpYbyjjP8">
+              <GoogleMapsLoader apiKey={apiKey}>
                 {google => (
                   <GeoSearch google={google}>
                     {({ hits }) => (

--- a/stories/places/connector.js
+++ b/stories/places/connector.js
@@ -1,0 +1,31 @@
+import { createConnector } from 'react-instantsearch-dom';
+
+export default createConnector({
+  displayName: 'AlgoliaGeoSearch',
+
+  getProvidedProps() {
+    return {};
+  },
+
+  refine(props, searchState, nextValue) {
+    // eslint-disable-next-line no-unused-vars
+    const { boundingBox, ...sliceSearchState } = searchState;
+
+    return {
+      ...sliceSearchState,
+      aroundLatLng: nextValue,
+    };
+  },
+
+  getSearchParameters(searchParameters, props, searchState) {
+    const currentRefinement =
+      searchState.aroundLatLng || props.defaultRefinement;
+
+    return searchParameters
+      .setQueryParameter('insideBoundingBox')
+      .setQueryParameter(
+        'aroundLatLng',
+        `${currentRefinement.lat}, ${currentRefinement.lng}`
+      );
+  },
+});

--- a/stories/places/index.js
+++ b/stories/places/index.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import places from 'places.js';
+import connect from './connector';
+
+class Places extends Component {
+  static propTypes = {
+    refine: PropTypes.func.isRequired,
+    defaultRefinement: PropTypes.object.isRequired,
+  };
+
+  createRef = c => (this.element = c);
+
+  componentDidMount() {
+    const { refine, defaultRefinement } = this.props;
+
+    const autocomplete = places({
+      container: this.element,
+    });
+
+    autocomplete.on('change', event => {
+      refine(event.suggestion.latlng);
+    });
+
+    autocomplete.on('clear', () => {
+      refine(defaultRefinement);
+    });
+  }
+
+  render() {
+    return (
+      <div style={{ marginBottom: 20 }}>
+        <input
+          ref={this.createRef}
+          type="search"
+          id="address-input"
+          placeholder="Where are we going?"
+        />
+      </div>
+    );
+  }
+}
+
+export default connect(Places);

--- a/stories/util.js
+++ b/stories/util.js
@@ -74,6 +74,7 @@ export const WrapWithHits = ({
   appId,
   apiKey,
   indexName,
+  hitsElement,
 }) => {
   const sourceCodeUrl = `https://github.com/algolia/react-instantsearch/tree/master/stories/${linkedStoryGroup}.stories.js`;
   const playgroundLink = hasPlayground ? (
@@ -93,6 +94,8 @@ export const WrapWithHits = ({
       </a>
     </div>
   ) : null;
+
+  const hits = hitsElement || <CustomHits />;
 
   const searchParameters = {
     hitsPerPage: 3,
@@ -120,7 +123,7 @@ export const WrapWithHits = ({
               ) : null}
               <ClearRefinements translations={{ reset: 'Clear all filters' }} />
             </div>
-            <CustomHits />
+            {hits}
             <div className="hit-pagination">
               {pagination ? <Pagination showLast={true} /> : null}
             </div>
@@ -142,6 +145,7 @@ WrapWithHits.propTypes = {
   hasPlayground: PropTypes.bool,
   pagination: PropTypes.bool,
   searchParameters: PropTypes.object,
+  hitsElement: PropTypes.element,
 };
 
 // defaultProps added so that they're displayed in the JSX addon

--- a/storybook/public/util.css
+++ b/storybook/public/util.css
@@ -17,8 +17,8 @@
   padding: 4px 6px;
   line-height: 1em;
   position: absolute;
-  background-color: #F3F3F3;
-  border: solid 1px #E4E4E4;
+  background-color: #f3f3f3;
+  border: solid 1px #e4e4e4;
   border-width: 0 1px 1px 0;
 }
 
@@ -28,10 +28,10 @@
   justify-content: space-around;
   overflow-x: hidden;
   clear: left;
-  border-bottom: solid 1px #E4E4E4;
-  border-left: solid 1px #E4E4E4;
-  border-right: solid 1px #E4E4E4;
-  background-color: #F3F3F3;
+  border-bottom: solid 1px #e4e4e4;
+  border-left: solid 1px #e4e4e4;
+  border-right: solid 1px #e4e4e4;
+  background-color: #f3f3f3;
 }
 
 .playground-url,
@@ -43,7 +43,7 @@
   color: #999999;
   padding: 4px 6px;
   line-height: 1em;
-  background-color: #F3F3F3;
+  background-color: #f3f3f3;
   border: none;
 }
 
@@ -52,12 +52,12 @@
  */
 
 .widget-container {
-  border: solid 1px #E4E4E4;
+  border: solid 1px #e4e4e4;
   border-radius: 5px 5px 0px 0px;
 }
 
 .widget-container:after {
-  content: "Widget display";
+  content: 'Widget display';
   border-radius: 5px 0 3px;
 }
 
@@ -66,15 +66,15 @@
  */
 
 .hits-container {
-  border-left: solid 1px #E4E4E4;
-  border-right: solid 1px #E4E4E4;
-  border-bottom: solid 1px #E4E4E4;
+  border-left: solid 1px #e4e4e4;
+  border-right: solid 1px #e4e4e4;
+  border-bottom: solid 1px #e4e4e4;
   display: flex;
   flex-direction: column;
 }
 
 .hits-container:after {
-  content: "Results";
+  content: 'Results';
 }
 
 /**
@@ -99,9 +99,15 @@
 }
 
 .hit {
-  margin: 10px 10px;
+  padding: 5px 5px;
   display: flex;
   align-items: center;
+}
+
+.hit--airbnb:hover,
+.hit--airbnb-active {
+  background-color: #3369e7;
+  color: #ffffff;
 }
 
 .ais-SearchBox__root {
@@ -142,4 +148,46 @@
 
 .multi-index_hit .multi-index_hit-content {
   padding-left: 10px;
+}
+
+/* GeoSearch */
+
+.my-custom-marker {
+  position: relative;
+  background-color: white;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  padding: 3px 5px;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.15);
+}
+
+.my-custom-marker:hover,
+.my-custom-marker--active {
+  background-color: #3369e7;
+  color: white;
+  cursor: pointer;
+}
+
+.my-custom-marker::after {
+  content: '';
+  display: block;
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  bottom: -5px;
+  background-color: white;
+  border-color: rgba(0, 0, 0, 0.2);
+  border-width: 0 1px 1px 0;
+  border-style: solid;
+  left: 50%;
+  margin-left: -4px;
+  transform: rotate(45deg);
+}
+
+.my-custom-marker:hover::after,
+.my-custom-marker--active::after {
+  background-color: #3369e7;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,7 +991,7 @@ ajv@^6.1.0:
     json-schema-traverse "^0.3.0"
     uri-js "^3.0.2"
 
-algolia-aerial@1.3.4:
+algolia-aerial@1.3.4, algolia-aerial@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/algolia-aerial/-/algolia-aerial-1.3.4.tgz#161d11120f96de56933442eb78bc74adfeb7c582"
   dependencies:
@@ -1435,6 +1435,12 @@ atoa@1.0.0:
 atob@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.0.tgz#ab2b150e51d7b122b9efc8d7340c06b6c41076bc"
+
+autocomplete.js@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.30.0.tgz#e7a1425474291d255911499cee2a3c5624c9ccc5"
+  dependencies:
+    immediate "^3.2.3"
 
 autoprefixer@8.6.3:
   version "8.6.3"
@@ -5761,6 +5767,10 @@ events@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/events/-/events-2.0.0.tgz#cbbb56bf3ab1ac18d71c43bb32c86255062769f2"
 
+events@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+
 eventsource@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-0.1.6.tgz#0acede849ed7dd1ccc32c811bb11b944d4f29232"
@@ -7471,6 +7481,10 @@ iltorb@^1.0.9:
 image-size@^0.6.0:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.2.tgz#8ee316d4298b028b965091b673d5f1537adee5b4"
+
+immediate@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
 
 immediate@~3.0.5:
   version "3.0.6"
@@ -10846,6 +10860,16 @@ pkginfo@0.3.x:
 pkginfo@0.x.x:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
+
+places.js@1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/places.js/-/places.js-1.7.3.tgz#70d9791fc6e6e7f3359a1cadcc8876914cdfdd65"
+  dependencies:
+    algolia-aerial "^1.3.4"
+    algoliasearch "^3.27.1"
+    autocomplete.js "^0.30.0"
+    events "^3.0.0"
+    insert-css "^2.0.0"
 
 plist@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
**Summary**

This is the third part of the GeoSearch widget. It implement the basic support of refine on map interaction. Every time the map move, we schedule a refinement on the next "idle" event. You can't control the behaviour of the refinement. It will comes after. I skip the support for the padding on refine because I didn't find a proper way to do it. Can be implement later.

![untitled](https://user-images.githubusercontent.com/6513513/39291571-c4f064ca-4933-11e8-8ff1-1bae23c2e745.gif)

This PR does not include new components:

- **`<Provider>`**: expose the refine function to his render props
- **`<GeoSearch>`**: provide the refine function to `<GoogleMaps>`
- **`<GoogleMaps>`**: setup the listeners on the map and bind the call to refine with the map bounds

**Result**

You can use the widget in [Storybook](https://deploy-preview-1192--react-instantsearch.netlify.com/react-instantsearch/storybook/?selectedKind=GeoSearch&selectedStory=default&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs).