### PR TITLE
poc: Will receive update

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
@@ -260,5 +261,17 @@ export default createConnector({
             ]
           : [],
     };
+  },
+
+  shouldWidgetUpdate(props, nextProps) {
+    const shouldUpdate =
+      props.attribute !== nextProps.attribute ||
+      props.operator !== nextProps.operator ||
+      props.limit !== nextProps.limit ||
+      props.showMoreLimit !== nextProps.showMoreLimit ||
+      props.showMore !== nextProps.showMore ||
+      !isEqual(props.defaultRefinement, nextProps.defaultRefinement);
+
+    return shouldUpdate;
   },
 });

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -42,6 +42,7 @@ export default function createConnector(connectorDesc) {
   const hasTransitionState = has(connectorDesc, 'transitionState');
   const hasCleanUp = has(connectorDesc, 'cleanUp');
   const hasShouldComponentUpdate = has(connectorDesc, 'shouldComponentUpdate');
+  const hasShoulWidgetdUpdate = has(connectorDesc, 'shouldWidgetUpdate');
   const isWidget = hasSearchParameters || hasMetadata || hasTransitionState;
 
   return Composed =>
@@ -173,10 +174,9 @@ export default function createConnector(connectorDesc) {
             props: this.getProvidedProps(nextProps),
           });
 
-          if (isWidget) {
-            // Since props might have changed, we need to re-run getSearchParameters
-            // and getMetadata with the new props.
+          if (isWidget && this.shouldWidgetUpdate(nextProps)) {
             this.context.ais.widgetsManager.update();
+
             if (connectorDesc.transitionState) {
               this.context.ais.onSearchStateChange(
                 connectorDesc.transitionState.call(
@@ -208,6 +208,18 @@ export default function createConnector(connectorDesc) {
             this.context.ais.onSearchStateChange(removeEmptyKey(newState));
           }
         }
+      }
+
+      shouldWidgetUpdate(nextProps) {
+        if (hasShoulWidgetdUpdate) {
+          return connectorDesc.shouldWidgetUpdate.call(
+            this,
+            this.props,
+            nextProps
+          );
+        }
+
+        return true;
       }
 
       shouldComponentUpdate(nextProps, nextState) {

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { Component } from 'react';
 import orderBy from 'lodash.orderby';
 import { setAddon, storiesOf } from '@storybook/react';
 import { boolean, number, array } from '@storybook/addon-knobs';
 import JSXAddon from 'storybook-addon-jsx';
-import { Panel, RefinementList, SearchBox } from 'react-instantsearch-dom';
+import {
+  Panel,
+  RefinementList,
+  SearchBox,
+  connectStateResults,
+} from 'react-instantsearch-dom';
 import { displayName, filterProps, WrapWithHits } from './util';
 
 setAddon(JSXAddon);
@@ -133,6 +138,90 @@ stories
         />
       </WrapWithHits>
     ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
+    'with re-render',
+    () => {
+      class Example extends Component {
+        state = {
+          count: 0,
+          limit: 5,
+          refinements: [],
+        };
+
+        onClickCounter = () => {
+          this.setState(({ count }) => ({
+            count: count + 1,
+          }));
+        };
+
+        onClickLimit = value => () => {
+          this.setState(({ limit }) => ({
+            limit: limit + value,
+          }));
+        };
+
+        onClickPush = value => () => {
+          this.setState(({ refinements }) => ({
+            refinements: refinements.concat(value),
+          }));
+        };
+
+        render() {
+          return (
+            <div>
+              <p>
+                <button onClick={this.onClickCounter}>
+                  Useless update ({this.state.count})
+                </button>
+              </p>
+
+              <p>
+                <button onClick={this.onClickLimit(-1)}>-</button>
+                <span>Count ({this.state.limit})</span>
+                <button onClick={this.onClickLimit(+1)}>+</button>
+              </p>
+
+              <p>
+                <button onClick={this.onClickPush('Decoration')}>
+                  {'"Decoration"'}
+                </button>
+
+                <button onClick={this.onClickPush('Lighting')}>
+                  {'"Lighting"'}
+                </button>
+
+                <button onClick={this.onClickPush('Eating')}>
+                  {'"Eating"'}
+                </button>
+              </p>
+
+              <RefinementList
+                attribute="category"
+                limit={this.state.limit}
+                defaultRefinement={this.state.refinements}
+                // defaultRefinement={['Decoration']}
+                translations={{
+                  showMore: extended => (extended ? 'Less' : 'More'),
+                }}
+              />
+            </div>
+          );
+        }
+      }
+
+      const Connected = connectStateResults(Example);
+
+      return (
+        <WrapWithHits linkedStoryGroup="RefinementList">
+          <Connected />
+        </WrapWithHits>
+      );
+    },
     {
       displayName,
       filterProps,


### PR DESCRIPTION
**Problem**

This is a first attempt to solve this issue #1042. With the current implementation we trigger a change on the widget manager each time a props change on a connector. We detect those changes with the [`isEqual`](https://lodash.com/docs/4.17.10#isEqual) function of Lodash. The widget manager update schedule new queries and a re-render. The queries are (most of the time) already cached so we don't see any network request. But in case we have a connector inside another one it can leads to an infinite loop:

```jsx
const Connected = connectStateResults(() => (
  <RefinementList
    attribute="colors"
    translations={{
      showMore: extended => (extended ? "Less" : "More")
    }}
  />
));

const App = () => (
  <InstantSearch>
    <Connected />
  </InstantSearch>
);
``` 

In that case we have an infinite loop because the translations prop contain a function. On each render a new function is created. It means that on each render React InstantSearch will trigger a new change on the widget manager that will also trigger a new render (∞). We have our infinite loop.

**Solution**

The responsibility to trigger a new change is hold by the `createConnector` function. But this abstraction don't have enough information to know wether or not a new request is required. The component that have the more knowledge about that is the connector. We can define a new hook (called `shouldWidgetUpdate`) on the connector description to determine when the widget needs to trigger a new request.

```jsx
const connectRefinementList = createConnector({
  shouldWidgetUpdate(props, nextProps) {
    return (
      props.attribute !== nextProps.attribute ||
      props.operator !== nextProps.operator ||
      props.limit !== nextProps.limit ||
      props.showMoreLimit !== nextProps.showMoreLimit ||
      props.showMore !== nextProps.showMore ||
      !isEqual(props.defaultRefinement, nextProps.defaultRefinement)
    );
  }
});
```

Now we trigger only a new change on the widget manager when on of those props change. I took `RefinementList` because it's one of the widget that has the most props implied in the request. For most of the widget the test will be less "complicated" than that.

**Pros**:

- more control on the lifecycle
- avoid wasteful loop to the widget manager
- we can now provide anonymous function to props
- nested connectors is a bit more safe (mount / unmount issue is still there)

**Cons**:

- one more function added to the connector API
- it feels (is) an escape hatch

-----

Let me know what do you think or if you have a better ideas!