### PR TITLE
feat(core): implement shouldWidgetUpdate

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -585,72 +585,6 @@ describe('createConnector', () => {
         { canRender: true, props: null }
       );
     });
-
-    describe('unmounting', () => {
-      const Connected = createConnector({
-        displayName: 'CoolConnector',
-        getProvidedProps: () => null,
-        getMetadata: () => null,
-        cleanUp: () => ({ another: { state: 'state', key: {} }, key: {} }),
-      })(() => null);
-      const unregister = jest.fn();
-      const setState = jest.fn();
-      const onSearchStateChange = jest.fn();
-      it('unregisters itself on unmount', () => {
-        const wrapper = mount(<Connected />, {
-          context: {
-            ais: {
-              store: {
-                getState: () => ({ widgets: { another: { state: 'state' } } }),
-                setState,
-                subscribe: () => () => null,
-              },
-              widgetsManager: {
-                registerWidget: () => unregister,
-              },
-              onSearchStateChange,
-            },
-          },
-        });
-        expect(unregister.mock.calls).toHaveLength(0);
-        expect(setState.mock.calls).toHaveLength(0);
-        expect(onSearchStateChange.mock.calls).toHaveLength(0);
-
-        wrapper.unmount();
-
-        expect(unregister.mock.calls).toHaveLength(1);
-        expect(setState.mock.calls).toHaveLength(1);
-        expect(onSearchStateChange.mock.calls).toHaveLength(1);
-        expect(setState.mock.calls[0][0]).toEqual({
-          widgets: { another: { state: 'state' } },
-        });
-        expect(onSearchStateChange.mock.calls[0][0]).toEqual({
-          another: { state: 'state' },
-        });
-      });
-      it('empty key from the search state should be removed', () => {
-        const wrapper = mount(<Connected />, {
-          context: {
-            ais: {
-              store: {
-                getState: () => ({ widgets: { another: { state: 'state' } } }),
-                setState,
-                subscribe: () => () => null,
-              },
-              widgetsManager: {
-                registerWidget: () => unregister,
-              },
-              onSearchStateChange,
-            },
-          },
-        });
-        wrapper.unmount();
-
-        expect(onSearchStateChange.mock.calls[0][0]).toEqual({
-          another: { state: 'state' },
-        });
-      });
-    });
   });
 
   describe('shouldWidgetUpdate', () => {
@@ -774,6 +708,74 @@ describe('createConnector', () => {
 
       expect(update).toHaveBeenCalledTimes(0);
       expect(onSearchStateChange).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('unmount', () => {
+    const Connected = createConnector({
+      displayName: 'CoolConnector',
+      getProvidedProps: () => null,
+      getMetadata: () => null,
+      cleanUp: () => ({ another: { state: 'state', key: {} }, key: {} }),
+    })(() => null);
+    const unregister = jest.fn();
+    const setState = jest.fn();
+    const onSearchStateChange = jest.fn();
+
+    it('unregisters itself on unmount', () => {
+      const wrapper = mount(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({ widgets: { another: { state: 'state' } } }),
+              setState,
+              subscribe: () => () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => unregister,
+            },
+            onSearchStateChange,
+          },
+        },
+      });
+      expect(unregister.mock.calls).toHaveLength(0);
+      expect(setState.mock.calls).toHaveLength(0);
+      expect(onSearchStateChange.mock.calls).toHaveLength(0);
+
+      wrapper.unmount();
+
+      expect(unregister.mock.calls).toHaveLength(1);
+      expect(setState.mock.calls).toHaveLength(1);
+      expect(onSearchStateChange.mock.calls).toHaveLength(1);
+      expect(setState.mock.calls[0][0]).toEqual({
+        widgets: { another: { state: 'state' } },
+      });
+      expect(onSearchStateChange.mock.calls[0][0]).toEqual({
+        another: { state: 'state' },
+      });
+    });
+
+    it('empty key from the search state should be removed', () => {
+      const wrapper = mount(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({ widgets: { another: { state: 'state' } } }),
+              setState,
+              subscribe: () => () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => unregister,
+            },
+            onSearchStateChange,
+          },
+        },
+      });
+      wrapper.unmount();
+
+      expect(onSearchStateChange.mock.calls[0][0]).toEqual({
+        another: { state: 'state' },
+      });
     });
   });
 

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -653,6 +653,130 @@ describe('createConnector', () => {
     });
   });
 
