### PR TITLE
chore: pin Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/react-instantsearch
   docker:
-    - image: circleci/node:8.12.0
+    - image: circleci/node:8.12.0@sha256:8b8ccd3e428085a6db8632e7248f841bfe51715a14bc8d0177c720e109ac8c31
 
 version: 2
 jobs:
@@ -57,7 +57,7 @@ jobs:
   test_e2e:
     <<: *defaults
     docker:
-      - image: circleci/node:8.12.0-browsers
+      - image: circleci/node:8.12.0-browsers@sha256:dc17d45c731dd31c3d727eb421cecff018e92c6c1967b19ad69aaec764fc3fae
     environment:
       FIREFOX_VERSION: '56.0'
     steps:


### PR DESCRIPTION
Recently the E2E tests stop working without any changes on the packages dependencies. The test did pass locally but they only failed on CircleCI. It's because Docker image tags are **mutable**. They can change at any time - it appears that one of the image update breaks one of the tools that we use for the E2E tests. To fix this issue we now pin the Docker images with their digest hash. 

Renovate should take care of the update in a dedicated PR.

> https://renovatebot.com/blog/docker-mutable-tags