### PR TITLE
 fix(toggle): compute canRefine differently when it is refined

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
@@ -67,15 +67,33 @@ describe('connectToggleRefinement', () => {
       expect(actual.currentRefinement).toBe(true);
     });
 
-    it('expect `canRefine` to be `true` with results', () => {
+    it('expect `canRefine` to be computed to `true` from all the facet values when the value is checked', () => {
       const props = { attribute: 'shipping', value: true };
-      const searchState = {};
+      const searchState = { toggle: { shipping: true } };
       const searchResults = createSingleIndexSearchResults({
         disjunctiveFacets: ['shipping'],
         facets: {
           shipping: {
             true: 100,
             false: 50,
+          },
+        },
+      });
+
+      const actual = getProvidedProps(props, searchState, searchResults);
+
+      expect(actual.canRefine).toBe(true);
+    });
+
+    it('expect `canRefine` to be computed to `true` from the selected facet value when the value is not checked', () => {
+      const props = { attribute: 'shipping', value: true };
+      const searchState = {};
+      const searchResults = createSingleIndexSearchResults({
+        disjunctiveFacets: ['shipping'],
+        facets: {
+          shipping: {
+            true: 50,
+            false: 100,
           },
         },
       });
@@ -389,15 +407,35 @@ describe('connectToggleRefinement', () => {
       expect(actual.currentRefinement).toBe(true);
     });
 
-    it('expect `canRefine` to be `true` with results', () => {
+    it('expect `canRefine` to be computed to `true` from all the facet values when the value is checked', () => {
       const props = { attribute: 'shipping', value: true };
-      const searchState = createMultiIndexSearchState();
+      const searchState = createMultiIndexSearchState({
+        toggle: { shipping: true },
+      });
       const searchResults = createMultiIndexSearchResults({
         disjunctiveFacets: ['shipping'],
         facets: {
           shipping: {
             true: 100,
             false: 50,
+          },
+        },
+      });
+
+      const actual = getProvidedProps(props, searchState, searchResults);
+
+      expect(actual.canRefine).toBe(true);
+    });
+
+    it('expect `canRefine` to be computed to `true` from the selected facet value when the value is not checked', () => {
+      const props = { attribute: 'shipping', value: true };
+      const searchState = createMultiIndexSearchState();
+      const searchResults = createMultiIndexSearchResults({
+        disjunctiveFacets: ['shipping'],
+        facets: {
+          shipping: {
+            true: 50,
+            false: 100,
           },
         },
       });

--- a/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
@@ -97,14 +97,18 @@ export default createConnector({
         ? allFacetValues.reduce((acc, item) => acc + item.count, 0)
         : null;
 
+    const canRefine = currentRefinement
+      ? allFacetValuesCount !== null && allFacetValuesCount > 0
+      : facetValueCount !== null && facetValueCount > 0;
+
     const count = {
       checked: allFacetValuesCount,
       unchecked: facetValueCount,
     };
 
     return {
-      canRefine: facetValueCount !== null && facetValueCount > 0,
       currentRefinement,
+      canRefine,
       count,
     };
   },


### PR DESCRIPTION
**Summary**

The connector fix the `canRefine` computation. Previously the computation was only on the facet value count whether the value is refined or not. But when the value is refined we should compute `canRefine` with all the facet values. e.g. The checkbox is selected  and the search returns no results. We still want to be able to unchecked the checkbox if without the filter there are results.