### PR TITLE
Hit Component: include Index Position as a data attribute

### DIFF
--- a/packages/react-instantsearch-dom/src/components/Hits.js
+++ b/packages/react-instantsearch-dom/src/components/Hits.js
@@ -10,9 +10,12 @@ const Hits = ({ hits, className, hitComponent: HitComponent }) => (
   // ex: <HitComponent {...hit} key={hit.objectID} />
   <div className={classNames(cx(''), className)}>
     <ul className={cx('list')}>
-      {hits.map(hit => (
+      {hits.map((hit, indexPosition) => (
         <li className={cx('item')} key={hit.objectID}>
-          <HitComponent hit={hit} />
+          <HitComponent
+            hit={hit}
+            indexPosition={indexPosition}
+          />
         </li>
       ))}
     </ul>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Summary

Use Case: As a consumer of Algolia/react-instancesearch, I want to be able to track the position of the hit my user has click.

Solution: pass `indexPosition` to `HitComponent`

Friendly Note: If there's already a way to do this that isn't hacky please let me know. As of currently I'm grabbing the hitID and reaching into the dom and determining the position of the hit manually.

Alternative Implementation: We could also add a data-attribute on the `Hit` component. Please see https://github.com/algolia/react-instantsearch/pull/1608

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
