### PR TITLE
chore: limit worker on CI for Jest

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,7 +3,13 @@
 # cause test to fail if one fails
 set -e
 
-yarn jest
+# Jest is super slow on the CI machine. Limit the workers to speed up the tests
+# https://facebook.github.io/jest/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server
+if [ "$CI" = "true" ]
+  then jest --maxWorkers=4
+  else jest
+fi
+
 yarn lint
 yarn test:regressions
 yarn argos


### PR DESCRIPTION
**Summary**

Recently we dropped the condition for Jest on the CI. But now the tests on the CI are incredibly slow. On the [Jest documentation](https://facebook.github.io/jest/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server) there is informations about how to address this issue. I picked the second one since we are running on Travis.

- before: https://travis-ci.org/algolia/react-instantsearch/builds/394883907#L545-L634
- after: https://travis-ci.org/algolia/react-instantsearch/builds/394887493#L448-L538