### PR TITLE
docs(refresh): use setState callback

### DIFF
--- a/docgen/src/guide/Refreshing_cache.md
+++ b/docgen/src/guide/Refreshing_cache.md
@@ -35,21 +35,18 @@ class App extends Component {
   }
 
   refresh = () => {
-    this.setState({ refresh: true });
-  };
-
-  onSearchStateChange = () => {
-    this.setState({ refresh: false });
+    this.setState({ refresh: true }, () => {
+      this.setState({ refresh: false });
+    });
   };
 
   render() {
     return (
       <InstantSearch
-        appId="yourAppId"
-        apiKey="yourApiKey"
-        indexName="yourIndexName"
+        appId="latency"
+        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+        indexName="instant_search"
         refresh={this.state.refresh}
-        onSearchStateChange={this.onSearchStateChange}
       >
         <SearchBox />
         <button onClick={this.refresh}>Refresh cache</button>
@@ -82,25 +79,26 @@ class App extends Component {
   }
 
   componentDidMount() {
-    this.interval = setInterval(() => this.setState({ refresh: true }), 5000);
+    this.interval = setInterval(
+      () =>
+        this.setState({ refresh: true }, () => {
+          this.setState({ refresh: false });
+        }),
+      5000
+    );
   }
 
   componentWillUnmount() {
     clearInterval(this.interval);
   }
 
-  onSearchStateChange = () => {
-    this.setState({ refresh: false });
-  };
-
   render() {
     return (
       <InstantSearch
-        appId="yourAppId"
-        apiKey="yourApiKey"
-        indexName="yourIndexName"
+        appId="latency"
+        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+        indexName="instant_search"
         refresh={this.state.refresh}
-        onSearchStateChange={this.onSearchStateChange}
       >
         <SearchBox />
         <Hits />

--- a/docgen/src/guide/Refreshing_cache.md
+++ b/docgen/src/guide/Refreshing_cache.md
@@ -23,7 +23,13 @@ If you know that the cache needs to be refreshed conditionally of a specific eve
 
 ```jsx
 import React, { Component } from 'react';
+import algoliasearch from 'algoliasearch/lite';
 import { InstantSearch, SearchBox, Hits } from 'react-instantsearch-dom';
+
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
 
 class App extends Component {
   constructor(props) {
@@ -43,9 +49,8 @@ class App extends Component {
   render() {
     return (
       <InstantSearch
-        appId="latency"
-        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
         indexName="instant_search"
+        searchClient={searchClient}
         refresh={this.state.refresh}
       >
         <SearchBox />
@@ -67,7 +72,13 @@ You should use this approach if you cannot use a user action as a specific event
 
 ```jsx
 import React, { Component } from 'react';
+import algoliasearch from 'algoliasearch/lite';
 import { InstantSearch, SearchBox, Hits } from 'react-instantsearch-dom';
+
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
 
 class App extends Component {
   constructor(props) {
@@ -95,9 +106,8 @@ class App extends Component {
   render() {
     return (
       <InstantSearch
-        appId="latency"
-        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
         indexName="instant_search"
+        searchClient={searchClient}
         refresh={this.state.refresh}
       >
         <SearchBox />

--- a/stories/RefreshCache.stories.js
+++ b/stories/RefreshCache.stories.js
@@ -1,9 +1,15 @@
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
+import algoliasearch from 'algoliasearch/lite';
 import { InstantSearch, SearchBox, Configure } from 'react-instantsearch-dom';
 import { CustomHits } from './util';
 
 const stories = storiesOf('RefreshCache', module);
+
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
 
 class AppWithRefresh extends Component {
   state = {
@@ -19,9 +25,8 @@ class AppWithRefresh extends Component {
   render() {
     return (
       <InstantSearch
-        appId="latency"
-        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
         indexName="instant_search"
+        searchClient={searchClient}
         refresh={this.state.refresh}
       >
         <Configure hitsPerPage={5} />
@@ -139,9 +144,8 @@ class App extends Component {
   render() {
     return (
       <InstantSearch
-        appId="latency"
-        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
         indexName="instant_search"
+        searchClient={searchClient}
         refresh={this.state.refresh}
       >
         <Configure hitsPerPage={5} />

--- a/stories/RefreshCache.stories.js
+++ b/stories/RefreshCache.stories.js
@@ -1,36 +1,30 @@
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
-import { InstantSearch, SearchBox } from 'react-instantsearch-dom';
+import { InstantSearch, SearchBox, Configure } from 'react-instantsearch-dom';
 import { CustomHits } from './util';
 
 const stories = storiesOf('RefreshCache', module);
 
 class AppWithRefresh extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      refresh: false,
-    };
-  }
-
-  refresh = () => {
-    this.setState({ refresh: true });
+  state = {
+    refresh: false,
   };
 
-  onSearchStateChange = () => {
-    this.setState({ refresh: false });
+  refresh = () => {
+    this.setState({ refresh: true }, () => {
+      this.setState({ refresh: false });
+    });
   };
 
   render() {
-    const displayRefresh = `${this.state.refresh}`;
     return (
       <InstantSearch
         appId="latency"
         apiKey="6be0576ff61c053d5f9a3225e2a90f76"
         indexName="instant_search"
         refresh={this.state.refresh}
-        onSearchStateChange={this.onSearchStateChange}
       >
+        <Configure hitsPerPage={5} />
         <div>
           <h2
             style={{
@@ -101,26 +95,11 @@ class AppWithRefresh extends Component {
             cursor: 'pointer',
             color: '#fff',
             background: '#3369e7',
+            marginTop: '10px',
           }}
         >
           Refresh cache
         </button>
-        <button
-          style={{
-            borderRadius: '2px',
-            padding: '10px',
-            marginTop: '15px',
-            border: 'none',
-            fontSize: '12px',
-            color: '#999999',
-            background: '#F3F3F3',
-            display: 'block',
-          }}
-          disabled
-        >
-          Refresh is set to: <em>{displayRefresh}</em>
-        </button>
-
         <CustomHits />
       </InstantSearch>
     );
@@ -130,21 +109,25 @@ class AppWithRefresh extends Component {
 stories.add('with a refresh button', () => <AppWithRefresh />);
 
 class App extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      refresh: false,
-      count: 0,
-    };
-  }
+  state = {
+    refresh: false,
+    count: 0,
+  };
 
   componentDidMount() {
     this.interval = setInterval(
       () =>
-        this.setState(prevState => ({
-          refresh: prevState.count === 5,
-          count: prevState.count === 5 ? 0 : prevState.count + 1,
-        })),
+        this.setState(
+          prevState => ({
+            refresh: prevState.count === 5,
+            count: prevState.count === 5 ? 0 : prevState.count + 1,
+          }),
+          () => {
+            this.setState({
+              refresh: false,
+            });
+          }
+        ),
       1000
     );
   }
@@ -161,6 +144,8 @@ class App extends Component {
         indexName="instant_search"
         refresh={this.state.refresh}
       >
+        <Configure hitsPerPage={5} />
+
         <span>{this.state.count} s elapsed since last refresh</span>
 
         <SearchBox


### PR DESCRIPTION
**Summary**

The previous implementation of the examples was relying on the `onSearchStateChange` callback to reset the `refresh` value. But the callback is not triggered when the cache is refreshed. It means that the value remains `true` until the search **actually** change. 

This PR reset the value immediately with the help of the `setState` callback.