### PR TITLE
fix(dom): publish server file

### DIFF
--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -26,6 +26,7 @@
   ],
   "files": [
     "README.md",
+    "server.js",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
**Summary**

We forgot to publish the `server` file along with the `dist` folder. This file is required for the SSR when we do the following import:

```js
import { createInstantSearch } from 'react-instantsearch/server'
import { createInstantSearch } from 'react-instantsearch-dom/server' 
```

This PR adds the file to the list of files to publish.