### PR TITLE
chore(docgen): add special case for edit this page on GeoSearch

### DIFF
--- a/docgen/assets/js/editThisPage.js
+++ b/docgen/assets/js/editThisPage.js
@@ -10,7 +10,10 @@ if (document.querySelector('.documentation-container')) {
 
   let pathname = document.location.pathname.replace('/react-instantsearch', '');
 
-  if (/^\/(?:widgets)\/.+/.test(pathname)) {
+  // Special case for the GeoSearch
+  if (/^\/(?:widgets\/GeoSearch).+/.test(pathname)) {
+    href += '/docgen/src/widgets/GeoSearch.md';
+  } else if (/^\/(?:widgets)\/.+/.test(pathname)) {
     href += `${apiDom}${pathname.replace('.html', '.js')}`;
 
     const instantsearchEncoded = encodeURIComponent('<InstantSearch>');


### PR DESCRIPTION
**Summary**

This PR fix the "Edit this page" button for the GeoSearch widget. It's the only one (for now) that doesn't have the doc written with the JSDoc. It's written with a plain Markdown file. I've added a special case for this widget. It's far from the best implem but the doc will move so it's fine for the moment.
