### PR TITLE
feat: export highlight tags from DOM / native

### DIFF
--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -1,5 +1,6 @@
 // Core
 export { createConnector } from 'react-instantsearch-core';
+export { HIGHLIGHT_TAGS } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';

--- a/packages/react-instantsearch-native/src/index.js
+++ b/packages/react-instantsearch-native/src/index.js
@@ -1,5 +1,6 @@
 // Core
 export { createConnector } from 'react-instantsearch-core';
+export { HIGHLIGHT_TAGS } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';


### PR DESCRIPTION
**Summary**

In some cases you may want to have a very specific highlighting behaviour. For those use cases you will need to have access to the `highlighTag` set by React InstantSearch (see [Yarn website](https://github.com/yarnpkg/website/blob/2b0f1c8351cd6e338b450d2bb7b87acef0fa9179/js/src/lib/util.js#L107-L111)). You can still override the tags but it can be handy to use the one by default. Previously it was only exported by the `core` package. Now you can access this value directly from DOM & Native.

**Before:**

```jsx
// Only available through `core`
import { HIGHLIGHT_TAGS } from "react-instantsearch-core";
```

**After:**

```jsx
// Now available through `dom`
import { HIGHLIGHT_TAGS } from "react-instantsearch-dom";

// and `native`
import { HIGHLIGHT_TAGS } from "react-instantsearch-native";
```