### PR TITLE
feat: Upgrade Client and Helper

### DIFF
--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -29,8 +29,8 @@
     "test:size": "bundlesize"
   },
   "dependencies": {
-    "algoliasearch": "^3.24.0",
-    "algoliasearch-helper": "^2.21.0",
+    "algoliasearch": "^3.27.1",
+    "algoliasearch-helper": "^2.26.0",
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10"

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
@@ -22,22 +22,7 @@ jest.mock('algoliasearch-helper/src/algoliasearch.helper.js', () => {
 });
 
 const client = algoliaClient('latency', '249078a3d4337a8231f1665ec5a44966');
-client.addAlgoliaAgent = () => {};
-client.search = jest.fn((queries, cb) => {
-  if (cb) {
-    setImmediate(() => {
-      // We do not care about the returned values because we also control how
-      // it will handle in the helper
-      cb(null, null);
-    });
-    return undefined;
-  }
-
-  return new Promise(resolve => {
-    // cf comment above
-    resolve(null);
-  });
-});
+client.search = jest.fn(() => Promise.resolve({ results: [{ hits: [] }] }));
 
 describe('createInstantSearchManager', () => {
   describe('with correct result from algolia', () => {
@@ -76,46 +61,46 @@ describe('createInstantSearchManager', () => {
 
         expect(ism.store.getState().results).toBe(null);
 
-        return Promise.resolve().then(() => {
-          jest.runAllTimers();
-
-          const store = ism.store.getState();
-          expect(store.results.first).toEqual({
-            query: 'first query 1',
-            page: 3,
-            index: 'first',
-          });
-          expect(store.results.second).toEqual({
-            query: 'second query 1',
-            page: 0,
-            index: 'second',
-          });
-          expect(store.error).toBe(null);
-
-          ism.widgetsManager.getWidgets()[0].getSearchParameters = params =>
-            params.setQuery('first query 2');
-          ism.widgetsManager.getWidgets()[1].getSearchParameters = params =>
-            params.setQuery('second query 2');
-
-          ism.widgetsManager.update();
-
-          return Promise.resolve().then(() => {
-            jest.runAllTimers();
-
-            const store1 = ism.store.getState();
+        return Promise.resolve()
+          .then(() => {})
+          .then(() => {
+            const store = ism.store.getState();
             expect(store.results.first).toEqual({
-              query: 'first query 2',
+              query: 'first query 1',
               page: 3,
               index: 'first',
             });
             expect(store.results.second).toEqual({
-              query: 'second query 2',
+              query: 'second query 1',
               page: 0,
               index: 'second',
             });
-            expect(store1.error).toBe(null);
+            expect(store.error).toBe(null);
+
+            ism.widgetsManager.getWidgets()[0].getSearchParameters = params =>
+              params.setQuery('first query 2');
+            ism.widgetsManager.getWidgets()[1].getSearchParameters = params =>
+              params.setQuery('second query 2');
+
+            ism.widgetsManager.update();
+
+            return Promise.resolve()
+              .then(() => {})
+              .then(() => {
+                const store1 = ism.store.getState();
+                expect(store.results.first).toEqual({
+                  query: 'first query 2',
+                  page: 3,
+                  index: 'first',
+                });
+                expect(store.results.second).toEqual({
+                  query: 'second query 2',
+                  page: 0,
+                  index: 'second',
+                });
+                expect(store1.error).toBe(null);
+              });
           });
-        });
       });
 
       it('updates the store and searches with duplicate Index & SortBy', () => {
@@ -174,22 +159,22 @@ describe('createInstantSearchManager', () => {
 
         ism.widgetsManager.update();
 
-        return Promise.resolve().then(() => {
-          jest.runAllTimers();
-
-          expect(ism.store.getState().results).toEqual({
-            first: {
-              index: 'third',
-              query: 'query',
-              page: 0,
-            },
-            second: {
-              index: 'second',
-              query: 'query',
-              page: 0,
-            },
+        return Promise.resolve()
+          .then(() => {})
+          .then(() => {
+            expect(ism.store.getState().results).toEqual({
+              first: {
+                index: 'third',
+                query: 'query',
+                page: 0,
+              },
+              second: {
+                index: 'second',
+                query: 'query',
+                page: 0,
+              },
+            });
           });
-        });
       });
     });
 
@@ -227,22 +212,25 @@ describe('createInstantSearchManager', () => {
 
         expect(ism.store.getState().results).toBe(null);
 
-        jest.runAllTimers();
-
-        const store = ism.store.getState();
-        expect(store.results.first).toEqual({
-          query: 'first query 1',
-          page: 3,
-          index: 'first',
+        return Promise.resolve().then(() => {
+          const store = ism.store.getState();
+          expect(store.results.first).toEqual({
+            query: 'first query 1',
+            page: 3,
+            index: 'first',
+          });
+          expect(store.results.second).toEqual({
+            query: 'second query 1',
+            page: 0,
+            index: 'second',
+          });
+          expect(store.error).toBe(null);
         });
-        expect(store.results.second).toEqual({
-          query: 'second query 1',
-          page: 0,
-          index: 'second',
-        });
-        expect(store.error).toBe(null);
       });
+
       it('updates the store and searches when switching from mono to multi index', () => {
+        expect.assertions(7);
+
         const ism = createInstantSearchManager({
           indexName: 'first',
           initialState: {},
@@ -275,69 +263,71 @@ describe('createInstantSearchManager', () => {
 
         expect(ism.store.getState().results).toBe(null);
 
-        jest.runAllTimers();
+        return Promise.resolve()
+          .then(() => {
+            const store = ism.store.getState();
+            expect(store.results.first).toEqual({
+              query: 'first query 1',
+              page: 3,
+              index: 'first',
+            });
+            expect(store.results.second).toEqual({
+              query: 'second query 1',
+              page: 0,
+              index: 'second',
+            });
+            expect(store.error).toBe(null);
 
-        let store = ism.store.getState();
-        expect(store.results.first).toEqual({
-          query: 'first query 1',
-          page: 3,
-          index: 'first',
-        });
-        expect(store.results.second).toEqual({
-          query: 'second query 1',
-          page: 0,
-          index: 'second',
-        });
-        expect(store.error).toBe(null);
+            ism.widgetsManager.getWidgets()[0].getSearchParameters = params =>
+              params.setQuery('first query 2');
+            ism.widgetsManager.getWidgets().pop();
+            ism.widgetsManager.getWidgets().pop();
+            ism.widgetsManager.getWidgets().pop();
 
-        ism.widgetsManager.getWidgets()[0].getSearchParameters = params =>
-          params.setQuery('first query 2');
-        ism.widgetsManager.getWidgets().pop();
-        ism.widgetsManager.getWidgets().pop();
-        ism.widgetsManager.getWidgets().pop();
+            ism.onExternalStateUpdate({});
+          })
+          .then(() => {})
+          .then(() => {
+            const store = ism.store.getState();
+            expect(store.results).toEqual({
+              query: 'first query 2',
+              page: 0,
+              index: 'first',
+            });
 
-        ism.onExternalStateUpdate({});
+            ism.widgetsManager.registerWidget({
+              getSearchParameters: params => params.setQuery('second query 2'),
+              context: { multiIndexContext: { targetedIndex: 'second' } },
+              props: {},
+            });
+            ism.widgetsManager.registerWidget({
+              getSearchParameters: params => params.setPage(3),
+              context: { multiIndexContext: { targetedIndex: 'first' } },
+              props: {},
+            });
+            ism.widgetsManager.registerWidget({
+              getSearchParameters: params => params.setIndex('second'),
+              context: { multiIndexContext: { targetedIndex: 'second' } },
+              props: {},
+            });
 
-        jest.runAllTimers();
+            ism.onExternalStateUpdate({});
+          })
+          .then(() => {})
+          .then(() => {
+            const store = ism.store.getState();
 
-        store = ism.store.getState();
-        expect(store.results).toEqual({
-          query: 'first query 2',
-          page: 0,
-          index: 'first',
-        });
-
-        ism.widgetsManager.registerWidget({
-          getSearchParameters: params => params.setQuery('second query 2'),
-          context: { multiIndexContext: { targetedIndex: 'second' } },
-          props: {},
-        });
-        ism.widgetsManager.registerWidget({
-          getSearchParameters: params => params.setPage(3),
-          context: { multiIndexContext: { targetedIndex: 'first' } },
-          props: {},
-        });
-        ism.widgetsManager.registerWidget({
-          getSearchParameters: params => params.setIndex('second'),
-          context: { multiIndexContext: { targetedIndex: 'second' } },
-          props: {},
-        });
-
-        ism.onExternalStateUpdate({});
-
-        jest.runAllTimers();
-
-        store = ism.store.getState();
-        expect(store.results.first).toEqual({
-          query: 'first query 2',
-          page: 3,
-          index: 'first',
-        });
-        expect(store.results.second).toEqual({
-          query: 'second query 2',
-          page: 0,
-          index: 'second',
-        });
+            expect(store.results.first).toEqual({
+              query: 'first query 2',
+              page: 3,
+              index: 'first',
+            });
+            expect(store.results.second).toEqual({
+              query: 'second query 2',
+              page: 0,
+              index: 'second',
+            });
+          });
       });
     });
   });

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
@@ -28,6 +28,8 @@ describe('createInstantSearchManager', () => {
   describe('with correct result from algolia', () => {
     describe('on widget lifecycle', () => {
       it('updates the store and searches', () => {
+        expect.assertions(7);
+
         const ism = createInstantSearchManager({
           indexName: 'first',
           initialState: {},
@@ -104,6 +106,8 @@ describe('createInstantSearchManager', () => {
       });
 
       it('updates the store and searches with duplicate Index & SortBy', () => {
+        expect.assertions(2);
+
         // <InstantSearch indexName="first">
         //   <SearchBox defaultRefinement="query" />
         //
@@ -180,6 +184,8 @@ describe('createInstantSearchManager', () => {
 
     describe('on external updates', () => {
       it('updates the store and searches', () => {
+        expect.assertions(4);
+
         const ism = createInstantSearchManager({
           indexName: 'first',
           initialState: {},

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.derived.test.js
@@ -62,7 +62,7 @@ describe('createInstantSearchManager', () => {
         expect(ism.store.getState().results).toBe(null);
 
         return Promise.resolve()
-          .then(() => {})
+          .then(() => {}) // We need to wait for the next tick
           .then(() => {
             const store = ism.store.getState();
             expect(store.results.first).toEqual({

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.error.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.error.test.js
@@ -21,24 +21,14 @@ jest.mock('algoliasearch-helper/src/algoliasearch.helper.js', () => {
 });
 
 const client = algoliaClient('latency', '249078a3d4337a8231f1665ec5a44966');
-client.search = jest.fn((queries, cb) => {
-  if (cb) {
-    setImmediate(() => {
-      cb(null, null);
-    });
-    return undefined;
-  }
-
-  return new Promise(resolve => {
-    // cf comment above
-    resolve(null);
-  });
-});
+client.search = jest.fn(() => Promise.resolve({ results: [{ hits: [] }] }));
 
 describe('createInstantSearchManager errors', () => {
   describe('with error from algolia', () => {
     describe('on widget lifecycle', () => {
       it('updates the store and searches', () => {
+        expect.assertions(5);
+
         const ism = createInstantSearchManager({
           indexName: 'index',
           initialState: {},
@@ -54,23 +44,21 @@ describe('createInstantSearchManager errors', () => {
 
         expect(ism.store.getState().error).toBe(null);
 
-        return Promise.resolve().then(() => {
-          jest.runAllTimers();
+        return Promise.resolve()
+          .then(() => {})
+          .then(() => {
+            const store = ism.store.getState();
+            expect(store.error).toEqual({ count: 0 });
+            expect(store.results).toEqual(null);
 
-          const store = ism.store.getState();
-          expect(store.error).toEqual({ count: 0 });
-          expect(store.results).toEqual(null);
-
-          ism.widgetsManager.update();
-
-          return Promise.resolve().then(() => {
-            jest.runAllTimers();
-
+            ism.widgetsManager.update();
+          })
+          .then(() => {})
+          .then(() => {
             const store1 = ism.store.getState();
             expect(store1.error).toEqual({ count: 1 });
             expect(store1.results).toBe(null);
           });
-        });
       });
     });
 
@@ -87,11 +75,13 @@ describe('createInstantSearchManager errors', () => {
 
         expect(ism.store.getState().error).toBe(null);
 
-        jest.runAllTimers();
-
-        const store = ism.store.getState();
-        expect(store.error).toEqual({ count: 2 });
-        expect(store.results).toBe(null);
+        return Promise.resolve()
+          .then(() => {})
+          .then(() => {
+            const store = ism.store.getState();
+            expect(store.error).toEqual({ count: 2 });
+            expect(store.results).toBe(null);
+          });
       });
     });
 
@@ -107,8 +97,6 @@ describe('createInstantSearchManager errors', () => {
         ism.onSearchForFacetValues({ facetName: 'facetName', query: 'query' });
 
         expect(ism.store.getState().error).toBe(null);
-
-        jest.runAllTimers();
 
         return Promise.resolve().then(() => {
           const store = ism.store.getState();
@@ -135,23 +123,21 @@ describe('createInstantSearchManager errors', () => {
 
         expect(ism.store.getState().error).toBe(null);
 
-        return Promise.resolve().then(() => {
-          jest.runAllTimers();
+        return Promise.resolve()
+          .then(() => {})
+          .then(() => {
+            const store = ism.store.getState();
+            expect(store.error).toEqual({ count: 3 });
+            expect(store.results).toEqual(null);
 
-          const store = ism.store.getState();
-          expect(store.error).toEqual({ count: 3 });
-          expect(store.results).toEqual(null);
-
-          ism.widgetsManager.update();
-
-          return Promise.resolve().then(() => {
-            jest.runAllTimers();
-
+            ism.widgetsManager.update();
+          })
+          .then(() => {})
+          .then(() => {
             const store1 = ism.store.getState();
             expect(store1.error).toEqual(null);
             expect(store1.results).toEqual({ count: 4 });
           });
-        });
       });
     });
   });

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.error.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.error.test.js
@@ -64,6 +64,8 @@ describe('createInstantSearchManager errors', () => {
 
     describe('on external updates', () => {
       it('updates the store and searches', () => {
+        expect.assertions(3);
+
         const ism = createInstantSearchManager({
           indexName: 'index',
           initialState: {},
@@ -87,6 +89,8 @@ describe('createInstantSearchManager errors', () => {
 
     describe('on search for facet values', () => {
       it('updates the store and searches', () => {
+        expect.assertions(3);
+
         const ism = createInstantSearchManager({
           indexName: 'index',
           initialState: {},
@@ -108,6 +112,8 @@ describe('createInstantSearchManager errors', () => {
 
     describe('reset error after a succesful query', () => {
       it('on widget lifecyle', () => {
+        expect.assertions(5);
+
         const ism = createInstantSearchManager({
           indexName: 'index',
           initialState: {},

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
@@ -20,13 +20,14 @@ jest.mock('algoliasearch-helper', () => {
 });
 
 const client = algoliaClient('latency', '249078a3d4337a8231f1665ec5a44966');
-client.addAlgoliaAgent = () => {};
 client.search = jest.fn(() => Promise.resolve({ results: [{ hits: [] }] }));
 
 describe('createInstantSearchManager', () => {
   describe('with correct result from algolia', () => {
     describe('on widget lifecycle', () => {
       it('updates the store and searches', () => {
+        expect.assertions(7);
+
         const _dispatchAlgoliaResponse = jest.fn(function(state) {
           this.emit('result', { value: 'results' }, state);
         });
@@ -77,6 +78,8 @@ describe('createInstantSearchManager', () => {
 
     describe('on external updates', () => {
       it('updates the store and searches', () => {
+        expect.assertions(7);
+
         const _dispatchAlgoliaResponse = jest.fn(function(state) {
           this.emit('result', { value: 'results' }, state);
         });
@@ -121,6 +124,8 @@ describe('createInstantSearchManager', () => {
 
     describe('on search for facet values', () => {
       it('updates the store and searches', () => {
+        expect.assertions(4);
+
         const searchForFacetValues = jest.fn(() =>
           Promise.resolve({
             facetHits: 'results',
@@ -165,6 +170,8 @@ describe('createInstantSearchManager', () => {
       });
 
       it('updates the store and searches with maxFacetHits', () => {
+        expect.assertions(4);
+
         const searchForFacetValues = jest.fn(() =>
           Promise.resolve({
             facetHits: 'results',

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
@@ -20,6 +20,7 @@ jest.mock('algoliasearch-helper', () => {
 });
 
 const client = algoliaClient('latency', '249078a3d4337a8231f1665ec5a44966');
+client.addAlgoliaAgent = () => {};
 client.search = jest.fn(() => Promise.resolve({ results: [{ hits: [] }] }));
 
 describe('createInstantSearchManager', () => {

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
@@ -21,21 +21,7 @@ jest.mock('algoliasearch-helper', () => {
 
 const client = algoliaClient('latency', '249078a3d4337a8231f1665ec5a44966');
 client.addAlgoliaAgent = () => {};
-client.search = jest.fn((queries, cb) => {
-  if (cb) {
-    setImmediate(() => {
-      // We do not care about the returned values because we also control how
-      // it will handle in the helper
-      cb(null, null);
-    });
-    return undefined;
-  }
-
-  return new Promise(resolve => {
-    // cf comment above
-    resolve(null);
-  });
-});
+client.search = jest.fn(() => Promise.resolve({ results: [{ hits: [] }] }));
 
 describe('createInstantSearchManager', () => {
   describe('with correct result from algolia', () => {
@@ -69,19 +55,18 @@ describe('createInstantSearchManager', () => {
         expect(ism.store.getState().results).toBe(null);
 
         return Promise.resolve()
+          .then(() => {}) // Simulate next tick
           .then(() => {
-            jest.runAllTimers();
-
             const store = ism.store.getState();
+
             expect(_dispatchAlgoliaResponse).toHaveBeenCalledTimes(1);
             expect(store.results).toEqual({ value: 'results' });
             expect(store.error).toBe(null);
 
             ism.widgetsManager.update();
           })
+          .then(() => {})
           .then(() => {
-            jest.runAllTimers();
-
             const store = ism.store.getState();
             expect(_dispatchAlgoliaResponse).toHaveBeenCalledTimes(2);
             expect(store.results).toEqual({ value: 'results' });
@@ -117,8 +102,6 @@ describe('createInstantSearchManager', () => {
 
         return Promise.resolve()
           .then(() => {
-            jest.runAllTimers();
-
             const store = ism.store.getState();
             expect(_dispatchAlgoliaResponse).toHaveBeenCalledTimes(1);
             expect(store.results).toEqual({ value: 'results' });
@@ -126,9 +109,8 @@ describe('createInstantSearchManager', () => {
 
             ism.widgetsManager.update();
           })
+          .then(() => {})
           .then(() => {
-            jest.runAllTimers();
-
             const store = ism.store.getState();
             expect(_dispatchAlgoliaResponse).toHaveBeenCalledTimes(2);
             expect(store.results).toEqual({ value: 'results' });
@@ -163,8 +145,6 @@ describe('createInstantSearchManager', () => {
         ism.onSearchForFacetValues({ facetName: 'facetName', query: 'query' });
 
         expect(ism.store.getState().results).toBe(null);
-
-        jest.runAllTimers();
 
         return Promise.resolve().then(() => {
           const store = ism.store.getState();
@@ -213,8 +193,6 @@ describe('createInstantSearchManager', () => {
         });
 
         expect(ism.store.getState().results).toBe(null);
-
-        jest.runAllTimers();
 
         return Promise.resolve().then(() => {
           const store = ism.store.getState();

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
@@ -157,6 +157,8 @@ describe('createInstantSearchManager', () => {
 
   describe('Loading state', () => {
     it('should be updated if search is stalled', () => {
+      expect.assertions(10);
+
       const managedClient = makeManagedClient();
       const ism = createInstantSearchManager({
         indexName: 'index',
@@ -227,6 +229,8 @@ describe('createInstantSearchManager', () => {
 
   describe('client.search', () => {
     it('should be called when there is a new widget', () => {
+      expect.assertions(2);
+
       const client0 = makeClient(defaultResponse());
       expect(client0.search).toHaveBeenCalledTimes(0);
       const ism = createInstantSearchManager({
@@ -247,6 +251,8 @@ describe('createInstantSearchManager', () => {
     });
 
     it('should be called when there is a new client', () => {
+      expect.assertions(4);
+
       const client0 = makeClient(defaultResponse());
       expect(client0.search).toHaveBeenCalledTimes(0);
 
@@ -268,6 +274,8 @@ describe('createInstantSearchManager', () => {
       });
     });
     it('should not be called when the search is skipped', () => {
+      expect.assertions(2);
+
       const client0 = makeClient(defaultResponse());
       expect(client0.search).toHaveBeenCalledTimes(0);
       const ism = createInstantSearchManager({

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
@@ -72,7 +72,7 @@ describe('createInstantSearchManager', () => {
   });
 
   describe('Widget manager', () => {
-    it('triggers the search when a widget is added', done => {
+    it('triggers the search when a widget is added', () => {
       expect.assertions(2);
 
       const ism = createInstantSearchManager({
@@ -93,10 +93,9 @@ describe('createInstantSearchManager', () => {
       const storeT0 = ism.store.getState();
       expect(storeT0.searching).toBe(false);
 
-      setImmediate(() => {
+      return Promise.resolve().then(() => {
         const storeT1 = ism.store.getState();
         expect(storeT1.searching).toBe(true);
-        done();
       });
     });
   });
@@ -190,7 +189,6 @@ describe('createInstantSearchManager', () => {
             isSearchStalled: true,
           });
 
-          managedClient.searchResultsResolvers[0]();
           return managedClient.searchResultsPromises[0];
         })
         .then(() => {
@@ -217,7 +215,6 @@ describe('createInstantSearchManager', () => {
             isSearchStalled: true,
           });
 
-          managedClient.searchResultsResolvers[1]();
           return managedClient.searchResultsPromises[1];
         })
         .then(() => {
@@ -300,38 +297,24 @@ function makeClient(response) {
     '249078a3d4337a8231f1665ec5a44966'
   );
   clientInstance.addAlgoliaAgent = () => {};
-  clientInstance.search = jest.fn((queries, cb) => {
+  clientInstance.search = jest.fn(() => {
     const clonedResponse = JSON.parse(JSON.stringify(response));
-    if (cb) {
-      setTimeout(() => {
-        cb(null, clonedResponse);
-      }, 1);
-      return undefined;
-    }
-
-    return new Promise(resolve => {
-      resolve(clonedResponse);
-    });
+    return Promise.resolve(clonedResponse);
   });
 
   return clientInstance;
 }
 
 function makeManagedClient() {
-  const searchResultsResolvers = [];
   const searchResultsPromises = [];
   const fakeClient = {
-    search: jest.fn((qs, cb) => {
-      const p = new Promise(resolve =>
-        searchResultsResolvers.push(resolve)
-      ).then(() => {
-        cb(null, defaultResponse());
-      });
-      searchResultsPromises.push(p);
+    search: jest.fn(() => {
+      const results = Promise.resolve(defaultResponse());
+      searchResultsPromises.push(results);
+      return results;
     }),
     addAlgoliaAgent: () => {},
     searchResultsPromises,
-    searchResultsResolvers,
   };
 
   return fakeClient;

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,18 +989,18 @@ algolia-frontend-components@0.0.34:
     webpack "^2.2.1"
     webpack-dev-server "^2.4.1"
 
-algoliasearch-helper@^2.21.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.24.0.tgz#6ebf91683a82799bc4019ee1ad92d0ad0f41167b"
+algoliasearch-helper@^2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.26.0.tgz#cb784b692a5aacf17062493cb0b94f6d60d30d0f"
   dependencies:
-    events "^1.1.0"
-    lodash "^4.13.1"
-    qs "^6.2.1"
+    events "^1.1.1"
+    lodash "^4.17.5"
+    qs "^6.5.1"
     util "^0.10.3"
 
-algoliasearch@^3.24.0:
-  version "3.26.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.26.0.tgz#5059cfe4b049ae1a1b9b7c25f5dbd3e75db6126a"
+algoliasearch@^3.27.1:
+  version "3.27.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.27.1.tgz#e1af42b97dbf44a2dd3a8c907be99c0c34e48414"
   dependencies:
     agentkeepalive "^2.2.0"
     debug "^2.6.8"
@@ -11050,7 +11050,7 @@ qs@6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.3.tgz#1cfcb25c10a9b2b483053ff39f5dfc9233908cfe"
 
-qs@6.5.1, qs@^6.2.1, qs@^6.5.1, qs@~6.5.1:
+qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 


### PR DESCRIPTION
This PR upgrades to `algoliasearch@3.27.1` and `algoliasearch-helper@2.26.0`, using the promisified version of `client.search()`. It is necessary for adding `searchClient` support to React InstantSearch.

I had to update the tests with a not-so-great hack because of the way we internally handle search with promises now:

```javascript
Promise.resolve()
  .then(() => {})
  .then(() => {
    // test...
  });
```