### PR TITLE
Fix: Compute canRefine on the transformed items

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectCurrentRefinements.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectCurrentRefinements.js
@@ -112,10 +112,11 @@ describe('connectCurrentRefinements', () => {
   });
 
   it('computes canRefine based on the length of the transformed items list', () => {
-    const transformItems = items => [];
+    const transformItems = () => [];
     const props = getProvidedProps({ transformItems }, null, null, [
-      { items: [{ label: 'one' }], id: 1, index: 'something' }
+      { items: [{ label: 'one' }], id: 1, index: 'something' },
     ]);
-    expect(props.canRefine).toEqual(false)
+
+    expect(props.canRefine).toEqual(false);
   });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectCurrentRefinements.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectCurrentRefinements.js
@@ -110,4 +110,12 @@ describe('connectCurrentRefinements', () => {
       { id: 2, index: 'something', label: 'cadabra' },
     ]);
   });
+
+  it('computes canRefine based on the length of the transformed items list', () => {
+    const transformItems = items => [];
+    const props = getProvidedProps({ transformItems }, null, null, [
+      { items: [{ label: 'one' }], id: 1, index: 'something' }
+    ]);
+    expect(props.canRefine).toEqual(false)
+  });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
@@ -544,13 +544,19 @@ describe('connectHierarchicalMenu', () => {
     });
 
     it('computes canRefine based on the length of the transformed items list', () => {
-      const transformItems = items => [];
+      const transformItems = () => [];
       const results = {
-        getFacetValues: () => ({ data: [{ id: "test" }] }),
+        getFacetValues: () => ({ data: [{ id: 'test' }] }),
         getFacetByName: () => true,
         hits: [],
       };
-      props = getProvidedProps({ attributes: ['ok'], transformItems }, {}, { results });
+
+      props = getProvidedProps(
+        { attributes: ['ok'], transformItems },
+        {},
+        { results }
+      );
+
       expect(props.canRefine).toEqual(false);
     });
   });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
@@ -542,7 +542,19 @@ describe('connectHierarchicalMenu', () => {
         hierarchicalMenu: {},
       });
     });
+
+    it('computes canRefine based on the length of the transformed items list', () => {
+      const transformItems = items => [];
+      const results = {
+        getFacetValues: () => ({ data: [{ id: "test" }] }),
+        getFacetByName: () => true,
+        hits: [],
+      };
+      props = getProvidedProps({ attributes: ['ok'], transformItems }, {}, { results });
+      expect(props.canRefine).toEqual(false);
+    });
   });
+
   describe('multi index', () => {
     let context = {
       context: {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectMenu.js
@@ -431,6 +431,17 @@ describe('connectMenu', () => {
         },
       ]);
     });
+
+    it('computes canRefine based on the length of the transformed items list', () => {
+      const transformItems = items => [];
+      const results = {
+        getFacetValues: () => [{ count: 1, id: "test", isRefined: true, name: "test" }],
+        getFacetByName: () => true,
+        hits: [],
+      };
+      props = getProvidedProps({ attribute: 'ok', transformItems }, {}, { results });
+      expect(props.canRefine).toEqual(false);
+    });
   });
   describe('multi index', () => {
     let context = {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectMenu.js
@@ -433,13 +433,21 @@ describe('connectMenu', () => {
     });
 
     it('computes canRefine based on the length of the transformed items list', () => {
-      const transformItems = items => [];
+      const transformItems = () => [];
       const results = {
-        getFacetValues: () => [{ count: 1, id: "test", isRefined: true, name: "test" }],
+        getFacetValues: () => [
+          { count: 1, id: 'test', isRefined: true, name: 'test' },
+        ],
         getFacetByName: () => true,
         hits: [],
       };
-      props = getProvidedProps({ attribute: 'ok', transformItems }, {}, { results });
+
+      props = getProvidedProps(
+        { attribute: 'ok', transformItems },
+        {},
+        { results }
+      );
+
       expect(props.canRefine).toEqual(false);
     });
   });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectNumericMenu.js
@@ -355,12 +355,8 @@ describe('connectNumericMenu', () => {
     });
 
     it('computes canRefine based on the length of the transformed items list', () => {
-      const transformItems = items => [];
-      const results = {
-        getFacetStats: () => ({ min: 0, max: 300 }),
-        getFacetByName: () => true,
-        hits: [],
-      };
+      const transformItems = () => [];
+
       props = getProvidedProps(
         {
           items: [{ label: 'Ok', start: 100 }],
@@ -369,6 +365,7 @@ describe('connectNumericMenu', () => {
         {},
         { results }
       );
+
       expect(props.canRefine).toEqual(false);
     });
   });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectNumericMenu.js
@@ -353,6 +353,24 @@ describe('connectNumericMenu', () => {
         another: { searchState: 'searchState' },
       });
     });
