### PR TITLE
feat(geo): enable static map

### DIFF
--- a/packages/react-instantsearch-dom-geo/src/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/GeoSearch.js
@@ -11,6 +11,7 @@ class GeoSearch extends Component {
     children: PropTypes.func.isRequired,
     initialZoom: PropTypes.number,
     initialPosition: LatLngPropType,
+    enableRefine: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -19,6 +20,7 @@ class GeoSearch extends Component {
       lat: 0,
       lng: 0,
     },
+    enableRefine: true,
   };
 
   renderChildrenWithBoundFunction = ({ hits, position, ...rest }) => {
@@ -27,6 +29,7 @@ class GeoSearch extends Component {
       children,
       initialZoom,
       initialPosition,
+      enableRefine,
       ...mapOptions
     } = this.props;
 
@@ -37,6 +40,7 @@ class GeoSearch extends Component {
         google={google}
         hits={hits}
         position={position}
+        isRefineEnable={enableRefine}
       >
         {({
           boundingBox,

--- a/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
@@ -94,17 +94,11 @@ class GoogleMaps extends Component {
           boundingBoxPadding
         );
       });
-
-      return;
-    }
-
-    if (!boundingBox) {
+    } else {
       this.lockUserInteration(() => {
         this.instance.setZoom(initialZoom);
         this.instance.setCenter(initialPosition);
       });
-
-      return;
     }
   }
 

--- a/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/GoogleMaps.js
@@ -80,9 +80,7 @@ class GoogleMaps extends Component {
       shouldUpdate,
     } = this.props;
 
-    const { isMapReady } = this.state;
-
-    if (!isMapReady || !shouldUpdate()) {
+    if (!shouldUpdate()) {
       return;
     }
 

--- a/packages/react-instantsearch-dom-geo/src/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/Provider.js
@@ -31,6 +31,8 @@ class Provider extends Component {
   };
 
   isPendingRefine = false;
+  boundingBox = null;
+  previousBoundingBox = null;
 
   getChildContext() {
     const {
@@ -72,6 +74,8 @@ class Provider extends Component {
     if (positionChanged || currentRefinementChanged) {
       setMapMoveSinceLastRefine(false);
     }
+
+    this.previousBoundingBox = this.boundingBox;
   }
 
   createBoundingBoxFromHits(hits) {
@@ -126,7 +130,11 @@ class Provider extends Component {
   shouldUpdate = () => {
     const { hasMapMoveSinceLastRefine } = this.props;
 
-    return !this.isPendingRefine && !hasMapMoveSinceLastRefine;
+    return (
+      !this.isPendingRefine &&
+      !hasMapMoveSinceLastRefine &&
+      !isEqual(this.boundingBox, this.previousBoundingBox)
+    );
   };
 
   render() {
@@ -142,6 +150,8 @@ class Provider extends Component {
       !currentRefinement && Boolean(hits.length)
         ? this.createBoundingBoxFromHits(hits)
         : currentRefinement;
+
+    this.boundingBox = boundingBox;
 
     return children({
       onChange: this.onChange,

--- a/packages/react-instantsearch-dom-geo/src/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/Provider.js
@@ -11,6 +11,7 @@ class Provider extends Component {
     hits: PropTypes.arrayOf(PropTypes.object).isRequired,
     isRefineOnMapMove: PropTypes.bool.isRequired,
     hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
+    isRefineEnable: PropTypes.bool.isRequired,
     refine: PropTypes.func.isRequired,
     toggleRefineOnMapMove: PropTypes.func.isRequired,
     setMapMoveSinceLastRefine: PropTypes.func.isRequired,
@@ -99,12 +100,18 @@ class Provider extends Component {
   };
 
   onChange = () => {
-    const { isRefineOnMapMove, setMapMoveSinceLastRefine } = this.props;
+    const {
+      isRefineOnMapMove,
+      isRefineEnable,
+      setMapMoveSinceLastRefine,
+    } = this.props;
 
-    setMapMoveSinceLastRefine(true);
+    if (isRefineEnable) {
+      setMapMoveSinceLastRefine(true);
 
-    if (isRefineOnMapMove) {
-      this.isPendingRefine = true;
+      if (isRefineOnMapMove) {
+        this.isPendingRefine = true;
+      }
     }
   };
 

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
@@ -147,6 +147,29 @@ describe('GeoSearch', () => {
         },
       });
     });
+
+    it('expect to render with enableRefine', () => {
+      const props = {
+        ...defaultProps,
+        enableRefine: false,
+      };
+
+      const connectorProps = {
+        ...defaultConnectorProps,
+      };
+
+      const renderConnectorWrapper = shallow(
+        <ShallowWapper>
+          {renderConnector({ props, connectorProps })}
+        </ShallowWapper>
+      );
+
+      const providerProps = renderConnectorWrapper
+        .find('[testID="Provider"]')
+        .props();
+
+      expect(providerProps.isRefineEnable).toBe(false);
+    });
   });
 
   describe('GoogleMaps', () => {

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
@@ -461,7 +461,7 @@ describe('GoogleMaps', () => {
       });
     });
 
-    it('expect to prevent the update shouldUpdate return false', () => {
+    it('expect to prevent the map update when shouldUpdate return false', () => {
       const mapInstance = createFakeMapInstance();
       const google = createFakeGoogleReference({
         mapInstance,
@@ -493,6 +493,36 @@ describe('GoogleMaps', () => {
 
       expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
       expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+    });
+
+    it('expect to still render the children when shouldUpdate return false', () => {
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+        shouldUpdate: () => false,
+        google,
+      };
+
+      const wrapper = shallow(
+        <GoogleMaps {...props}>
+          <div>This is the children</div>
+        </GoogleMaps>
+      );
+
+      simulateMapReadyEvent(google);
+      simulateEvent(mapInstance, 'center_changed');
+
+      expect(wrapper).toMatchSnapshot();
+
+      wrapper.setProps({
+        children: <div>This is the children updated</div>,
+      });
+
+      expect(wrapper).toMatchSnapshot();
     });
   });
 

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GoogleMaps.js
@@ -461,36 +461,6 @@ describe('GoogleMaps', () => {
       });
     });
 
-    it('expect to prevent the update when the map is not ready', () => {
-      const mapInstance = createFakeMapInstance();
-      const google = createFakeGoogleReference({
-        mapInstance,
-      });
-
-      const props = {
-        ...defaultProps,
-        google,
-      };
-
-      const wrapper = shallow(
-        <GoogleMaps {...props}>
-          <div>This is the children</div>
-        </GoogleMaps>
-      );
-
-      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
-
-      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
-      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
-
-      wrapper.setProps();
-
-      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(0);
-
-      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
-      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
-    });
-
     it('expect to prevent the update shouldUpdate return false', () => {
       const mapInstance = createFakeMapInstance();
       const google = createFakeGoogleReference({

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
@@ -16,6 +16,7 @@ describe('Provider', () => {
     initialPosition: { lat: 0, lng: 0 },
     isRefineOnMapMove: true,
     hasMapMoveSinceLastRefine: false,
+    isRefineEnable: true,
     refine: () => {},
     toggleRefineOnMapMove: () => {},
     setMapMoveSinceLastRefine: () => {},
@@ -283,6 +284,25 @@ describe('Provider', () => {
       lastRenderArgs(children).onChange();
 
       expect(wrapper.instance().isPendingRefine).toBe(false);
+    });
+
+    it('expect to be a noop when refine is disabled', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+        isRefineEnable: false,
+        setMapMoveSinceLastRefine: jest.fn(),
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+
+      lastRenderArgs(children).onChange();
+
+      expect(wrapper.instance().isPendingRefine).toBe(false);
+      expect(props.setMapMoveSinceLastRefine).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
@@ -401,7 +401,7 @@ describe('Provider', () => {
   });
 
   describe('shouldUpdate', () => {
-    it('expect to return true when there is no pending refinement and the map has not moved', () => {
+    it('expect to return true on mount when conditions are fulfilled', () => {
       const children = jest.fn(x => x);
 
       const props = {
@@ -409,6 +409,35 @@ describe('Provider', () => {
       };
 
       shallow(<Provider {...props}>{children}</Provider>);
+
+      const actual = lastRenderArgs(children).shouldUpdate();
+
+      expect(actual).toBe(true);
+    });
+
+    it('expect to return true on update when conditions are fulfilled', () => {
+      const children = jest.fn(x => x);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>, {
+        disableLifecycleMethods: true,
+      });
+
+      wrapper.setProps({
+        currentRefinement: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      });
 
       const actual = lastRenderArgs(children).shouldUpdate();
 
@@ -440,6 +469,33 @@ describe('Provider', () => {
       };
 
       shallow(<Provider {...props}>{children}</Provider>);
+
+      const actual = lastRenderArgs(children).shouldUpdate();
+
+      expect(actual).toBe(false);
+    });
+
+    it("expect to return false when the boundingBox doesn't change", () => {
+      const children = jest.fn(x => x);
+      const currentRefinement = {
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      };
+
+      const props = {
+        ...defaultProps,
+        currentRefinement,
+      };
+
+      const wrapper = shallow(<Provider {...props}>{children}</Provider>);
+
+      wrapper.setProps({ currentRefinement });
 
       const actual = lastRenderArgs(children).shouldUpdate();
 

--- a/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/Provider.js
@@ -286,7 +286,7 @@ describe('Provider', () => {
       expect(wrapper.instance().isPendingRefine).toBe(false);
     });
 
-    it('expect to be a noop when refine is disabled', () => {
+    it('expect to do nothing when refine is disabled', () => {
       const children = jest.fn(x => x);
 
       const props = {
@@ -378,7 +378,7 @@ describe('Provider', () => {
       expect(wrapper.instance().isPendingRefine).toBe(false);
     });
 
-    it('expect to be a noop when there is no pending refinement', () => {
+    it('expect to do nothing when there is no pending refinement', () => {
       const mapInstance = createFakeMapInstance();
       const children = jest.fn(x => x);
 

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
@@ -59,6 +59,7 @@ exports[`GeoSearch Provider expect to render 1`] = `
   }
   hasMapMoveSinceLastRefine={false}
   hits={Array []}
+  isRefineEnable={true}
   isRefineOnMapMove={true}
   refine={[Function]}
   setMapMoveSinceLastRefine={[Function]}

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GoogleMaps.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GoogleMaps.js.snap
@@ -32,3 +32,26 @@ exports[`GoogleMaps expect render correctly without the map rendered 1`] = `
   />
 </div>
 `;
+
+exports[`GoogleMaps update expect to still render the children when shouldUpdate return false 1`] = `
+<div
+  className="ais-GeoSearch"
+>
+  <div
+    className="ais-GeoSearch-map"
+  />
+</div>
+`;
+
+exports[`GoogleMaps update expect to still render the children when shouldUpdate return false 2`] = `
+<div
+  className="ais-GeoSearch"
+>
+  <div
+    className="ais-GeoSearch-map"
+  />
+  <div>
+    This is the children updated
+  </div>
+</div>
+`;

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -88,43 +88,6 @@ stories
     }
   );
 
-// With Places
-stories.addWithJSX(
-  'with Places',
-  () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
-      <Configure hitsPerPage={20} aroundRadius={5000} />
-
-      <Places
-        defaultRefinement={{
-          lat: 37.7793,
-          lng: -122.419,
-        }}
-      />
-
-      <Container>
-        <GoogleMapsLoader apiKey={apiKey}>
-          {google => (
-            <GeoSearch google={google} initialZoom={12}>
-              {({ hits }) => (
-                <Fragment>
-                  <Control />
-
-                  {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
-                </Fragment>
-              )}
-            </GeoSearch>
-          )}
-        </GoogleMapsLoader>
-      </Container>
-    </WrapWithHits>
-  ),
-  {
-    displayName,
-    filterProps,
-  }
-);
-
 // Only UI
 stories
   .addWithJSX(
@@ -409,6 +372,43 @@ stories
       filterProps,
     }
   );
+
+// With Places
+stories.addWithJSX(
+  'with Places',
+  () => (
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+      <Configure hitsPerPage={20} aroundRadius={5000} />
+
+      <Places
+        defaultRefinement={{
+          lat: 37.7793,
+          lng: -122.419,
+        }}
+      />
+
+      <Container>
+        <GoogleMapsLoader apiKey={apiKey}>
+          {google => (
+            <GeoSearch google={google} initialZoom={12}>
+              {({ hits }) => (
+                <Fragment>
+                  <Control />
+
+                  {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                </Fragment>
+              )}
+            </GeoSearch>
+          )}
+        </GoogleMapsLoader>
+      </Container>
+    </WrapWithHits>
+  ),
+  {
+    displayName,
+    filterProps,
+  }
+);
 
 stories.addWithJSX('with InfoWindow', () => {
   class Example extends Component {

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -34,32 +34,59 @@ const initialPosition = {
   lng: -74.01,
 };
 
-stories.addWithJSX(
-  'default',
-  () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
-      <Configure aroundLatLngViaIP hitsPerPage={20} />
+stories
+  .addWithJSX(
+    'default',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
 
-      <Container>
-        <GoogleMapsLoader apiKey={apiKey}>
-          {google => (
-            <GeoSearch google={google}>
-              {({ hits }) => (
-                <Fragment>
-                  {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
-                </Fragment>
-              )}
-            </GeoSearch>
-          )}
-        </GoogleMapsLoader>
-      </Container>
-    </WrapWithHits>
-  ),
-  {
-    displayName,
-    filterProps,
-  }
-);
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google}>
+                {({ hits }) => (
+                  <Fragment>
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with refine disabled',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch google={google} enableRefine={false}>
+                {({ hits }) => (
+                  <Fragment>
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  );
 
 // With Places
 stories.addWithJSX(


### PR DESCRIPTION
**Summary**

This PR allows to use the `GeoSearch` component without the refine functionality. We introduce a new prop `enableRefine` on the `GeoSearch` component. When `false` the map is always controlled by the rest of the search. Each time the results change the map fit the bounding box of the hits.

![usage](https://user-images.githubusercontent.com/6513513/41817585-54562dfa-779e-11e8-8108-6ce6026871ed.gif)

**Usage**

```jsx
import { GeoSearch, Marker } from "react-instantsearch-dom-maps";

const App = ({ google }) => (
  <GeoSearch google={google} enableRefine={false}>
    {({ hits }) => (
      <Fragment>
        {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
      </Fragment>
    )}
  </GeoSearch>
);
```

You can also use it on [Storybook](http://deploy-preview-1378--react-instantsearch.netlify.com/react-instantsearch/storybook/?selectedKind=GeoSearch&selectedStory=with%20refine%20disabled&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs).