### PR TITLE
chore: update react-instantsearch-dom version on top level package

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react": "16.4.0",
     "react-autosuggest": "9.3.4",
     "react-dom": "16.4.0",
-    "react-instantsearch-dom": "5.1.0",
+    "react-instantsearch-dom": "5.2.0-beta.0",
     "react-native": "0.54.2",
     "rheostat": "2.2.0",
     "storybook-addon-a11y": "3.1.9",


### PR DESCRIPTION
**Summary**

We forgot to update the top level package with the release. This PR only fix the version for running the pending PRs on Travis. I will push a fix for the release script just after.