### PR TITLE
fix(material): use onClick instead of onTouchTap

### DIFF
--- a/docgen/src/examples/material-ui/App.js
+++ b/docgen/src/examples/material-ui/App.js
@@ -348,7 +348,7 @@ function CustomHits({ hits, marginLeft, hasMore, refine }) {
       </main>
       <div style={{ display: 'flex', justifyContent: 'center' }}>
         <RaisedButton
-          onTouchTap={() => {
+          onClick={() => {
             if (hasMore) {
               refine();
             }


### PR DESCRIPTION
**Summary**

The `onTouchTap` seems to not be supported anymore. I looked at some code and examples I only find samples with `onClick`. 

**Before**

![before](https://user-images.githubusercontent.com/6513513/40615599-b831d4fe-6287-11e8-818b-58033b9d2795.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/40615618-cc922070-6287-11e8-866a-9fe748fa1b07.gif)