### PR TITLE
docs: typo in the file name

### DIFF
--- a/docgen/src/guide/Server-side_rendering.md
+++ b/docgen/src/guide/Server-side_rendering.md
@@ -78,7 +78,7 @@ export { App, findResultsState };
 ```jsx
 import React from 'react';
 import { createServer } from 'http';
-import { App, findResultsState } from './app.js';
+import { App, findResultsState } from './App.js';
 import { renderToString } from 'react-dom/server';
 
 const server = createServer((req, res) => {

--- a/docgen/src/guide/Server-side_rendering.md
+++ b/docgen/src/guide/Server-side_rendering.md
@@ -78,8 +78,8 @@ export { App, findResultsState };
 ```jsx
 import React from 'react';
 import { createServer } from 'http';
-import { App, findResultsState } from './App.js';
 import { renderToString } from 'react-dom/server';
+import { App, findResultsState } from './App';
 
 const server = createServer((req, res) => {
   const searchState = {query: 'chair'};


### PR DESCRIPTION
Small typo in the file name for the `App.js` module.