+
+    it('computes canRefine based on the length of the transformed items list', () => {
+      const transformItems = items => [];
+      const results = {
+        getFacetStats: () => ({ min: 0, max: 300 }),
+        getFacetByName: () => true,
+        hits: [],
+      };
+      props = getProvidedProps(
+        {
+          items: [{ label: 'Ok', start: 100 }],
+          transformItems,
+        },
+        {},
+        { results }
+      );
+      expect(props.canRefine).toEqual(false);
+    });
   });
   describe('multi index', () => {
     let context = {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
@@ -422,6 +422,17 @@ describe('connectRefinementList', () => {
         maxFacetHits: 25,
       });
     });
+
+    it('computes canRefine based on the length of the transformed items list', () => {
+      const transformItems = items => [];
+      const results = {
+        getFacetValues: () => [{ count: 1, id: "test", isRefined: true, name: "test" }],
+        getFacetByName: () => true,
+        hits: [],
+      };
+      props = getProvidedProps({ attribute: 'ok', transformItems }, {}, { results });
+      expect(props.canRefine).toEqual(false)
+    });
   });
 
   describe('multi index', () => {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
@@ -424,14 +424,15 @@ describe('connectRefinementList', () => {
     });
 
     it('computes canRefine based on the length of the transformed items list', () => {
-      const transformItems = items => [];
-      const results = {
-        getFacetValues: () => [{ count: 1, id: "test", isRefined: true, name: "test" }],
-        getFacetByName: () => true,
-        hits: [],
-      };
-      props = getProvidedProps({ attribute: 'ok', transformItems }, {}, { results });
-      expect(props.canRefine).toEqual(false)
+      const transformItems = () => [];
+
+      props = getProvidedProps(
+        { attribute: 'ok', transformItems },
+        {},
+        { results }
+      );
+
+      expect(props.canRefine).toEqual(false);
     });
   });
 

--- a/packages/react-instantsearch-core/src/connectors/connectCurrentRefinements.js
+++ b/packages/react-instantsearch-core/src/connectors/connectCurrentRefinements.js
@@ -45,9 +45,13 @@ export default createConnector({
       return res;
     }, []);
 
+    const transformedItems = props.transformItems
+      ? props.transformItems(items)
+      : items;
+
     return {
-      items: props.transformItems ? props.transformItems(items) : items,
-      canRefine: items.length > 0,
+      items: transformedItems,
+      canRefine: transformedItems.length > 0,
     };
   },
 

--- a/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
@@ -204,7 +204,7 @@ export default createConnector({
     return {
       items: truncate(transformedItems, itemsLimit),
       currentRefinement: getCurrentRefinement(props, searchState, this.context),
-      canRefine: items.length > 0,
+      canRefine: transformedItems.length > 0,
     };
   },
 

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -166,7 +166,7 @@ export default createConnector({
       currentRefinement: getCurrentRefinement(props, searchState, this.context),
       isFromSearch,
       searchable,
-      canRefine: items.length > 0,
+      canRefine: transformedItems.length > 0,
     };
   },
 

--- a/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
@@ -168,7 +168,8 @@ export default createConnector({
       items: transformedItems,
       currentRefinement,
       canRefine:
-        transformedItems.length > 0 && transformedItems.some(item => item.noRefinement === false),
+        transformedItems.length > 0 &&
+        transformedItems.some(item => item.noRefinement === false),
     };
   },
 

--- a/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
@@ -160,11 +160,15 @@ export default createConnector({
       });
     }
 
+    const transformedItems = props.transformItems
+      ? props.transformItems(items)
+      : items;
+
     return {
-      items: props.transformItems ? props.transformItems(items) : items,
+      items: transformedItems,
       currentRefinement,
       canRefine:
-        items.length > 0 && items.some(item => item.noRefinement === false),
+        transformedItems.length > 0 && transformedItems.some(item => item.noRefinement === false),
     };
   },
 

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -179,7 +179,7 @@ export default createConnector({
       currentRefinement: getCurrentRefinement(props, searchState, this.context),
       isFromSearch,
       searchable,
-      canRefine: items.length > 0,
+      canRefine: transformedItems.length > 0,
     };
   },
 


### PR DESCRIPTION
Resolves #1524

**Summary**
There was previously a bug where `canRefine` props were calculated based on untransformed item lists. This caused unintended behaviors such as a ClearRefinements button remaining active when a refinement being ignored via a filter in `transformItems` was present.

**Result**
This PR calculates `canRefine` on the transformed list of items, correcting this behavior.

