### PR TITLE
chore: setup Jest Watch Typeahead

### DIFF
--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -50,6 +50,7 @@
     "enzyme-adapter-react-16": "1.1.1",
     "enzyme-to-json": "3.3.4",
     "jest": "23.0.1",
+    "jest-watch-typeahead": "0.1.0",
     "react": "16.4.0",
     "react-dom": "16.4.0",
     "react-native": "0.54.2",
@@ -66,6 +67,10 @@
   "jest": {
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
+    ],
+    "watchPlugins": [
+      "jest-watch-typeahead/filename",
+      "jest-watch-typeahead/testname"
     ]
   },
   "bundlesize": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3495,7 +3495,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.4.1:
+chalk@^2.3.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -8150,6 +8150,17 @@ jest-validate@^23.0.1:
     jest-get-type "^22.1.0"
     leven "^2.1.0"
     pretty-format "^23.0.1"
+
+jest-watch-typeahead@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-0.1.0.tgz#16b6cfe087fc7f181daadea5abeb68a0fcc70eac"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.3.1"
+    lodash "4.17.5"
+    slash "^1.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^4.0.0"
 
 jest-worker@22.2.2:
   version "22.2.2"


### PR DESCRIPTION
**Summary**

It brings back typeahead to Jest!

**Results**

![screen shot 2018-05-31 at 11 47 19](https://user-images.githubusercontent.com/6513513/40775512-8d89c93a-64c8-11e8-9053-c8d98247a93c.png)
