### PR TITLE
refactor: rename shouldUpdate to shouldComponentUpdate

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -707,10 +707,10 @@ describe('connectGeoSearch', () => {
       });
     });
 
-    describe('shouldUpdate', () => {
+    describe('shouldComponentUpdate', () => {
       it('expect to always return true', () => {
         const expectation = true;
-        const actual = connector.shouldUpdate();
+        const actual = connector.shouldComponentUpdate();
 
         expect(actual).toBe(expectation);
       });

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -222,7 +222,7 @@ export default createConnector({
     };
   },
 
-  shouldUpdate() {
+  shouldComponentUpdate() {
     return true;
   },
 });

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -538,14 +538,14 @@ describe('createConnector', () => {
       expect(transitionState.mock.calls).toHaveLength(0);
     });
 
-    it('use shouldUpdate when provided', () => {
-      const shouldUpdate = jest.fn(() => true);
+    it('use shouldComponentUpdate when provided', () => {
+      const shouldComponentUpdate = jest.fn(() => true);
       const Connected = createConnector({
         displayName: 'CoolConnector',
         getProvidedProps: () => null,
         getMetadata: () => null,
         getId,
-        shouldUpdate,
+        shouldComponentUpdate,
       })(() => null);
 
       const onSearchStateChange = jest.fn();
@@ -567,8 +567,8 @@ describe('createConnector', () => {
         },
       });
 
-      expect(shouldUpdate).toHaveBeenCalledTimes(1);
-      expect(shouldUpdate).toHaveBeenCalledWith(
+      expect(shouldComponentUpdate).toHaveBeenCalledTimes(1);
+      expect(shouldComponentUpdate).toHaveBeenCalledWith(
         { hello: 'there' },
         { hello: 'there' },
         { canRender: false, props: null },
@@ -577,8 +577,8 @@ describe('createConnector', () => {
 
       wrapper.setProps({ hello: 'here' });
 
-      expect(shouldUpdate).toHaveBeenCalledTimes(2);
-      expect(shouldUpdate).toHaveBeenCalledWith(
+      expect(shouldComponentUpdate).toHaveBeenCalledTimes(2);
+      expect(shouldComponentUpdate).toHaveBeenCalledWith(
         { hello: 'there' },
         { hello: 'here' },
         { canRender: true, props: null },

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -41,7 +41,7 @@ export default function createConnector(connectorDesc) {
   const hasMetadata = has(connectorDesc, 'getMetadata');
   const hasTransitionState = has(connectorDesc, 'transitionState');
   const hasCleanUp = has(connectorDesc, 'cleanUp');
-  const hasShouldUpdate = has(connectorDesc, 'shouldUpdate');
+  const hasShouldComponentUpdate = has(connectorDesc, 'shouldComponentUpdate');
   const isWidget = hasSearchParameters || hasMetadata || hasTransitionState;
 
   return Composed =>
@@ -211,8 +211,8 @@ export default function createConnector(connectorDesc) {
       }
 
       shouldComponentUpdate(nextProps, nextState) {
-        if (hasShouldUpdate) {
-          return connectorDesc.shouldUpdate.call(
+        if (hasShouldComponentUpdate) {
+          return connectorDesc.shouldComponentUpdate.call(
             this,
             this.props,
             nextProps,


### PR DESCRIPTION
**Summary**

This PR rename the function `shouldUpdate` added for `connectGeoSearch`:

- `shouldUpdate` → `shouldComponentUpdate`

We rename the function because we might introduce a new function called `shouldWidgetUpdate` in a near future. It will avoid confusion about the purpose of each hooks. The latter might solve the issue related to `willReceiveProps` (see #1042).

This change don't have any impact because the only connector that use this functionality is `connectGeoSearch`. The feature is on `master` but not yet released.