### PR TITLE
HeirachialMenu empty array parent--item

### DIFF
--- a/packages/react-instantsearch-dom/src/components/List.js
+++ b/packages/react-instantsearch-dom/src/components/List.js
@@ -61,7 +61,7 @@ class List extends Component {
   };
 
   renderItem = (item, resetQuery) => {
-    const items = item.items && (
+    const items = item.items && item.items.length && (
       <ul className={this.props.cx('list', 'list--child')}>
         {item.items
           .slice(0, this.getLimit())


### PR DESCRIPTION
There is more context in AlgoliaPartners#ps-digital8 channel.
![Image of Bug](https://i.imgur.com/q35MbR5.png)

The bug happens when a product is in a level 1 category and a level 2 category.