### PR TITLE
feat(connectToggleRefinement): implement canRefine & count

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "63.5 kB"
+      "maxSize": "63.75 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
@@ -3,7 +3,6 @@ import connect from '../connectToggleRefinement';
 
 jest.mock('../../core/createConnector', () => x => x);
 
-let props;
 let params;
 
 describe('connectToggleRefinement', () => {
@@ -15,15 +14,52 @@ describe('connectToggleRefinement', () => {
     const getMetadata = connect.getMetadata.bind(context);
     const cleanUp = connect.cleanUp.bind(context);
 
-    it('provides the correct props to the component', () => {
-      props = getProvidedProps({ attribute: 't' }, {});
-      expect(props).toEqual({ currentRefinement: false });
+    it('provides the correct props to the component with the value unchecked', () => {
+      const _props = { attribute: 't' };
+      const searchState = {};
+      const searchResults = {};
 
-      props = getProvidedProps({ attribute: 't' }, { toggle: { t: true } });
-      expect(props).toEqual({ currentRefinement: true });
+      const providedProps = getProvidedProps(
+        _props,
+        searchState,
+        searchResults
+      );
 
-      props = getProvidedProps({ defaultRefinement: true, attribute: 't' }, {});
-      expect(props).toEqual({ currentRefinement: true });
+      expect(providedProps).toEqual({
+        currentRefinement: false,
+      });
+    });
+
+    it('provides the correct props to the component with value checked', () => {
+      const _props = { attribute: 't' };
+      const searchState = { toggle: { t: true } };
+      const searchResults = {};
+
+      const providedProps = getProvidedProps(
+        _props,
+        searchState,
+        searchResults
+      );
+
+      expect(providedProps).toEqual({
+        currentRefinement: true,
+      });
+    });
+
+    it('provides the correct props to the component with a default refinement', () => {
+      const _props = { defaultRefinement: true, attribute: 't' };
+      const searchState = {};
+      const searchResults = {};
+
+      const providedProps = getProvidedProps(
+        _props,
+        searchState,
+        searchResults
+      );
+
+      expect(providedProps).toEqual({
+        currentRefinement: true,
+      });
     });
 
     it("calling refine updates the widget's search state", () => {
@@ -177,6 +213,7 @@ describe('connectToggleRefinement', () => {
       });
     });
   });
+
   describe('multi index', () => {
     let context = {
       context: {
@@ -184,20 +221,40 @@ describe('connectToggleRefinement', () => {
         multiIndexContext: { targetedIndex: 'first' },
       },
     };
+
     const getProvidedProps = connect.getProvidedProps.bind(context);
     const getSP = connect.getSearchParameters.bind(context);
     const getMetadata = connect.getMetadata.bind(context);
     const cleanUp = connect.cleanUp.bind(context);
 
-    it('provides the correct props to the component', () => {
-      props = getProvidedProps({ attribute: 't' }, {});
-      expect(props).toEqual({ currentRefinement: false });
+    it('provides the correct props to the component with value unchecked', () => {
+      const _props = { attribute: 't' };
+      const searchState = {};
+      const searchResults = {};
 
-      props = getProvidedProps(
-        { attribute: 't' },
-        { indices: { first: { toggle: { t: true } } } }
+      const providedProps = getProvidedProps(
+        _props,
+        searchState,
+        searchResults
       );
-      expect(props).toEqual({ currentRefinement: true });
+
+      expect(providedProps).toEqual({ currentRefinement: false });
+    });
+
+    it('provides the correct props to the component with value checked', () => {
+      const _props = { attribute: 't' };
+      const searchState = { indices: { first: { toggle: { t: true } } } };
+      const searchResults = {};
+
+      const providedProps = getProvidedProps(
+        _props,
+        searchState,
+        searchResults
+      );
+
+      expect(providedProps).toEqual({
+        currentRefinement: true,
+      });
     });
 
     it("calling refine updates the widget's search state", () => {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
@@ -14,6 +14,7 @@ describe('connectToggleRefinement', () => {
     const getSP = connect.getSearchParameters.bind(context);
     const getMetadata = connect.getMetadata.bind(context);
     const cleanUp = connect.cleanUp.bind(context);
+
     it('provides the correct props to the component', () => {
       props = getProvidedProps({ attribute: 't' }, {});
       expect(props).toEqual({ currentRefinement: false });
@@ -45,16 +46,38 @@ describe('connectToggleRefinement', () => {
       });
     });
 
-    it('refines the corresponding facet', () => {
+    it('refines the corresponding facet with `true`', () => {
       params = getSP(
         new SearchParameters(),
         {
           attribute: 'facet',
           value: 'val',
         },
-        { toggle: { facet: true } }
+        {
+          toggle: {
+            facet: true,
+          },
+        }
       );
-      expect(params.getConjunctiveRefinements('facet')).toEqual(['val']);
+
+      expect(params.getDisjunctiveRefinements('facet')).toEqual(['val']);
+    });
+
+    it('does not refine the corresponding facet with `false`', () => {
+      params = getSP(
+        new SearchParameters(),
+        {
+          attribute: 'facet',
+          value: 'val',
+        },
+        {
+          toggle: {
+            facet: false,
+          },
+        }
+      );
+
+      expect(params.getDisjunctiveRefinements('facet')).toEqual([]);
     });
 
     it('applies the provided filter', () => {
@@ -192,16 +215,46 @@ describe('connectToggleRefinement', () => {
       });
     });
 
-    it('refines the corresponding facet', () => {
+    it('refines the corresponding facet with `true`', () => {
       params = getSP(
         new SearchParameters(),
         {
           attribute: 'facet',
           value: 'val',
         },
-        { indices: { first: { toggle: { facet: true } } } }
+        {
+          indices: {
+            first: {
+              toggle: {
+                facet: true,
+              },
+            },
+          },
+        }
       );
-      expect(params.getConjunctiveRefinements('facet')).toEqual(['val']);
+
+      expect(params.getDisjunctiveRefinements('facet')).toEqual(['val']);
+    });
+
+    it('does not refines the corresponding facet with `false`', () => {
+      params = getSP(
+        new SearchParameters(),
+        {
+          attribute: 'facet',
+          value: 'val',
+        },
+        {
+          indices: {
+            first: {
+              toggle: {
+                facet: false,
+              },
+            },
+          },
+        }
+      );
+
+      expect(params.getDisjunctiveRefinements('facet')).toEqual([]);
     });
 
     it('applies the provided filter', () => {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
@@ -80,16 +80,38 @@ describe('connectToggleRefinement', () => {
       expect(params.getDisjunctiveRefinements('facet')).toEqual([]);
     });
 
-    it('applies the provided filter', () => {
+    it('applies the provided filter with `true`', () => {
       params = getSP(
         new SearchParameters(),
         {
           attribute: 'facet',
           filter: sp => sp.setQuery('yep'),
         },
-        { toggle: { facet: true } }
+        {
+          toggle: {
+            facet: true,
+          },
+        }
       );
+
       expect(params.query).toEqual('yep');
+    });
+
+    it('does not apply the provided filter with `false`', () => {
+      params = getSP(
+        new SearchParameters(),
+        {
+          attribute: 'facet',
+          filter: sp => sp.setQuery('yep'),
+        },
+        {
+          toggle: {
+            facet: false,
+          },
+        }
+      );
+
+      expect(params.query).toEqual('');
     });
 
     it('registers its filter in metadata', () => {
@@ -257,16 +279,46 @@ describe('connectToggleRefinement', () => {
       expect(params.getDisjunctiveRefinements('facet')).toEqual([]);
     });
 
-    it('applies the provided filter', () => {
+    it('applies the provided filter with `true`', () => {
       params = getSP(
         new SearchParameters(),
         {
           attribute: 'facet',
           filter: sp => sp.setQuery('yep'),
         },
-        { indices: { first: { toggle: { facet: true } } } }
+        {
+          indices: {
+            first: {
+              toggle: {
+                facet: true,
+              },
+            },
+          },
+        }
       );
+
       expect(params.query).toEqual('yep');
+    });
+
+    it('does not apply the provided filter with `false`', () => {
+      params = getSP(
+        new SearchParameters(),
+        {
+          attribute: 'facet',
+          filter: sp => sp.setQuery('yep'),
+        },
+        {
+          indices: {
+            first: {
+              toggle: {
+                facet: false,
+              },
+            },
+          },
+        }
+      );
+
+      expect(params.query).toEqual('');
     });
 
     it('registers its filter in metadata', () => {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
@@ -558,7 +558,7 @@ describe('connectToggleRefinement', () => {
       expect(params.getDisjunctiveRefinements('facet')).toEqual(['val']);
     });
 
-    it('does not refines the corresponding facet with `false`', () => {
+    it('does not refine the corresponding facet with `false`', () => {
       params = getSP(
         new SearchParameters(),
         {

--- a/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
@@ -62,10 +62,10 @@ export default createConnector({
   displayName: 'AlgoliaToggle',
 
   propTypes: {
-    label: PropTypes.string,
+    label: PropTypes.string.isRequired,
+    attribute: PropTypes.string.isRequired,
+    value: PropTypes.any.isRequired,
     filter: PropTypes.func,
-    attribute: PropTypes.string,
-    value: PropTypes.any,
     defaultRefinement: PropTypes.bool,
   },
 

--- a/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
@@ -80,24 +80,24 @@ export default createConnector({
       this.context
     );
 
-    const facetValues = results && results.getFacetValues(attribute);
+    const allFacetValues = results && results.getFacetValues(attribute);
     const facetValue =
       // Use null to always be consistent with type of the value
       // count: number | null
-      facetValues && facetValues.length
-        ? find(facetValues, item => item.name === value.toString())
+      allFacetValues && allFacetValues.length
+        ? find(allFacetValues, item => item.name === value.toString())
         : null;
 
     const facetValueCount = facetValue && facetValue.count;
-    const facetValuesCount =
+    const allFacetValuesCount =
       // Use null to always be consistent with type of the value
       // count: number | null
-      facetValues && facetValues.length
-        ? facetValues.reduce((acc, item) => acc + item.count, 0)
+      allFacetValues && allFacetValues.length
+        ? allFacetValues.reduce((acc, item) => acc + item.count, 0)
         : null;
 
     const count = {
-      checked: facetValuesCount,
+      checked: allFacetValuesCount,
       unchecked: facetValueCount,
     };
 

--- a/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
@@ -90,12 +90,14 @@ export default createConnector({
     const { attribute, value, filter } = props;
     const checked = getCurrentRefinement(props, searchState, this.context);
 
+    searchParameters = searchParameters.addDisjunctiveFacet(attribute);
+
     if (checked) {
-      if (attribute) {
-        searchParameters = searchParameters
-          .addFacet(attribute)
-          .addFacetRefinement(attribute, value);
-      }
+      searchParameters = searchParameters.addDisjunctiveFacetRefinement(
+        attribute,
+        value
+      );
+
       if (filter) {
         searchParameters = filter(searchParameters);
       }

--- a/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
@@ -90,20 +90,20 @@ export default createConnector({
     const { attribute, value, filter } = props;
     const checked = getCurrentRefinement(props, searchState, this.context);
 
-    searchParameters = searchParameters.addDisjunctiveFacet(attribute);
+    let nextSearchParameters = searchParameters.addDisjunctiveFacet(attribute);
 
     if (checked) {
-      searchParameters = searchParameters.addDisjunctiveFacetRefinement(
+      nextSearchParameters = nextSearchParameters.addDisjunctiveFacetRefinement(
         attribute,
         value
       );
 
       if (filter) {
-        searchParameters = filter(searchParameters);
+        nextSearchParameters = filter(nextSearchParameters);
       }
     }
 
-    return searchParameters;
+    return nextSearchParameters;
   },
 
   getMetadata(props, searchState) {

--- a/packages/react-instantsearch-dom/src/components/ToggleRefinement.js
+++ b/packages/react-instantsearch-dom/src/components/ToggleRefinement.js
@@ -5,8 +5,14 @@ import { createClassNames } from '../core/utils';
 
 const cx = createClassNames('ToggleRefinement');
 
-const ToggleRefinement = ({ currentRefinement, label, refine, className }) => (
-  <div className={classNames(cx(''), className)}>
+const ToggleRefinement = ({
+  currentRefinement,
+  label,
+  canRefine,
+  refine,
+  className,
+}) => (
+  <div className={classNames(cx('', !canRefine && '-noRefinement'), className)}>
     <label className={cx('label')}>
       <input
         className={cx('checkbox')}
@@ -22,6 +28,7 @@ const ToggleRefinement = ({ currentRefinement, label, refine, className }) => (
 ToggleRefinement.propTypes = {
   currentRefinement: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,
+  canRefine: PropTypes.bool.isRequired,
   refine: PropTypes.func.isRequired,
   className: PropTypes.string,
 };

--- a/packages/react-instantsearch-dom/src/components/__tests__/ToggleRefinement.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/ToggleRefinement.js
@@ -9,6 +9,7 @@ describe('ToggleRefinement', () => {
   const defaultProps = {
     currentRefinement: true,
     label: 'toggle the refinement',
+    canRefine: true,
     refine: () => {},
   };
 
@@ -26,6 +27,17 @@ describe('ToggleRefinement', () => {
     const props = {
       ...defaultProps,
       currentRefinement: false,
+    };
+
+    const wrapper = shallow(<ToggleRefinement {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expect to render with a negative canRefine', () => {
+    const props = {
+      ...defaultProps,
+      canRefine: false,
     };
 
     const wrapper = shallow(<ToggleRefinement {...props} />);

--- a/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/ToggleRefinement.js.snap
+++ b/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/ToggleRefinement.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ToggleRefinement expect to render with a negative canRefine 1`] = `
+<div
+  className="ais-ToggleRefinement ais-ToggleRefinement--noRefinement"
+>
+  <label
+    className="ais-ToggleRefinement-label"
+  >
+    <input
+      checked={true}
+      className="ais-ToggleRefinement-checkbox"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <span
+      className="ais-ToggleRefinement-labelText"
+    >
+      toggle the refinement
+    </span>
+  </label>
+</div>
+`;
+
 exports[`ToggleRefinement expect to render with a negative currentRefinement 1`] = `
 <div
   className="ais-ToggleRefinement"


### PR DESCRIPTION
**Summary**

This PR adds `canRefine` & `count` on the provided props of the `connectToggleRefinement` connector. I didn't implement the count on the widget because it will be a breaking change only in the connector. 

The count object has the following shape (see below). When the `currentRefinement` is `false` (unchecked) the user can pick the `unchecked` attribute. It displays the number of results that match the value provided to the Toggle widget. Once it's checked the count displays the total number of results (compute from the facet values).

```ts
type Count = {
  checked: number | null;
  unchecked: number | null;
};
```

**Changes**:

- the computation of the `SearchParameters` (conjunctiveFacet -> disjunctiveFacet)
- the computation of the `providedProps` (adds `canRefine` & `count`)
- adds the `noRefinement` class on the Toggle root element