### PR TITLE
chore: fix bundlesize report

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:recipes": "./scripts/test:recipes.sh",
     "test:build": "yarn build && yarn test:size",
     "test:regressions": "webpack --config test/regressions/webpack.config.js && rm -rf test/screenshots && happo run && babel-node ./test/regressions/normalize.js",
-    "test:size": "lerna run test:size --scope react-* --parallel",
+    "test:size": "bundlesize",
     "argos": "argos upload test/screenshots --token $ARGOS_TOKEN || true",
     "dev": "jest --watch --bail",
     "docs:storybook-start": "start-storybook -p 6006 -c ./storybook -s ./storybook/public",
@@ -47,6 +47,7 @@
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
+    "bundlesize": "0.17.0",
     "conventional-changelog-cli": "2.0.1",
     "css-loader": "0.28.11",
     "doctoc": "1.3.1",
@@ -97,5 +98,27 @@
       "jest-watch-typeahead/filename",
       "jest-watch-typeahead/testname"
     ]
-  }
+  },
+  "bundlesize": [
+    {
+      "path": "packages/react-instantsearch/dist/umd/Core.min.js",
+      "maxSize": "8 kB"
+    },
+    {
+      "path": "packages/react-instantsearch/dist/umd/Connectors.min.js",
+      "maxSize": "40 kB"
+    },
+    {
+      "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
+      "maxSize": "63 kB"
+    },
+    {
+      "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
+      "maxSize": "40 kB"
+    },
+    {
+      "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
+      "maxSize": "63 kB"
+    }
+  ]
 }

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -77,11 +77,5 @@
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ]
-  },
-  "bundlesize": [
-    {
-      "path": "dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "40 kB"
-    }
-  ]
+  }
 }

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -35,7 +35,6 @@
     "build:es": "BABEL_ENV=es babel src --out-dir dist/es --ignore __tests__,__mocks__ --quiet",
     "build:umd": "BABEL_ENV=es rollup -c rollup.config.js",
     "test": "jest",
-    "test:size": "bundlesize",
     "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
     "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
   },
@@ -53,7 +52,6 @@
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
-    "bundlesize": "0.17.0",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "enzyme-to-json": "3.3.4",

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -37,7 +37,6 @@
     "build:es": "BABEL_ENV=es babel src --out-dir dist/es --ignore __tests__,__mocks__ --quiet",
     "build:umd": "BABEL_ENV=es rollup -c rollup.config.js",
     "test": "jest",
-    "test:size": "bundlesize",
     "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
     "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
   },
@@ -57,7 +56,6 @@
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
-    "bundlesize": "0.17.0",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "enzyme-to-json": "3.3.4",

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -82,11 +82,5 @@
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ]
-  },
-  "bundlesize": [
-    {
-      "path": "dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "63 kB"
-    }
-  ]
+  }
 }

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -64,19 +64,5 @@
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ]
-  },
-  "bundlesize": [
-    {
-      "path": "dist/umd/Core.min.js",
-      "maxSize": "8 kB"
-    },
-    {
-      "path": "dist/umd/Connectors.min.js",
-      "maxSize": "40 kB"
-    },
-    {
-      "path": "dist/umd/Dom.min.js",
-      "maxSize": "63 kB"
-    }
-  ]
+  }
 }

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -32,7 +32,6 @@
     "build:es": "BABEL_ENV=es babel connectors.js dom.js index.js native.js server.js --out-dir dist/es --quiet",
     "build:umd": "BABEL_ENV=es rollup -c rollup.config.js",
     "test": "jest",
-    "test:size": "bundlesize",
     "preparePackageFolder": "mkdir -p dist && cp {package.json,README.md} dist",
     "release": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish --new-version $VERSION",
     "release:beta": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish --tag beta --new-version $VERSION"
@@ -50,7 +49,6 @@
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
-    "bundlesize": "0.17.0",
     "rollup": "0.60.7",
     "rollup-plugin-babel": "3.0.4",
     "rollup-plugin-commonjs": "9.1.3",


### PR DESCRIPTION
**Summary**

The `bundlesize` report is broken on master because we run the command multiple times (one for each package). The CLI doesn't support this project structure. On the first run it built the report. The others commands might fail but they are not in the report. We also run the commands in parallel so the order is non deterministic. The package that is reported might change between different builds (see below).

This PR solve this issue by managing the `bundlesize` configuration on the root package. 

**Before**

![screen shot 2018-06-20 at 08 58 36](https://user-images.githubusercontent.com/6513513/41643139-b916efb8-746a-11e8-8e28-25e6c193242d.png)

![screen shot 2018-06-20 at 08 58 50](https://user-images.githubusercontent.com/6513513/41643143-bc99f2b6-746a-11e8-8607-feb69f99770f.png)

**After**

![screen shot 2018-06-20 at 09 28 47](https://user-images.githubusercontent.com/6513513/41643754-6389863a-746c-11e8-8081-bd44ddbdc8b4.png)