### PR TITLE
fix(material): use onClick rather than onTouchTap

### DIFF
--- a/docgen/src/examples/material-ui/App.js
+++ b/docgen/src/examples/material-ui/App.js
@@ -164,7 +164,7 @@ const MaterialUiSearchBox = ({ currentRefinement, refine }) => {
     <FontIcon
       style={{ color: 'lightgrey' }}
       className="material-icons"
-      onTouchTap={() => refine('')}
+      onClick={() => refine('')}
     >
       {' '}
       clear{' '}
@@ -277,8 +277,7 @@ class MaterialUiSortBy extends React.Component {
             key={item.value}
             value={item.value}
             primaryText={item.label}
-            onTouchTap={e => {
-              e.preventDefault();
+            onClick={() => {
               this.props.refine(item.value);
             }}
           />
@@ -366,7 +365,7 @@ function CustomHits({ hits, marginLeft, hasMore, refine }) {
 function MaterialUiClearAllFilters({ items, refine }) {
   return (
     <FlatButton
-      onTouchTap={() => refine(items)}
+      onClick={() => refine(items)}
       label="Clear All"
       primary
       style={{ height: 48, width: '100%' }}


### PR DESCRIPTION
**Summary**

In a recent [PR](https://github.com/algolia/react-instantsearch/pull/1280) we updated the event handler for the "Load more" button but we missed some of the other button that still use the wrong callback.
