### PR TITLE
docs(guide): Deprecated react-instansearch

### DIFF
--- a/docgen/src/Getting_started.md
+++ b/docgen/src/Getting_started.md
@@ -47,7 +47,7 @@ React InstantSearch is available in the [npm](https://www.npmjs.com) registry. T
 yarn add react-instantsearch-dom
 ```
 
-Note: we use `yarn add` to install dependencies but React InstantSearch is also installable via `npm install --save react-instantsearch-dom`.
+Note: we use `yarn add` to install dependencies but React InstantSearch is also installable via `npm install react-instantsearch-dom`.
 
 ## Add the `<InstantSearch>` component
 

--- a/docgen/src/Getting_started.md
+++ b/docgen/src/Getting_started.md
@@ -39,15 +39,15 @@ It contains sample data for an e-commerce website.
 This guide also expects you to have a working [React](https://facebook.github.io/react/) project. If you need to setup a React project, we suggest you use
 [facebookincubator/create-react-app](https://github.com/facebookincubator/create-react-app#getting-started) which is the official React-CLI from Facebook.
 
-## Install `react-instantsearch`
+## Install `react-instantsearch-dom`
 
-React InstantSearch is available in the [npm](https://www.npmjs.com) registry. Install it:
+React InstantSearch is available in the [npm](https://www.npmjs.com) registry. To install it:
 
 ```shell
-yarn add react-instantsearch
+yarn add react-instantsearch-dom
 ```
 
-Note: we use `yarn add` to install dependencies but React InstantSearch is also installable via `npm install`.
+Note: we use `yarn add` to install dependencies but React InstantSearch is also installable via `npm install --save react-instantsearch-dom`.
 
 ## Add the `<InstantSearch>` component
 


### PR DESCRIPTION
In the [Guides Migration Guide - Package import](https://community.algolia.com/react-instantsearch/guide/Migration_guide_package_import.html) it is stated that "The package react-instantsearch is deprecated in favor of react-instantsearch-dom and react-instantsearch-native." while the [guide](https://community.algolia.com/react-instantsearch/Getting_started.html#install-react-instantsearch) still instructs you to install the "react-instantsearch" package and not the "-dom" one.

I also changed the "Note:" part for it to be consistent with the [React-Native](https://community.algolia.com/react-instantsearch/Getting_started_React_native.html) guide.