### PR TITLE
Add option to disable empty search

### DIFF
--- a/packages/react-instantsearch-core/src/components/InstantSearch.js
+++ b/packages/react-instantsearch-core/src/components/InstantSearch.js
@@ -35,6 +35,7 @@ function validateNextProps(props, nextProps) {
  * @propType {func} [createURL] - Function to call when creating links, useful for [URL Routing](guide/Routing.html).
  * @propType {SearchResults|SearchResults[]} [resultsState] - Use this to inject the results that will be used at first rendering. Those results are found by using the `findResultsState` function. Useful for [Server Side Rendering](guide/Server-side_rendering.html).
  * @propType {number} [stalledSearchDelay=200] - The amount of time before considering that the search takes too much time. The time is expressed in milliseconds.
+ * @propType {boolean} [disableEmptySearch=false] - Flag to activate when searching for empty query is not desired.
  * @propType {{ Root: string|function, props: object }} [root] - Use this to customize the root element. Default value: `{ Root: 'div' }`
  * @example
  * import React from 'react';
@@ -64,6 +65,7 @@ class InstantSearch extends Component {
       initialState,
       resultsState: props.resultsState,
       stalledSearchDelay: props.stalledSearchDelay,
+      disableEmptySearch: props.disableEmptySearch,
     });
   }
 
@@ -202,6 +204,7 @@ InstantSearch.propTypes = {
   }).isRequired,
 
   stalledSearchDelay: PropTypes.number,
+  disableEmptySearch: PropTypes.bool,
 };
 
 InstantSearch.childContextTypes = {

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -19,6 +19,7 @@ export default function createInstantSearchManager({
   searchClient,
   resultsState,
   stalledSearchDelay,
+  disableEmptySearch,
 }) {
   const baseSP = new SearchParameters({
     index: indexName,
@@ -157,6 +158,10 @@ export default function createInstantSearchManager({
       });
 
       helper.setState(mainIndexParameters);
+
+      if (disableEmptySearch && !helper.state.query) {
+        return;
+      }
 
       helper.search();
     }


### PR DESCRIPTION
Closes #1111 

Added an extra prop to `InstantSearch` which disables searching for empty queries.

As suggested in the issue it might also be an option to add a `searchFunction` hook which can be used to disable searching depending on the query. I'm open to implementing it if that would be a prefered solution.