### PR TITLE
chore: update Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,7 @@
 {
-  "pinVersions": true,
-  "semanticCommits": true,
-  "extends": [":library"],
-  "depTypes": [
-    {
-      "depType": "dependencies",
-      "pinVersions": false,
-      "semanticPrefix": "chore(deps): "
-    }
-  ],
-  "ignoreDeps": ["jsdoc-parse", "uglify-js"],
-  "packageRules": [
-    {
-      "packagePatterns": "^@storybook",
-      "groupName": ["@storybook packages"]
-    }
-  ],
-  "automerge": true,
-  "major": {
-    "automerge": false
-  }
+  "extends": [
+    "config:js-lib",
+    ":automergeMinor",
+    ":automergePr"
+  ]
 }


### PR DESCRIPTION
Renovate change *a lot* since we did this configuration. The default presets cover almost all the configuration that we previously have. I did not use the Algolia one because I don't want to have the scheduler on the repo.
