### PR TITLE
fix(connectGeoSearch): use empty object as default value

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -616,7 +616,7 @@ describe('connectGeoSearch', () => {
     });
 
     describe('getMetadata', () => {
-      it('expect to return the meta when boudingBox is provided', () => {
+      it('expect to return the meta when boundingBox is provided', () => {
         const instance = createSingleIndexInstance();
         const props = {};
         const searchState = {
@@ -658,7 +658,7 @@ describe('connectGeoSearch', () => {
         expect(actual).toEqual(expectation);
       });
 
-      it('expect to return an empty meta when boudingBox is omit', () => {
+      it('expect to return an empty meta when boundingBox is omit', () => {
         const instance = createSingleIndexInstance();
         const props = {};
         const searchState = {};
@@ -1338,7 +1338,7 @@ describe('connectGeoSearch', () => {
     });
 
     describe('getMetadata', () => {
-      it('expect to return the meta when boudingBox is provided', () => {
+      it('expect to return the meta when boundingBox is provided', () => {
         const instance = createMultiIndexInstance();
         const props = {};
         const searchState = createMultiIndexSearchState({
@@ -1380,7 +1380,7 @@ describe('connectGeoSearch', () => {
         expect(actual).toEqual(expectation);
       });
 
-      it('expect to return an empty meta when boudingBox is omit', () => {
+      it('expect to return an empty meta when boundingBox is omit', () => {
         const instance = createMultiIndexInstance();
         const props = {};
         const searchState = createMultiIndexSearchState();

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -700,6 +700,7 @@ describe('connectGeoSearch', () => {
 
         const expectation = {
           query: 'studio',
+          boundingBox: {},
           page: 1,
         };
 
@@ -1424,6 +1425,7 @@ describe('connectGeoSearch', () => {
           indices: {
             second: {
               query: 'studio',
+              boundingBox: {},
               page: 1,
             },
           },

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash';
 import createConnector from '../core/createConnector';
 import {
   getResults,
@@ -68,13 +69,15 @@ const getCurrentRefinement = (props, searchState, context) => {
     props,
     searchState,
     context,
-    getBoundingBoxId()
+    getBoundingBoxId(),
+    {}
   );
 
-  if (!refinement) {
-    return refinement;
+  if (isEmpty(refinement)) {
+    return;
   }
 
+  // eslint-disable-next-line consistent-return
   return {
     northEast: {
       lat: parseFloat(refinement.northEast.lat),
@@ -201,6 +204,7 @@ export default createConnector({
     const items = [];
     const id = getBoundingBoxId();
     const index = getIndex(this.context);
+    const nextRefinement = {};
     const currentRefinement = getCurrentRefinement(
       props,
       searchState,
@@ -210,7 +214,7 @@ export default createConnector({
     if (currentRefinement) {
       items.push({
         label: `${id}: ${currentRefinementToString(currentRefinement)}`,
-        value: nextState => refine(nextState, undefined, this.context),
+        value: nextState => refine(nextState, nextRefinement, this.context),
         currentRefinement,
       });
     }

--- a/stories/places/connector.js
+++ b/stories/places/connector.js
@@ -8,12 +8,10 @@ export default createConnector({
   },
 
   refine(props, searchState, nextValue) {
-    // eslint-disable-next-line no-unused-vars
-    const { boundingBox, ...sliceSearchState } = searchState;
-
     return {
-      ...sliceSearchState,
+      ...searchState,
       aroundLatLng: nextValue,
+      boundingBox: {},
     };
   },
 


### PR DESCRIPTION
**Summary**

With the current implementation of React InstantSearch the `defaultRefinement` is used when the value **is not present** on the `searchState`. Right now in the places example when we update the location we completely remove the value from the state. On the next render the geo connector pick the `defaultRefinement` since the `boundingBox` is not present on the `searchState`. It means that the map won't move to the new location since we have an active refinement (the default one).

This PR fix this issue by allowing the `boundingBox` to be reset with an empty object rather than removing the value from the `searchState`. All the other connectors behaves like that.