### PR TITLE
chore(release): avoid interactive release

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -35,8 +35,8 @@
     "build:es": "BABEL_ENV=es babel src --out-dir dist/es --ignore __tests__,__mocks__ --quiet",
     "build:umd": "BABEL_ENV=es rollup -c rollup.config.js",
     "test": "jest",
-    "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
-    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
+    "release": "yarn clean && yarn build && yarn publish --non-interactive",
+    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --non-interactive"
   },
   "dependencies": {
     "algoliasearch-helper": "^2.26.0",

--- a/packages/react-instantsearch-dom-maps/package.json
+++ b/packages/react-instantsearch-dom-maps/package.json
@@ -38,8 +38,8 @@
     "build:es": "BABEL_ENV=es babel src --out-dir dist/es --ignore __tests__,__mocks__ --quiet",
     "build:umd": "BABEL_ENV=rollup rollup -c rollup.config.js",
     "test": "jest",
-    "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
-    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
+    "release": "yarn clean && yarn build && yarn publish --non-interactive",
+    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --non-interactive"
   },
   "dependencies": {
     "lodash": "^4.17.4",

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -37,8 +37,8 @@
     "build:es": "BABEL_ENV=es babel src --out-dir dist/es --ignore __tests__,__mocks__ --quiet",
     "build:umd": "BABEL_ENV=es rollup -c rollup.config.js",
     "test": "jest",
-    "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
-    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
+    "release": "yarn clean && yarn build && yarn publish --non-interactive",
+    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --non-interactive"
   },
   "dependencies": {
     "algoliasearch": "^3.27.1",

--- a/packages/react-instantsearch-native/package.json
+++ b/packages/react-instantsearch-native/package.json
@@ -35,8 +35,8 @@
     "build:cjs": "babel src --out-dir dist/cjs --ignore __tests__,__mocks__ --quiet",
     "build:es": "BABEL_ENV=es babel src --out-dir dist/es --ignore __tests__,__mocks__ --quiet",
     "test": "jest",
-    "release": "yarn clean && yarn build && yarn publish --new-version $VERSION",
-    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --new-version $VERSION"
+    "release": "yarn clean && yarn build && yarn publish --non-interactive",
+    "release:beta": "yarn clean && yarn build && yarn publish --tag beta --non-interactive"
   },
   "dependencies": {
     "algoliasearch": "^3.27.1",

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -33,8 +33,8 @@
     "build:umd": "BABEL_ENV=es rollup -c rollup.config.js",
     "test": "jest",
     "preparePackageFolder": "mkdir -p dist && cp {package.json,README.md} dist",
-    "release": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish --new-version $VERSION",
-    "release:beta": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish --tag beta --new-version $VERSION"
+    "release": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish --non-interactive",
+    "release:beta": "yarn clean && yarn preparePackageFolder && yarn build && cd dist && yarn publish --tag beta --non-interactive"
   },
   "dependencies": {
     "react-instantsearch-core": "^5.2.2",


### PR DESCRIPTION
**Summary**

Yarn can now publish without the interactive prompt even without providing the version. 