### PR TITLE
chore(release): explicitly pass a version on Yarn publish

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -36,8 +36,8 @@
     "build:umd": "BABEL_ENV=es rollup -c rollup.config.js",
     "test": "jest",
     "test:size": "bundlesize",
-    "release": "yarn clean && yarn build && yarn publish",
-    "release:beta": "yarn clean && yarn build && yarn publish --tag beta"
+    "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
+    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
   },
   "dependencies": {
     "algoliasearch-helper": "^2.26.0",

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -37,8 +37,8 @@
     "build:umd": "BABEL_ENV=es rollup -c rollup.config.js",
     "test": "jest",
     "test:size": "bundlesize",
-    "release": "yarn clean && yarn build && yarn publish",
-    "release:beta": "yarn clean && yarn build && yarn publish --tag beta"
+    "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
+    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
   },
   "dependencies": {
     "algoliasearch": "^3.27.1",

--- a/packages/react-instantsearch-native/package.json
+++ b/packages/react-instantsearch-native/package.json
@@ -35,8 +35,8 @@
     "build:cjs": "babel src --out-dir dist/cjs --ignore __tests__,__mocks__ --quiet",
     "build:es": "BABEL_ENV=es babel src --out-dir dist/es --ignore __tests__,__mocks__ --quiet",
     "test": "jest",
-    "release": "yarn clean && yarn build && yarn publish",
-    "release:beta": "yarn clean && yarn build && yarn publish --tag beta"
+    "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
+    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
   },
   "dependencies": {
     "algoliasearch": "^3.27.1",

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -34,8 +34,8 @@
     "test": "jest",
     "test:size": "bundlesize",
     "preparePackageFolder": "mkdir -p dist && cp {package.json,README.md} dist",
-    "release": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish",
-    "release:beta": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish --tag beta"
+    "release": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish --new-version $VERSION",
+    "release:beta": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish --tag beta --new-version $VERSION"
   },
   "dependencies": {
     "react-instantsearch-core": "^5.2.0-beta.0",


### PR DESCRIPTION
**Summary**

When we don't provide an explicit version to `yarn publish` the CLI will prompt the user to select the next version to publish. In our case we already knew which version we want to use. We can use the `--new-version` flag to provide the argument.