### PR TITLE
feat(geo): add stories [PART-9]

### DIFF
--- a/docgen/src/stylesheets/components/_documentation.sass
+++ b/docgen/src/stylesheets/components/_documentation.sass
@@ -3,7 +3,7 @@ $offset-height: 60px
 
 .documentation-section,
 .examples-section
-  padding-bottom: 300px
+  padding-bottom: 320px
 
   .container
     article
@@ -136,7 +136,6 @@ $offset-height: 60px
       background: #fff
       border: 1px solid #d8d8d8
       border-radius: 2px 2px 0 0
-      margin: -8px 0 0
       padding: 0.75em 1em
       font-family: $paragraphs-font-family
       border-radius: 6px 6px 0 0
@@ -201,6 +200,10 @@ $offset-height: 60px
         display: block
         height: $offset-height
         // margin: (-$offset-height) 0 0
+
+    .sub-component-title
+      &:before
+        height: 10px
 
     .anchor
       margin-left: .2em

--- a/docgen/src/widgets/GeoSearch.md
+++ b/docgen/src/widgets/GeoSearch.md
@@ -1,0 +1,735 @@
+---
+mainTitle: Widgets
+title: GeoSearch
+layout: widget.pug
+category: widget
+showInNav: true
+navWeight: 0
+external: true
+---
+
+## Description
+
+The `GeoSearch` widget displays the list of results from the search on a Google Maps. It also provides a way to search for results based on their position. The widget provides some of the common GeoSearch patterns like search on map interaction.
+
+<div class="storybook-section">
+  <a class="btn btn-cta" href="https://community.algolia.com/react-instantsearch/storybook?selectedKind=GeoSearch&selectedStory=default" target="_blank">
+    See live example
+  </a>
+</div>
+
+## Requirements
+
+The API of this widget is a bit different than the others that you can find in React InstantSearch. The API is component driven rather than options driven. We chose the former because it brings more flexibility to the widget. Since the geo search pattern is not a use case for every applications we decided to ship the widget in a separate package. Be sure to install it before using it:
+
+```shell
+yarn add react-instantsearch-dom-maps
+```
+
+The GeoSearch widget uses the [geo search](https://www.algolia.com/doc/guides/searching/geo-search) capabilities of Algolia. Your hits **must** have a `_geoloc` attribute in order to be available in the render prop.
+
+Currently, the feature is not compatible with multiple values in the `_geoloc` attribute (e.g. a restaurant with multiple locations). In that case you can duplicate your records and use the [distinct](https://www.algolia.com/doc/guides/ranking/distinct) feature of Algolia to only retrieve unique results.
+
+You are also responsible for loading the Google Maps library. We provide a component to load the library ([`<GoogleMapsLoader />`](/widgets/GeoSearch.html#googlemapsloader)) but its usage **is not required to use the geo widget**. You can use any strategy you want to load Google Maps. You can find more informations about that in [the Google Maps documentation](https://developers.google.com/maps/documentation/javascript/tutorial).
+
+Don’t forget to explicitly set the `height` of the map container, otherwise it won’t be shown (it’s a requirement of Google Maps).
+
+## Example
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GoogleMapsLoader, GeoSearch, Control, Marker } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <div style={{ height: 500 }}>
+      <GoogleMapsLoader apiKey="GOOGLE_MAPS_API_KEY">
+        {google => (
+          <GeoSearch google={google}>
+            {({ hits }) => (
+              <div>
+                <Control />
+
+                {hits.map(hit => (
+                  <Marker key={hit.objectID} hit={hit} />
+                ))}
+              </div>
+            )}
+          </GeoSearch>
+        )}
+      </GoogleMapsLoader>
+    </div>
+  </InstantSearch>
+);
+```
+
+## `<GeoSearch />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component provides the `hits` to display. All the other geo components need to be nested under it.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        // render the hits
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>google*</td>
+      <td>Type: <code>object</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Reference to the global window.google object. See <a href="https://developers.google.com/maps/documentation/javascript/tutorial" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>children*</td>
+      <td>Type: <code>({ hits: object[] }) => React.ReactNode</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          The render function takes an object as argument with the <code>hits</code> inside.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>initialZoom</td>
+      <td>Type: <code>number</code></td>
+      <td>Default: <code>1</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>By default the map will set the zoom accordingly to the markers displayed on it. When we refine it may happen that the results are empty. For those situations we need to provide a zoom to render the map.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>initialPosition</td>
+      <td>Type: <code>{ lat: number, lng: number }</code></td>
+      <td>Default: <code>{ lat: 0, lng: 0 }</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>By default the map will set the position accordingly to the markers displayed on it. When we refine it may happen that the results are empty. For those situations we need to provide a position to render the map.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+This component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+This component has no translations.
+
+## `<Marker />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component is a wapper around [`google.maps.Marker`](https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#MarkerOptions), all the options avaible on the Marker class can be provided as props. This component cannot render any children components. See [`<CustomMarker />`](/widgets/GeoSearch.html#custommarker) for this behaviour.
+
+Currently the component does not support the update of the options. Once the component is rendered changing the props won't update the marker options.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, Marker } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <div>
+          {hits.map(hit => (
+            <Marker key={hit.objectID} hit={hit} />
+          ))}
+        </div>
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>hit*</td>
+      <td>Type: <code>object</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Hit to attach on the marker.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the marker icon was clicked, see <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.click" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onDoubleClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the marker icon was double clicked, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.dblclick" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseDown</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired for a mousedown on the marker, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mousedown" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOut</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the mouse leaves the area of the marker icon, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mouseout" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOver</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired when the mouse enters the area of the marker icon, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mouseover" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseUp</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>This event is fired for a mouseup on the marker, <a href="https://developers.google.com/maps/documentation/javascript/reference/3.exp/marker#Marker.mouseup" target="_blank" rel="noopener">the documentation</a> for more information.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+This component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+This component has no translations.
+
+## `<CustomMarker />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component is an alternative to [`<Marker />`](/widgets/GeoSearch.html#marker). In some cases you may want to have the full control of the marker rendering. You can provide any React components to design your custom marker.
+
+Currently the component does not support the update of the options. Once the component is rendered changing the props won't update the marker options.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, CustomMarker } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <div>
+          {hits.map(hit => (
+            <CustomMarker key={hit.objectID} hit={hit}>
+              <span>{hit.price}</span>
+            </CustomMarker>
+          ))}
+        </div>
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>hit*</td>
+      <td>Type: <code>object</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Hit to attach on the marker.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>className</td>
+      <td>Type: <code>string</code></td>
+      <td><code>''</<code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>The className to add on the marker wrapper element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>anchor</td>
+      <td>Type: <code>{ x: number, y: number }</code></td>
+      <td><code>{ x: 0, y: 0 }</<code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Offset for the marker element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onDoubleClick</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseDown</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseEnter</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseLeave</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseMove</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOut</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseOver</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>onMouseUp</td>
+      <td>Type: <code>function</code></td>
+      <td>-</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>Standard DOM event.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+This component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+This component has no translations.
+
+## `<Control />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component allows the user to control the different strategy for the refinement (enable / disable refine on map move).
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, Control } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <Control />
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>enableRefineOnMapMove</td>
+      <td>Type: <code>boolean</code></td>
+      <td>Default: <code>true</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>If true, refine will be triggered as you move the map.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>.ais-GeoSearch-control {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The control element of the widget.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-label {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the control element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-input {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The input of the control element.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-redo {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The redo search button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>control</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the radio button.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>redo</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the redo button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## `<Redo />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component disable the refine on map move behaviour.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GeoSearch, Redo } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GeoSearch google={window.google}>
+      {({ hits }) => (
+        <Redo />
+      )}
+    </GeoSearch>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+The component has no props.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>.ais-GeoSearch-control {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The control element of the widget.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-redo {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The redo search button.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>.ais-GeoSearch-redo--disabled {}</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The disabled redo search button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>redo</td>
+    </tr>
+    <tr>
+      <td>
+        <p>The label of the redo button.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## `<GoogleMapsLoader />`
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Decription</h3>
+
+This component provide a built-in solution to load the `google.maps` library in your application. Its usage is completely optional. You can use any strategy you want to load the library. You can find more informations about that in [the Google Maps documentation](https://developers.google.com/maps/documentation/javascript/tutorial).
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Usage</h3>
+
+```jsx
+import { InstantSearch } from 'react-instantsearch-dom';
+import { GoogleMapsLoader, GeoSearch } from 'react-instantsearch-dom-maps';
+
+const App = () => (
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+  >
+    <GoogleMapsLoader apiKey="GOOGLE_MAPS_API_KEY">
+      {google => (
+        <GeoSearch google={google}>
+          {({ hits }) => (
+            <Redo />
+          )}
+        </GeoSearch>
+      )}
+    </GoogleMapsLoader>
+  </InstantSearch>
+);
+```
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Props</h3>
+
+<table class="api">
+  <tbody>
+    <tr>
+      <td>apiKey*</td>
+      <td>Type: <code>string</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          Your Google API Key in case you don't have one you can create it on <a href="https://developers.google.com/maps/documentation/javascript/get-api-key" target="_blank" rel="noopener">the Google documentation</a>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>children*</td>
+      <td>Type: <code>(google: object) => React.ReactNode</code></td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          The render function that takes the <code>google</code> object as argument.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>endpoint</td>
+      <td>Type: <code>string</code></td>
+      <td>Default: <code>https://maps.googleapis.com/maps/api/js?v=3.31</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>
+          Endpoint that will be used to fetch the Google Maps library, can be used to load a different version, libraries, ... You can find more inforamtion <a href="https://developers.google.com/maps/documentation/javascript/libraries" target="_blank" rel="noopener">in the Google documentation</a>.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">CSS classes</h3>
+
+The component has no CSS classes.
+
+<!-- Avoid the huge margin on the pseudo element -->
+<h3 class="sub-component-title">Translation keys</h3>
+
+The component has no translations keys.

--- a/packages/react-instantsearch-dom-geo/package.json
+++ b/packages/react-instantsearch-dom-geo/package.json
@@ -2,7 +2,7 @@
   "name": "react-instantsearch-dom-maps",
   "private": true,
   "version": "5.2.0-beta.2",
-  "description": "⚡ Lightning-fast search for Google Maps, by Algolia",
+  "description": "⚡ Lightning-fast search for React DOM & Google Maps, by Algolia",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "sideEffects": false,

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { setAddon, storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import JSXAddon from 'storybook-addon-jsx';
-import { Configure } from 'react-instantsearch-dom';
+import { Configure, Highlight, connectHits } from 'react-instantsearch-dom';
 import {
   GoogleMapsLoader,
   GeoSearch,
@@ -382,6 +382,104 @@ stories
       filterProps,
     }
   );
+
+stories.addWithJSX('with hits communication (custom)', () => {
+  const CustomHits = connectHits(({ hits, selectedHit, onHitOver }) => (
+    <div className="hits">
+      {hits.map(hit => {
+        const classNames = [
+          'hit',
+          'hit--airbnb',
+          selectedHit && selectedHit.objectID === hit.objectID
+            ? 'hit--airbnb-active'
+            : '',
+        ];
+
+        return (
+          <div
+            key={hit.objectID}
+            className={classNames.join(' ').trim()}
+            onMouseEnter={() => onHitOver(hit)}
+            onMouseLeave={() => onHitOver(null)}
+          >
+            <div className="hit-content">
+              <div>
+                <Highlight attribute="name" hit={hit} />
+                <span> - ${hit.price}</span>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  ));
+
+  class Example extends Component {
+    state = {
+      selectedHit: null,
+    };
+
+    onHitOver = hit =>
+      this.setState(() => ({
+        selectedHit: hit,
+      }));
+
+    renderGeoHit = hit => {
+      const { selectedHit } = this.state;
+
+      const classNames = [
+        'my-custom-marker',
+        selectedHit && selectedHit.objectID === hit.objectID
+          ? 'my-custom-marker--active'
+          : '',
+      ];
+
+      return (
+        <CustomMarker
+          key={hit.objectID}
+          hit={hit}
+          anchor={{ x: 0, y: 5 }}
+          onMouseEnter={() => this.onHitOver(hit)}
+          onMouseLeave={() => this.onHitOver(null)}
+        >
+          <div className={classNames.join(' ').trim()}>
+            <span>{hit.price_formatted}</span>
+          </div>
+        </CustomMarker>
+      );
+    };
+
+    render() {
+      const { selectedHit } = this.state;
+
+      return (
+        <WrapWithHits
+          indexName="airbnb"
+          linkedStoryGroup="GeoSearch"
+          hitsElement={
+            <CustomHits selectedHit={selectedHit} onHitOver={this.onHitOver} />
+          }
+        >
+          <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+          <Container>
+            <GoogleMapsLoader apiKey={apiKey}>
+              {google => (
+                <GeoSearch google={google}>
+                  {({ hits }) => (
+                    <Fragment>{hits.map(this.renderGeoHit)}</Fragment>
+                  )}
+                </GeoSearch>
+              )}
+            </GoogleMapsLoader>
+          </Container>
+        </WrapWithHits>
+      );
+    }
+  }
+
+  return <Example />;
+});
 
 stories.addWithJSX('with unmount', () => {
   class Example extends Component {

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -383,6 +383,62 @@ stories
     }
   );
 
+stories.addWithJSX('with InfoWindow', () => {
+  class Example extends Component {
+    static propTypes = {
+      google: PropTypes.object.isRequired,
+    };
+
+    InfoWindow = new this.props.google.maps.InfoWindow();
+
+    onClickMarker = ({ hit, marker }) => {
+      if (this.InfoWindow.getMap()) {
+        this.InfoWindow.close();
+      }
+
+      this.InfoWindow.setContent(hit.name);
+
+      this.InfoWindow.open(marker.getMap(), marker);
+    };
+
+    renderGeoHit = hit => (
+      <Marker
+        key={hit.objectID}
+        hit={hit}
+        anchor={{ x: 0, y: 5 }}
+        onClick={({ marker }) => {
+          this.onClickMarker({
+            hit,
+            marker,
+          });
+        }}
+      />
+    );
+
+    render() {
+      const { google } = this.props;
+
+      return (
+        <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+          <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+          <Container>
+            <GeoSearch google={google}>
+              {({ hits }) => <Fragment>{hits.map(this.renderGeoHit)}</Fragment>}
+            </GeoSearch>
+          </Container>
+        </WrapWithHits>
+      );
+    }
+  }
+
+  return (
+    <GoogleMapsLoader apiKey={apiKey}>
+      {google => <Example google={google} />}
+    </GoogleMapsLoader>
+  );
+});
+
 stories.addWithJSX('with hits communication (custom)', () => {
   const CustomHits = connectHits(({ hits, selectedHit, onHitOver }) => (
     <div className="hits">

--- a/stories/util.js
+++ b/stories/util.js
@@ -74,6 +74,7 @@ export const WrapWithHits = ({
   appId,
   apiKey,
   indexName,
+  hitsElement,
 }) => {
   const sourceCodeUrl = `https://github.com/algolia/react-instantsearch/tree/master/stories/${linkedStoryGroup}.stories.js`;
   const playgroundLink = hasPlayground ? (
@@ -93,6 +94,8 @@ export const WrapWithHits = ({
       </a>
     </div>
   ) : null;
+
+  const hits = hitsElement || <CustomHits />;
 
   const searchParameters = {
     hitsPerPage: 3,
@@ -120,7 +123,7 @@ export const WrapWithHits = ({
               ) : null}
               <ClearRefinements translations={{ reset: 'Clear all filters' }} />
             </div>
-            <CustomHits />
+            {hits}
             <div className="hit-pagination">
               {pagination ? <Pagination showLast={true} /> : null}
             </div>
@@ -142,6 +145,7 @@ WrapWithHits.propTypes = {
   hasPlayground: PropTypes.bool,
   pagination: PropTypes.bool,
   searchParameters: PropTypes.object,
+  hitsElement: PropTypes.element,
 };
 
 // defaultProps added so that they're displayed in the JSX addon

--- a/storybook/public/util.css
+++ b/storybook/public/util.css
@@ -99,9 +99,15 @@
 }
 
 .hit {
-  margin: 10px 10px;
+  padding: 5px 5px;
   display: flex;
   align-items: center;
+}
+
+.hit--airbnb:hover,
+.hit--airbnb-active {
+  background-color: #3369e7;
+  color: #ffffff;
 }
 
 .ais-SearchBox__root {


### PR DESCRIPTION
**Summary**

This is PR adds two stories:

- how to implement communication between the hits & the map
- how to implement an `InfoWindow` with markers

This PR also introduce an option to render a custom Hits component with `<WrapWithHits />`. It's a bit hard to extend the wrapper component with the current implementation. In the upcoming months, it might worth it to have a more coherent showcase cross InstantSearch flavors.

**Result**

You can use them in [Storybook](https://deploy-preview-1236--react-instantsearch.netlify.com/react-instantsearch/storybook/?selectedKind=GeoSearch&selectedStory=with%20InfoWindow&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs).