### PR TITLE
fix(toggle): ensure facet is present

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
@@ -121,11 +121,24 @@ describe('connectToggleRefinement', () => {
       expect(actual.canRefine).toBe(false);
     });
 
-    it('expect `canRefine` to be `false` without the facet', () => {
+    it('expect `canRefine` to be `false` without the facet values', () => {
       const props = { attribute: 'shipping', value: true };
       const searchState = {};
       const searchResults = createSingleIndexSearchResults({
         disjunctiveFacets: ['shipping'],
+        facets: {},
+      });
+
+      const actual = getProvidedProps(props, searchState, searchResults);
+
+      expect(actual.canRefine).toBe(false);
+    });
+
+    it('expect `canRefine` to be `false` without the facet', () => {
+      const props = { attribute: 'shipping', value: true };
+      const searchState = {};
+      const searchResults = createSingleIndexSearchResults({
+        disjunctiveFacets: [],
         facets: {},
       });
 
@@ -463,11 +476,24 @@ describe('connectToggleRefinement', () => {
       expect(actual.canRefine).toBe(false);
     });
 
-    it('expect `canRefine` to be `false` without the facet', () => {
+    it('expect `canRefine` to be `false` without the facet values', () => {
       const props = { attribute: 'shipping', value: true };
       const searchState = createMultiIndexSearchState();
       const searchResults = createMultiIndexSearchResults({
         disjunctiveFacets: ['shipping'],
+        facets: {},
+      });
+
+      const actual = getProvidedProps(props, searchState, searchResults);
+
+      expect(actual.canRefine).toBe(false);
+    });
+
+    it('expect `canRefine` to be `false` without the facet', () => {
+      const props = { attribute: 'shipping', value: true };
+      const searchState = createMultiIndexSearchState();
+      const searchResults = createMultiIndexSearchResults({
+        disjunctiveFacets: [],
         facets: {},
       });
 

--- a/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
@@ -81,7 +81,11 @@ export default createConnector({
       this.context
     );
 
-    const allFacetValues = results && results.getFacetValues(attribute);
+    const allFacetValues =
+      results && results.getFacetByName(attribute)
+        ? results.getFacetValues(attribute)
+        : null;
+
     const facetValue =
       // Use null to always be consistent with type of the value
       // count: number | null


### PR DESCRIPTION
**Summary**

This PR fixes an issue when we tried to access the facet values on a `SearchResults` that don't have the expected facet. We can ensure this with `getFacetByName` - this method is deprecated on the helper but we don't have a proper alternative yet.

**Before**

![before](https://user-images.githubusercontent.com/6513513/46029529-fc765700-c0f3-11e8-8963-877c31a35301.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/46029539-04ce9200-c0f4-11e8-83ce-8b1bfe631423.gif)
