### PR TITLE
test(e2e): remove GeoSearch it is too brittle

### DIFF
--- a/test/regressions/tests.js
+++ b/test/regressions/tests.js
@@ -14,7 +14,13 @@ function normalize(string) {
   return string.replace(/[ -/]/g, '_');
 }
 
-const stories = require.context('../../stories', true, /\.stories\.js$/);
+// Remove the GeoSearch stories from the
+// tests because they are too brittle
+const stories = require.context(
+  '../../stories',
+  true,
+  /^((?!GeoSearch).)*\.stories\.js$/
+);
 
 // loadStories
 stories.keys().forEach(filename => stories(filename));


### PR DESCRIPTION
**Summary**

This PR removes the `GeoSearch` tests in the E2E, because they are too flaky:

- Google Maps is loaded aync
- Tiles of the map are also loaded async
