### PR TITLE
fix(maps): avoid cascade update

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,5 +2,8 @@ module.exports = {
   extends: ['algolia/react', 'algolia/jest'],
   rules: {
     'no-param-reassign': 'off',
+    // Should be removed when the new verison of
+    // eslint-config-algolia is released (> 13.1.0)
+    'no-unused-vars': ['error', { ignoreRestSiblings: true }],
   },
 };

--- a/docgen/src/widgets/GeoSearch.md
+++ b/docgen/src/widgets/GeoSearch.md
@@ -496,20 +496,7 @@ const App = () => (
 <!-- Avoid the huge margin on the pseudo element -->
 <h3 class="sub-component-title">Props</h3>
 
-<table class="api">
-  <tbody>
-    <tr>
-      <td>enableRefineOnMapMove</td>
-      <td>Type: <code>boolean</code></td>
-      <td>Default: <code>true</code></td>
-    </tr>
-    <tr>
-      <td colspan="3">
-        <p>If true, refine will be triggered as you move the map.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+The component has no props.
 
 <!-- Avoid the huge margin on the pseudo element -->
 <h3 class="sub-component-title">CSS classes</h3>

--- a/docgen/src/widgets/GeoSearch.md
+++ b/docgen/src/widgets/GeoSearch.md
@@ -153,6 +153,16 @@ const App = () => (
         <p>If false, this map is for display purposes only, not for refining the search</p>
       </td>
     </tr>
+    <tr>
+      <td>enableRefineOnMapMove</td>
+      <td>Type: <code>boolean</code></td>
+      <td>Default: <code>true</code></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <p>If true, refine will be triggered as you move the map.</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/packages/react-instantsearch-dom-geo/src/Connector.js
+++ b/packages/react-instantsearch-dom-geo/src/Connector.js
@@ -9,6 +9,7 @@ export class Connector extends Component {
   static propTypes = {
     hits: PropTypes.arrayOf(PropTypes.object).isRequired,
     isRefinedWithMap: PropTypes.bool.isRequired,
+    enableRefineOnMapMove: PropTypes.bool.isRequired,
     refine: PropTypes.func.isRequired,
     children: PropTypes.func.isRequired,
     position: LatLngPropType,
@@ -16,7 +17,7 @@ export class Connector extends Component {
   };
 
   state = {
-    isRefineOnMapMove: true,
+    isRefineOnMapMove: this.props.enableRefineOnMapMove,
     hasMapMoveSinceLastRefine: false,
   };
 

--- a/packages/react-instantsearch-dom-geo/src/Control.js
+++ b/packages/react-instantsearch-dom-geo/src/Control.js
@@ -9,7 +9,6 @@ const cx = createClassNames('GeoSearch');
 export class Control extends Component {
   static propTypes = {
     translate: PropTypes.func.isRequired,
-    enableRefineOnMapMove: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -24,25 +23,12 @@ export class Control extends Component {
     }).isRequired,
   };
 
-  static defaultProps = {
-    enableRefineOnMapMove: true,
-  };
-
   getStateContext() {
     return this.context[STATE_CONTEXT];
   }
 
   getGoogleMapsContext() {
     return this.context[GOOGLE_MAPS_CONTEXT];
-  }
-
-  componentDidMount() {
-    const { enableRefineOnMapMove } = this.props;
-    const { isRefineOnMapMove, toggleRefineOnMapMove } = this.getStateContext();
-
-    if (!enableRefineOnMapMove && isRefineOnMapMove) {
-      toggleRefineOnMapMove();
-    }
   }
 
   render() {

--- a/packages/react-instantsearch-dom-geo/src/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/GeoSearch.js
@@ -12,15 +12,14 @@ class GeoSearch extends Component {
     initialZoom: PropTypes.number,
     initialPosition: LatLngPropType,
     enableRefine: PropTypes.bool,
+    enableRefineOnMapMove: PropTypes.bool,
   };
 
   static defaultProps = {
     initialZoom: 1,
-    initialPosition: {
-      lat: 0,
-      lng: 0,
-    },
+    initialPosition: { lat: 0, lng: 0 },
     enableRefine: true,
+    enableRefineOnMapMove: true,
   };
 
   renderChildrenWithBoundFunction = ({ hits, position, ...rest }) => {
@@ -30,6 +29,7 @@ class GeoSearch extends Component {
       initialZoom,
       initialPosition,
       enableRefine,
+      enableRefineOnMapMove,
       ...mapOptions
     } = this.props;
 
@@ -69,8 +69,13 @@ class GeoSearch extends Component {
   };
 
   render() {
+    const { enableRefineOnMapMove } = this.props;
+
     return (
-      <Connector testID="Connector">
+      <Connector
+        testID="Connector"
+        enableRefineOnMapMove={enableRefineOnMapMove}
+      >
         {this.renderChildrenWithBoundFunction}
       </Connector>
     );

--- a/packages/react-instantsearch-dom-geo/src/Redo.js
+++ b/packages/react-instantsearch-dom-geo/src/Redo.js
@@ -13,8 +13,6 @@ export class Redo extends Component {
 
   static contextTypes = {
     [STATE_CONTEXT]: PropTypes.shape({
-      isRefineOnMapMove: PropTypes.bool.isRequired,
-      toggleRefineOnMapMove: PropTypes.func.isRequired,
       hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
       refineWithInstance: PropTypes.func.isRequired,
     }).isRequired,
@@ -29,14 +27,6 @@ export class Redo extends Component {
 
   getGoogleMapsContext() {
     return this.context[GOOGLE_MAPS_CONTEXT];
-  }
-
-  componentDidMount() {
-    const { isRefineOnMapMove, toggleRefineOnMapMove } = this.getStateContext();
-
-    if (isRefineOnMapMove) {
-      toggleRefineOnMapMove();
-    }
   }
 
   render() {

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Connector.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Connector.js
@@ -11,6 +11,7 @@ describe('Connector', () => {
     position: null,
     currentRefinement: null,
     isRefinedWithMap: false,
+    enableRefineOnMapMove: true,
     refine: () => {},
   };
 
@@ -37,6 +38,24 @@ describe('Connector', () => {
       setMapMoveSinceLastRefine: expect.any(Function),
       refine: expect.any(Function),
     });
+  });
+
+  it('expect to call children with refine on map move disabled', () => {
+    const children = jest.fn(x => x);
+
+    const props = {
+      ...defaultProps,
+      enableRefineOnMapMove: false,
+    };
+
+    shallow(<Connector {...props}>{children}</Connector>);
+
+    expect(children).toHaveBeenCalledTimes(1);
+    expect(children).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isRefineOnMapMove: false,
+      })
+    );
   });
 
   describe('setMapMoveSinceLastRefine', () => {

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Control.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Control.js
@@ -10,7 +10,6 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('Control', () => {
   const defaultProps = {
-    enableRefineOnMapMove: true,
     translate: x => x,
   };
 
@@ -86,67 +85,6 @@ describe('Control', () => {
     });
 
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it('expect to disable refine on map move onDidMount', () => {
-    const props = {
-      ...defaultProps,
-      enableRefineOnMapMove: false,
-    };
-
-    const context = {
-      ...defaultContext,
-      [STATE_CONTEXT]: {
-        ...getStateContext(defaultContext),
-        toggleRefineOnMapMove: jest.fn(),
-      },
-    };
-
-    const wrapper = shallow(<Control {...props} />, {
-      disableLifecycleMethods: true,
-      context,
-    });
-
-    expect(
-      getStateContext(context).toggleRefineOnMapMove
-    ).toHaveBeenCalledTimes(0);
-
-    wrapper.instance().componentDidMount();
-
-    expect(
-      getStateContext(context).toggleRefineOnMapMove
-    ).toHaveBeenCalledTimes(1);
-  });
-
-  it('expect to only disable refine on map move when previous value is true onDidMount', () => {
-    const props = {
-      ...defaultProps,
-      enableRefineOnMapMove: false,
-    };
-
-    const context = {
-      ...defaultContext,
-      [STATE_CONTEXT]: {
-        ...getStateContext(defaultContext),
-        isRefineOnMapMove: false,
-        toggleRefineOnMapMove: jest.fn(),
-      },
-    };
-
-    const wrapper = shallow(<Control {...props} />, {
-      disableLifecycleMethods: true,
-      context,
-    });
-
-    expect(
-      getStateContext(context).toggleRefineOnMapMove
-    ).toHaveBeenCalledTimes(0);
-
-    wrapper.instance().componentDidMount();
-
-    expect(
-      getStateContext(context).toggleRefineOnMapMove
-    ).toHaveBeenCalledTimes(0);
   });
 
   it('expect to call toggleRefineOnMapMove on input change', () => {

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
@@ -28,6 +28,29 @@ describe('GeoSearch', () => {
       .props()
       .children(connectorProps);
 
+  describe('Connector', () => {
+    it('expect to render', () => {
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<GeoSearch {...props}>{() => null}</GeoSearch>);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('expect to render with enableRefineOnMapMove', () => {
+      const props = {
+        ...defaultProps,
+        enableRefineOnMapMove: false,
+      };
+
+      const wrapper = shallow(<GeoSearch {...props}>{() => null}</GeoSearch>);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
   describe('Provider', () => {
     it('expect to render', () => {
       const props = {

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Redo.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Redo.js
@@ -15,9 +15,7 @@ describe('Redo', () => {
 
   const defaultContext = {
     [STATE_CONTEXT]: {
-      isRefineOnMapMove: true,
       hasMapMoveSinceLastRefine: false,
-      toggleRefineOnMapMove: () => {},
       refineWithInstance: () => {},
     },
     [GOOGLE_MAPS_CONTEXT]: {
@@ -64,65 +62,6 @@ describe('Redo', () => {
 
     expect(wrapper.find('button').prop('disabled')).toBe(false);
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it('expect to disable refine on map move onDidMount', () => {
-    const props = {
-      ...defaultProps,
-    };
-
-    const context = {
-      ...defaultContext,
-      [STATE_CONTEXT]: {
-        ...getStateContext(defaultContext),
-        toggleRefineOnMapMove: jest.fn(),
-      },
-    };
-
-    const wrapper = shallow(<Redo {...props} />, {
-      disableLifecycleMethods: true,
-      context,
-    });
-
-    expect(
-      getStateContext(context).toggleRefineOnMapMove
-    ).toHaveBeenCalledTimes(0);
-
-    wrapper.instance().componentDidMount();
-
-    expect(
-      getStateContext(context).toggleRefineOnMapMove
-    ).toHaveBeenCalledTimes(1);
-  });
-
-  it('expect to only disable refine on map move when value is true onDidMount', () => {
-    const props = {
-      ...defaultProps,
-    };
-
-    const context = {
-      ...defaultContext,
-      [STATE_CONTEXT]: {
-        ...getStateContext(defaultContext),
-        isRefineOnMapMove: false,
-        toggleRefineOnMapMove: jest.fn(),
-      },
-    };
-
-    const wrapper = shallow(<Redo {...props} />, {
-      disableLifecycleMethods: true,
-      context,
-    });
-
-    expect(
-      getStateContext(context).toggleRefineOnMapMove
-    ).toHaveBeenCalledTimes(0);
-
-    wrapper.instance().componentDidMount();
-
-    expect(
-      getStateContext(context).toggleRefineOnMapMove
-    ).toHaveBeenCalledTimes(0);
   });
 
   it('expect to call refineWithInstance on button click', () => {

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GeoSearch Connector expect to render 1`] = `
+<AlgoliaGeoSearch(Connector)
+  enableRefineOnMapMove={true}
+  testID="Connector"
+/>
+`;
+
+exports[`GeoSearch Connector expect to render with enableRefineOnMapMove 1`] = `
+<AlgoliaGeoSearch(Connector)
+  enableRefineOnMapMove={false}
+  testID="Connector"
+/>
+`;
+
 exports[`GeoSearch GoogleMaps expect to render 1`] = `
 <GoogleMaps
   google={

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -220,7 +220,7 @@ stories
         <Container>
           <GoogleMapsLoader apiKey={apiKey}>
             {google => (
-              <GeoSearch google={google}>
+              <GeoSearch google={google} enableRefineOnMapMove={false}>
                 {({ hits }) => (
                   <Fragment>
                     <Redo />

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -276,10 +276,10 @@ stories
         <Container>
           <GoogleMapsLoader apiKey={apiKey}>
             {google => (
-              <GeoSearch google={google}>
+              <GeoSearch google={google} enableRefineOnMapMove={false}>
                 {({ hits }) => (
                   <Fragment>
-                    <Control enableRefineOnMapMove={false} />
+                    <Control />
 
                     {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
                   </Fragment>


### PR DESCRIPTION
**Summary**

With the current implementation of `Redo` & `Control` components we perform a synchronous call to `setState` on `componentDidMount`. It leads to a wasteful re-render right after the components are mount. All the state is managed by the `Connector` component. When a user uses the `Redo` component it implicitly disable the refine on map move. To do so we call a setState callback from the `Redo.componentDidMount`. It trigger the wasteful re-render for the full tree of the `GeoSearch` component.

This PR solves this issue by removing the implicitness when a user uses the `Redo` component. Now we can disable the refinement on map move with a prop on the `GeoSearch` component. Since the value is directly control by the user we don't need to update the state when the components are rendered. The usage of `Redo` doesn't change. The `Control` component doesn't accept props anymore the value is directly read from the context.

**Usage**

```jsx
// Before with Redo
<GeoSearch google={google}>
  {({ hits }) => <Redo />}
</GeoSearch>

// After with Redo
<GeoSearch google={google} enableRefineOnMapMove={false}>
  {({ hits }) => <Redo />}
</GeoSearch>
```

```jsx
// Before with Control
<GeoSearch google={google}>
  {({ hits }) => <Control enableRefineOnMapMove={false} />}
</GeoSearch>

// After with Control
<GeoSearch google={google} enableRefineOnMapMove={false}>
  {({ hits }) => <Control />}
</GeoSearch>
```

**Metrics**

On the first screenshot you can notice that there is something going wrong during the commit phase, due to the synchronous `setState` (see the ⛔️). Then after the commit phase the all tree is re-render once again. But on the second screenshot we can observe that after the commit phase nothing happens anymore 👌

![screen shot 2018-06-21 at 09 57 05 10 31 17](https://user-images.githubusercontent.com/6513513/41707412-55632304-753e-11e8-91eb-248022514dd6.png)

![screen shot 2018-06-21 at 09 59 05](https://user-images.githubusercontent.com/6513513/41707413-5582e284-753e-11e8-9d5c-801e82ca5837.png)