### PR TITLE
fix(maps): add support for default refinement in GeoSearch

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -770,15 +770,6 @@ describe('connectGeoSearch', () => {
         expect(actual).toEqual(expectation);
       });
     });
-
-    describe('shouldComponentUpdate', () => {
-      it('expect to always return true', () => {
-        const expectation = true;
-        const actual = connector.shouldComponentUpdate();
-
-        expect(actual).toBe(expectation);
-      });
-    });
   });
 
   describe('multi index', () => {
@@ -1559,6 +1550,15 @@ describe('connectGeoSearch', () => {
 
         expect(actual).toEqual(expectation);
       });
+    });
+  });
+
+  describe('shouldComponentUpdate', () => {
+    it('expect to always return true', () => {
+      const expectation = true;
+      const actual = connector.shouldComponentUpdate();
+
+      expect(actual).toBe(expectation);
     });
   });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -799,7 +799,7 @@ describe('connectGeoSearch', () => {
       },
     });
 
-    const createSingleSearchResults = (hits = [], state) => ({
+    const createMultiIndexSearchResults = (hits = [], state) => ({
       results: {
         second: new SearchResults(new SearchParameters(state), [
           {
@@ -844,7 +844,7 @@ describe('connectGeoSearch', () => {
           const instance = createMultiIndexInstance();
           const props = {};
           const searchState = createMultiIndexSearchState();
-          const searchResults = createSingleSearchResults(hits);
+          const searchResults = createMultiIndexSearchResults(hits);
 
           const actual = connector.getProvidedProps.call(
             instance,
@@ -872,7 +872,7 @@ describe('connectGeoSearch', () => {
           const instance = createMultiIndexInstance();
           const props = {};
           const searchState = createMultiIndexSearchState();
-          const searchResults = createSingleSearchResults(hits);
+          const searchResults = createMultiIndexSearchResults(hits);
 
           const actual = connector.getProvidedProps.call(
             instance,
@@ -912,7 +912,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the position from the searchState (aroundLatLng)', () => {
           const instance = createMultiIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createMultiIndexSearchResults();
           const searchState = createMultiIndexSearchState({
             aroundLatLng: {
               lat: 10,
@@ -936,7 +936,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the position from the searchState (configure.aroungLatLng)', () => {
           const instance = createMultiIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createMultiIndexSearchResults();
           const searchState = createMultiIndexSearchState({
             configure: {
               aroundLatLng: '10, 12',
@@ -960,7 +960,7 @@ describe('connectGeoSearch', () => {
           const instance = createMultiIndexInstance();
           const props = {};
           const searchState = createMultiIndexSearchState();
-          const searchResults = createSingleSearchResults();
+          const searchResults = createMultiIndexSearchResults();
 
           const actual = connector.getProvidedProps.call(
             instance,
@@ -975,7 +975,7 @@ describe('connectGeoSearch', () => {
         it('expect to return undefined with the default refinement', () => {
           const instance = createMultiIndexInstance();
           const searchState = createMultiIndexSearchState();
-          const searchResults = createSingleSearchResults();
+          const searchResults = createMultiIndexSearchResults();
           const props = {
             defaultRefinement: {
               northEast: {
@@ -1004,7 +1004,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the boundingBox from the searchState', () => {
           const instance = createMultiIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createMultiIndexSearchResults();
           const searchState = createMultiIndexSearchState({
             boundingBox: {
               northEast: {
@@ -1040,7 +1040,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the boundingBox from the searchState with string values', () => {
           const instance = createMultiIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createMultiIndexSearchResults();
           const searchState = createMultiIndexSearchState({
             boundingBox: {
               northEast: {
@@ -1077,7 +1077,7 @@ describe('connectGeoSearch', () => {
           const instance = createMultiIndexInstance();
           const props = {};
           const searchState = {};
-          const searchResults = createSingleSearchResults([], {
+          const searchResults = createMultiIndexSearchResults([], {
             insideBoundingBox: '10, 12, 12, 14',
           });
 
@@ -1103,7 +1103,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the default refinement', () => {
           const instance = createMultiIndexInstance();
           const searchState = createMultiIndexSearchState();
-          const searchResults = createSingleSearchResults();
+          const searchResults = createMultiIndexSearchResults();
           const props = {
             defaultRefinement: {
               northEast: {
@@ -1140,7 +1140,7 @@ describe('connectGeoSearch', () => {
           const instance = createMultiIndexInstance();
           const props = {};
           const searchState = createMultiIndexSearchState();
-          const searchResults = createSingleSearchResults();
+          const searchResults = createMultiIndexSearchResults();
 
           const actual = connector.getProvidedProps.call(
             instance,
@@ -1163,7 +1163,7 @@ describe('connectGeoSearch', () => {
 
           const instance = createMultiIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults(hits);
+          const searchResults = createMultiIndexSearchResults(hits);
           const searchState = createMultiIndexSearchState({
             boundingBox: {
               northEast: {
@@ -1197,7 +1197,7 @@ describe('connectGeoSearch', () => {
           const instance = createMultiIndexInstance();
           const props = {};
           const searchState = createMultiIndexSearchState();
-          const searchResults = createSingleSearchResults(hits, {
+          const searchResults = createMultiIndexSearchResults(hits, {
             insideBoundingBox: '10, 12, 12, 14',
           });
 
@@ -1221,7 +1221,7 @@ describe('connectGeoSearch', () => {
           const instance = createMultiIndexInstance();
           const props = {};
           const searchState = createMultiIndexSearchState();
-          const searchResults = createSingleSearchResults(hits);
+          const searchResults = createMultiIndexSearchResults(hits);
 
           const actual = connector.getProvidedProps.call(
             instance,

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -206,6 +206,33 @@ describe('connectGeoSearch', () => {
 
           expect(actual.position).toBe(undefined);
         });
+
+        it('expect to return undefined with the default refinement', () => {
+          const instance = createSingleIndexInstance();
+          const searchState = {};
+          const searchResults = createSingleSearchResults();
+          const props = {
+            defaultRefinement: {
+              northEast: {
+                lat: 10,
+                lng: 12,
+              },
+              southWest: {
+                lat: 12,
+                lng: 14,
+              },
+            },
+          };
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.position).toBe(undefined);
+        });
       });
 
       describe('currentRefinement', () => {
@@ -288,6 +315,42 @@ describe('connectGeoSearch', () => {
           const searchResults = createSingleSearchResults([], {
             insideBoundingBox: '10, 12, 12, 14',
           });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toEqual({
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          });
+        });
+
+        it('expect to return the default refinement', () => {
+          const instance = createSingleIndexInstance();
+          const searchState = {};
+          const searchResults = createSingleSearchResults();
+          const props = {
+            defaultRefinement: {
+              northEast: {
+                lat: 10,
+                lng: 12,
+              },
+              southWest: {
+                lat: 12,
+                lng: 14,
+              },
+            },
+          };
 
           const actual = connector.getProvidedProps.call(
             instance,
@@ -908,6 +971,33 @@ describe('connectGeoSearch', () => {
 
           expect(actual.position).toBe(undefined);
         });
+
+        it('expect to return undefined with the default refinement', () => {
+          const instance = createMultiIndexInstance();
+          const searchState = createMultiIndexSearchState();
+          const searchResults = createSingleSearchResults();
+          const props = {
+            defaultRefinement: {
+              northEast: {
+                lat: 10,
+                lng: 12,
+              },
+              southWest: {
+                lat: 12,
+                lng: 14,
+              },
+            },
+          };
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.position).toBe(undefined);
+        });
       });
 
       describe('currentRefinement', () => {
@@ -990,6 +1080,42 @@ describe('connectGeoSearch', () => {
           const searchResults = createSingleSearchResults([], {
             insideBoundingBox: '10, 12, 12, 14',
           });
+
+          const actual = connector.getProvidedProps.call(
+            instance,
+            props,
+            searchState,
+            searchResults
+          );
+
+          expect(actual.currentRefinement).toEqual({
+            northEast: {
+              lat: 10,
+              lng: 12,
+            },
+            southWest: {
+              lat: 12,
+              lng: 14,
+            },
+          });
+        });
+
+        it('expect to return the default refinement', () => {
+          const instance = createMultiIndexInstance();
+          const searchState = createMultiIndexSearchState();
+          const searchResults = createSingleSearchResults();
+          const props = {
+            defaultRefinement: {
+              northEast: {
+                lat: 10,
+                lng: 12,
+              },
+              southWest: {
+                lat: 12,
+                lng: 14,
+              },
+            },
+          };
 
           const actual = connector.getProvidedProps.call(
             instance,

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectGeoSearch.js
@@ -15,7 +15,7 @@ describe('connectGeoSearch', () => {
       },
     });
 
-    const createSingleSearchResults = (hits = [], state) => ({
+    const createSingleIndexSearchResults = (hits = [], state) => ({
       results: new SearchResults(new SearchParameters(state), [
         {
           hits,
@@ -58,7 +58,7 @@ describe('connectGeoSearch', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchState = {};
-          const searchResults = createSingleSearchResults(hits);
+          const searchResults = createSingleIndexSearchResults(hits);
 
           const actual = connector.getProvidedProps.call(
             instance,
@@ -86,7 +86,7 @@ describe('connectGeoSearch', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchState = {};
-          const searchResults = createSingleSearchResults(hits);
+          const searchResults = createSingleIndexSearchResults(hits);
 
           const actual = connector.getProvidedProps.call(
             instance,
@@ -126,7 +126,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the position from the searchState (aroundLatLng)', () => {
           const instance = createSingleIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createSingleIndexSearchResults();
           const searchState = {
             aroundLatLng: {
               lat: 10,
@@ -150,7 +150,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the position from the searchState (configure.aroundLatLng)', () => {
           const instance = createSingleIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createSingleIndexSearchResults();
           const searchState = {
             configure: {
               aroundLatLng: '10, 12',
@@ -174,7 +174,7 @@ describe('connectGeoSearch', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchState = {};
-          const searchResults = createSingleSearchResults([], {
+          const searchResults = createSingleIndexSearchResults([], {
             aroundLatLng: '10, 12',
           });
 
@@ -195,7 +195,7 @@ describe('connectGeoSearch', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchState = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createSingleIndexSearchResults();
 
           const actual = connector.getProvidedProps.call(
             instance,
@@ -210,7 +210,7 @@ describe('connectGeoSearch', () => {
         it('expect to return undefined with the default refinement', () => {
           const instance = createSingleIndexInstance();
           const searchState = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createSingleIndexSearchResults();
           const props = {
             defaultRefinement: {
               northEast: {
@@ -239,7 +239,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the boundingBox from the searchState', () => {
           const instance = createSingleIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createSingleIndexSearchResults();
           const searchState = {
             boundingBox: {
               northEast: {
@@ -275,7 +275,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the boundingBox from the searchState with string values', () => {
           const instance = createSingleIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createSingleIndexSearchResults();
           const searchState = {
             boundingBox: {
               northEast: {
@@ -312,7 +312,7 @@ describe('connectGeoSearch', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchState = {};
-          const searchResults = createSingleSearchResults([], {
+          const searchResults = createSingleIndexSearchResults([], {
             insideBoundingBox: '10, 12, 12, 14',
           });
 
@@ -338,7 +338,7 @@ describe('connectGeoSearch', () => {
         it('expect to return the default refinement', () => {
           const instance = createSingleIndexInstance();
           const searchState = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createSingleIndexSearchResults();
           const props = {
             defaultRefinement: {
               northEast: {
@@ -375,7 +375,7 @@ describe('connectGeoSearch', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchState = {};
-          const searchResults = createSingleSearchResults();
+          const searchResults = createSingleIndexSearchResults();
 
           const actual = connector.getProvidedProps.call(
             instance,
@@ -398,7 +398,7 @@ describe('connectGeoSearch', () => {
 
           const instance = createSingleIndexInstance();
           const props = {};
-          const searchResults = createSingleSearchResults(hits);
+          const searchResults = createSingleIndexSearchResults(hits);
           const searchState = {
             boundingBox: {
               northEast: {
@@ -432,7 +432,7 @@ describe('connectGeoSearch', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchState = {};
-          const searchResults = createSingleSearchResults(hits, {
+          const searchResults = createSingleIndexSearchResults(hits, {
             insideBoundingBox: '10, 12, 12, 14',
           });
 
@@ -456,7 +456,7 @@ describe('connectGeoSearch', () => {
           const instance = createSingleIndexInstance();
           const props = {};
           const searchState = {};
-          const searchResults = createSingleSearchResults(hits);
+          const searchResults = createSingleIndexSearchResults(hits);
 
           const actual = connector.getProvidedProps.call(
             instance,

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -91,8 +91,10 @@ const getCurrentRefinement = (props, searchState, context) => {
 };
 
 const getCurrentPosition = (props, searchState, context) => {
+  const { defaultRefinement, ...propsWithoutDefaultRefinement } = props;
+
   const aroundLatLng = getCurrentRefinementValue(
-    props,
+    propsWithoutDefaultRefinement,
     searchState,
     context,
     getAroundLatLngId()
@@ -101,7 +103,7 @@ const getCurrentPosition = (props, searchState, context) => {
   if (!aroundLatLng) {
     // Fallback on `configure.aroundLatLng`
     const configureAroundLatLng = getCurrentRefinementValue(
-      props,
+      propsWithoutDefaultRefinement,
       searchState,
       context,
       getConfigureAroundLatLngId()

--- a/packages/react-instantsearch-dom-geo/src/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/GeoSearch.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { LatLngPropType } from './propTypes';
+import { LatLngPropType, BoundingBoxPropType } from './propTypes';
 import Connector from './Connector';
 import Provider from './Provider';
 import GoogleMaps from './GoogleMaps';
@@ -13,6 +13,7 @@ class GeoSearch extends Component {
     initialPosition: LatLngPropType,
     enableRefine: PropTypes.bool,
     enableRefineOnMapMove: PropTypes.bool,
+    defaultRefinement: BoundingBoxPropType,
   };
 
   static defaultProps = {
@@ -20,6 +21,7 @@ class GeoSearch extends Component {
     initialPosition: { lat: 0, lng: 0 },
     enableRefine: true,
     enableRefineOnMapMove: true,
+    defaultRefinement: null,
   };
 
   renderChildrenWithBoundFunction = ({ hits, position, ...rest }) => {
@@ -30,6 +32,7 @@ class GeoSearch extends Component {
       initialPosition,
       enableRefine,
       enableRefineOnMapMove,
+      defaultRefinement,
       ...mapOptions
     } = this.props;
 
@@ -69,12 +72,13 @@ class GeoSearch extends Component {
   };
 
   render() {
-    const { enableRefineOnMapMove } = this.props;
+    const { enableRefineOnMapMove, defaultRefinement } = this.props;
 
     return (
       <Connector
         testID="Connector"
         enableRefineOnMapMove={enableRefineOnMapMove}
+        defaultRefinement={defaultRefinement}
       >
         {this.renderChildrenWithBoundFunction}
       </Connector>

--- a/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/GeoSearch.js
@@ -49,6 +49,26 @@ describe('GeoSearch', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('expect to render with defaultRefinement', () => {
+      const props = {
+        ...defaultProps,
+        defaultRefinement: {
+          northEast: {
+            lat: 10,
+            lng: 12,
+          },
+          southWest: {
+            lat: 12,
+            lng: 14,
+          },
+        },
+      };
+
+      const wrapper = shallow(<GeoSearch {...props}>{() => null}</GeoSearch>);
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
   describe('Provider', () => {

--- a/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
+++ b/packages/react-instantsearch-dom-geo/src/__tests__/__snapshots__/GeoSearch.js.snap
@@ -2,6 +2,26 @@
 
 exports[`GeoSearch Connector expect to render 1`] = `
 <AlgoliaGeoSearch(Connector)
+  defaultRefinement={null}
+  enableRefineOnMapMove={true}
+  testID="Connector"
+/>
+`;
+
+exports[`GeoSearch Connector expect to render with defaultRefinement 1`] = `
+<AlgoliaGeoSearch(Connector)
+  defaultRefinement={
+    Object {
+      "northEast": Object {
+        "lat": 10,
+        "lng": 12,
+      },
+      "southWest": Object {
+        "lat": 12,
+        "lng": 14,
+      },
+    }
+  }
   enableRefineOnMapMove={true}
   testID="Connector"
 />
@@ -9,6 +29,7 @@ exports[`GeoSearch Connector expect to render 1`] = `
 
 exports[`GeoSearch Connector expect to render with enableRefineOnMapMove 1`] = `
 <AlgoliaGeoSearch(Connector)
+  defaultRefinement={null}
   enableRefineOnMapMove={false}
   testID="Connector"
 />

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -62,6 +62,44 @@ stories
     }
   )
   .addWithJSX(
+    'with default refinement',
+    () => (
+      <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <Configure aroundLatLngViaIP hitsPerPage={20} />
+
+        <Container>
+          <GoogleMapsLoader apiKey={apiKey}>
+            {google => (
+              <GeoSearch
+                google={google}
+                defaultRefinement={{
+                  northEast: {
+                    lat: 48.871495114865986,
+                    lng: 2.398494434852978,
+                  },
+                  southWest: {
+                    lat: 48.8432595812564,
+                    lng: 2.326310825844189,
+                  },
+                }}
+              >
+                {({ hits }) => (
+                  <Fragment>
+                    {hits.map(hit => <Marker key={hit.objectID} hit={hit} />)}
+                  </Fragment>
+                )}
+              </GeoSearch>
+            )}
+          </GoogleMapsLoader>
+        </Container>
+      </WrapWithHits>
+    ),
+    {
+      displayName,
+      filterProps,
+    }
+  )
+  .addWithJSX(
     'with refine disabled',
     () => (
       <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">


### PR DESCRIPTION
**Summary**

The `GeoSearch` widget differs from the others because it is not directly wrapped by the connector. It means that we need to pass down the `defaultRefinement` prop to the connector. 

In the connector we have to be careful because we use the `searchState` to retrieve two values `currentRefinement` and `position`. But the latter should not be impacted by the `defaultRefinement`. It means that we need to filter out the `defaultRefinement` prop when retrieve the `position` value.