+  describe('shouldWidgetUpdate', () => {
+    it('use shouldWidgetUpdate when provided', () => {
+      const transitionState = jest.fn();
+      const shouldWidgetUpdate = jest.fn(() => true);
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps: () => null,
+        getMetadata: () => null,
+        getId,
+        transitionState,
+        shouldWidgetUpdate,
+      })(() => null);
+
+      const update = jest.fn();
+      const onSearchStateChange = jest.fn();
+      const props = { hello: 'there' };
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => null,
+              update,
+            },
+            onSearchStateChange,
+          },
+        },
+      });
+
+      expect(shouldWidgetUpdate).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps({ hello: 'you' });
+
+      expect(shouldWidgetUpdate).toHaveBeenCalledTimes(1);
+      expect(shouldWidgetUpdate).toHaveBeenCalledWith(
+        { hello: 'there' },
+        { hello: 'you' }
+      );
+    });
+
+    it('triggers the update when `shouldWidgetUpdate` return `true`', () => {
+      const transitionState = jest.fn();
+      const shouldWidgetUpdate = jest.fn(() => true);
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps: () => null,
+        getMetadata: () => null,
+        getId,
+        transitionState,
+        shouldWidgetUpdate,
+      })(() => null);
+
+      const update = jest.fn();
+      const onSearchStateChange = jest.fn();
+      const props = { hello: 'there' };
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => null,
+              update,
+            },
+            onSearchStateChange,
+          },
+        },
+      });
+
+      expect(update).toHaveBeenCalledTimes(0);
+      expect(onSearchStateChange).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps({ hello: 'you' });
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(onSearchStateChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('dont triggers the update when `shouldWidgetUpdate` return `false`', () => {
+      const transitionState = jest.fn();
+      const shouldWidgetUpdate = jest.fn(() => false);
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps: () => null,
+        getMetadata: () => null,
+        getId,
+        transitionState,
+        shouldWidgetUpdate,
+      })(() => null);
+
+      const update = jest.fn();
+      const onSearchStateChange = jest.fn();
+      const props = { hello: 'there' };
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => null,
+              update,
+            },
+            onSearchStateChange,
+          },
+        },
+      });
+
+      expect(update).toHaveBeenCalledTimes(0);
+      expect(onSearchStateChange).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps({ hello: 'you' });
+
+      expect(update).toHaveBeenCalledTimes(0);
+      expect(onSearchStateChange).toHaveBeenCalledTimes(0);
+    });
+  });
+
   describe('refine', () => {
     it('passes a refine method to the component', () => {
       const Dummy = () => null;

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -42,6 +42,7 @@ export default function createConnector(connectorDesc) {
   const hasTransitionState = has(connectorDesc, 'transitionState');
   const hasCleanUp = has(connectorDesc, 'cleanUp');
   const hasShouldComponentUpdate = has(connectorDesc, 'shouldComponentUpdate');
+  const hasShouldWidgetdUpdate = has(connectorDesc, 'shouldWidgetUpdate');
   const isWidget = hasSearchParameters || hasMetadata || hasTransitionState;
 
   return Composed =>
@@ -173,10 +174,9 @@ export default function createConnector(connectorDesc) {
             props: this.getProvidedProps(nextProps),
           });
 
-          if (isWidget) {
-            // Since props might have changed, we need to re-run getSearchParameters
-            // and getMetadata with the new props.
+          if (isWidget && this.shouldWidgetUpdate(nextProps)) {
             this.context.ais.widgetsManager.update();
+
             if (connectorDesc.transitionState) {
               this.context.ais.onSearchStateChange(
                 connectorDesc.transitionState.call(
@@ -208,6 +208,18 @@ export default function createConnector(connectorDesc) {
             this.context.ais.onSearchStateChange(removeEmptyKey(newState));
           }
         }
+      }
+
+      shouldWidgetUpdate(nextProps) {
+        if (hasShouldWidgetdUpdate) {
+          return connectorDesc.shouldWidgetUpdate.call(
+            this,
+            this.props,
+            nextProps
+          );
+        }
+
+        return true;
       }
 
       shouldComponentUpdate(nextProps, nextState) {


### PR DESCRIPTION
**Summary**

Fix #1042 

This PR implements the hook `shouldWidgetUpdate` in `createConnector` following what we discuss in #1389. I will create one PR for each connector it will be easier to review with this branch as a base.

The diff in the test file is a bit long because I moved another test on the top level. What really matters for the PR is in this commit https://github.com/algolia/react-instantsearch/pull/1394/commits/e5cfa22396be74bfa92fb3b1d2addea44d292bdd.

**Usage**

```jsx
const customConnector = createConnector({
  shouldWidgetUpdate(props, nextProps) {
    return props.attribute !== nextProps.attribute;
  }
});
```