### PR TITLE
feat(createInstantSearch): enable _useRequestCache

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearch.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearch.js
@@ -40,7 +40,10 @@ describe('createInstantSearch', () => {
     shallow(<CustomInstantSearch appId="app" apiKey="key" indexName="name" />);
 
     expect(algoliaClientFactory).toHaveBeenCalledTimes(1);
-    expect(algoliaClientFactory).toHaveBeenCalledWith('app', 'key');
+    expect(algoliaClientFactory).toHaveBeenCalledWith('app', 'key', {
+      _useRequestCache: true,
+    });
+
     expect(algoliaClient.addAlgoliaAgent).toHaveBeenCalledTimes(1);
     expect(algoliaClient.addAlgoliaAgent).toHaveBeenCalledWith(
       `react-instantsearch ${version}`

--- a/packages/react-instantsearch-core/src/core/createInstantSearch.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearch.js
@@ -61,7 +61,9 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
       this.client =
         this.props.searchClient ||
         this.props.algoliaClient ||
-        defaultAlgoliaClient(this.props.appId, this.props.apiKey);
+        defaultAlgoliaClient(this.props.appId, this.props.apiKey, {
+          _useRequestCache: true,
+        });
 
       if (typeof this.client.addAlgoliaAgent === 'function') {
         this.client.addAlgoliaAgent(`react-instantsearch ${version}`);


### PR DESCRIPTION
**Summary**

This PR enable the option `_useRequestCache` on the default client. It doesn't impact clients that don't support this option. We only apply the option on the default implementation not on the `searchClient`.