### PR TITLE
Fix/infinite hits

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -44,7 +44,7 @@ export default createConnector({
     const results = getResults(searchResults, this.context);
 
     this._allResults = this._allResults || [];
-    this.previousPage = this.previousPage || 0;
+    this._previousPage = this._previousPage || 0;
 
     if (!results) {
       return {
@@ -57,16 +57,16 @@ export default createConnector({
 
     if (page === 0) {
       this._allResults = hits;
-    } else if (page > this.previousPage) {
+    } else if (page > this._previousPage) {
       this._allResults = [...this._allResults, ...hits];
-    } else if (page < this.previousPage) {
+    } else if (page < this._previousPage) {
       this._allResults = hits;
     }
 
     const lastPageIndex = nbPages - 1;
     const hasMore = page < lastPageIndex;
 
-    this.previousPage = page;
+    this._previousPage = page;
 
     return {
       hits: this._allResults,

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -44,6 +44,7 @@ export default createConnector({
     const results = getResults(searchResults, this.context);
 
     this._allResults = this._allResults || [];
+    this.previousPage = this.previousPage || 0;
 
     if (!results) {
       return {

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -221,7 +221,7 @@ describe('connectInfiniteHits', () => {
       };
 
       const expectation = {
-        hits: [],
+        hits: [{}, {}, {}],
         hasMore: true,
       };
 


### PR DESCRIPTION
**Summary**

Prevent the `connectInfinteHits` connector to render an empty array when the previous page is not defined. When it's `undefined` all the tests regarding the page will fail because we compare a number with `undefined` and it's always `false`.

**Before**

![before](https://user-images.githubusercontent.com/6513513/39320775-6fde3bfe-4985-11e8-8d4c-0ae6095dfba2.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/39320777-71bcf488-4985-11e8-9d24-793eb384bb3d.gif)

You can also test it live:

- before: [Material UI](https://community.algolia.com/react-instantsearch/examples/material-ui/?page=9&configure%5BhitsPerPage%5D=20)
- after: [Material UI](url)