### PR TITLE
fix(indexUtils): avoid throw an error on cleanUp multi indices

### DIFF
--- a/packages/react-instantsearch/src/core/indexUtils.js
+++ b/packages/react-instantsearch/src/core/indexUtils.js
@@ -187,31 +187,64 @@ export function getCurrentRefinementValue(
 }
 
 export function cleanUpValue(searchState, context, id) {
-  const index = getIndex(context);
+  const indexName = getIndex(context);
   const { namespace, attributeName } = getNamespaceAndAttributeName(id);
+
   if (hasMultipleIndex(context) && Boolean(searchState.indices)) {
-    const searchStateIndex = searchState.indices[index];
-    return namespace && searchStateIndex
-      ? {
-          ...searchState,
-          indices: {
-            ...searchState.indices,
-            [index]: {
-              ...searchStateIndex,
-              [namespace]: omit(
-                searchStateIndex[namespace],
-                `${attributeName}`
-              ),
-            },
-          },
-        }
-      : omit(searchState, `indices.${index}.${id}`);
-  } else {
-    return namespace
-      ? {
-          ...searchState,
-          [namespace]: omit(searchState[namespace], `${attributeName}`),
-        }
-      : omit(searchState, `${id}`);
+    return cleanUpValueWithMutliIndex({
+      attribute: attributeName,
+      searchState,
+      indexName,
+      id,
+      namespace,
+    });
   }
+
+  return cleanUpValueWithSingleIndex({
+    attribute: attributeName,
+    searchState,
+    id,
+    namespace,
+  });
+}
+
+function cleanUpValueWithSingleIndex({
+  searchState,
+  id,
+  namespace,
+  attribute,
+}) {
+  if (namespace) {
+    return {
+      ...searchState,
+      [namespace]: omit(searchState[namespace], attribute),
+    };
+  }
+
+  return omit(searchState, id);
+}
+
+function cleanUpValueWithMutliIndex({
+  searchState,
+  indexName,
+  id,
+  namespace,
+  attribute,
+}) {
+  const index = searchState.indices[indexName];
+
+  if (namespace && index) {
+    return {
+      ...searchState,
+      indices: {
+        ...searchState.indices,
+        [indexName]: {
+          ...index,
+          [namespace]: omit(index[namespace], attribute),
+        },
+      },
+    };
+  }
+
+  return omit(searchState, `indices.${indexName}.${id}`);
 }

--- a/packages/react-instantsearch/src/core/indexUtils.js
+++ b/packages/react-instantsearch/src/core/indexUtils.js
@@ -190,15 +190,16 @@ export function cleanUpValue(searchState, context, id) {
   const index = getIndex(context);
   const { namespace, attributeName } = getNamespaceAndAttributeName(id);
   if (hasMultipleIndex(context) && Boolean(searchState.indices)) {
-    return namespace
+    const searchStateIndex = searchState.indices[index];
+    return namespace && searchStateIndex
       ? {
           ...searchState,
           indices: {
             ...searchState.indices,
             [index]: {
-              ...searchState.indices[index],
+              ...searchStateIndex,
               [namespace]: omit(
-                searchState.indices[index][namespace],
+                searchStateIndex[namespace],
                 `${attributeName}`
               ),
             },

--- a/packages/react-instantsearch/src/core/indexUtils.test.js
+++ b/packages/react-instantsearch/src/core/indexUtils.test.js
@@ -511,6 +511,29 @@ describe('utility method for manipulating the search state', () => {
         page: 1,
         namespace: {},
       });
+
+      // It might happen that we try to cleanUp an index that is not
+      // present on the searchState. We should not throw an error in
+      // that case, just return the searchState as it is.
+      searchState = {
+        page: 1,
+        indices: {
+          second: {
+            page: 1,
+          },
+        },
+      };
+
+      searchState = cleanUpValue(searchState, context, 'menu.category');
+
+      expect(searchState).toEqual({
+        page: 1,
+        indices: {
+          second: {
+            page: 1,
+          },
+        },
+      });
     });
 
     it('get results', () => {


### PR DESCRIPTION
**Summary**

The PR solve an issue when we try to clean up a index that is not in the searchState. It might happen with a multi indices configuration. You can take look at [this example](https://xp4wll1rlq.codesandbox.io/?doctype=wiki) for more context (switch on the Wikis tabs). 

Now, we make sure that the index exists on the `searchState` before trying to remove the value. You can take a look at [this commit](https://github.com/algolia/react-instantsearch/commit/8770cbd8539ae7552820f28924f753b45d6faba1) for the fix.

I also rewrite a bit the function that handle the clean up. Instead of relying on one function we now have two function dedicated to the single / multi index. I found a bit hard to follow the code with the extended ternaries. I replaced them with early returns.