### PR TITLE
fix(sffv): clamp maxFacetHits to the allowed range

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "40.5 kB"
+      "maxSize": "40.75 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.result.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.result.js
@@ -218,6 +218,106 @@ describe('createInstantSearchManager', () => {
           expect(store.searchingForFacetValues).toBe(false);
         });
       });
+
+      it('updates the store and searches with maxFacetHits out of range (higher)', () => {
+        expect.assertions(4);
+
+        const searchForFacetValues = jest.fn(() =>
+          Promise.resolve({
+            facetHits: 'results',
+          })
+        );
+
+        jsHepler.mockImplementationOnce((...args) => {
+          const instance = jsHepler(...args);
+
+          instance.searchForFacetValues = searchForFacetValues;
+
+          return instance;
+        });
+
+        const ism = createInstantSearchManager({
+          indexName: 'index',
+          initialState: {},
+          searchParameters: {},
+          searchClient: client,
+        });
+
+        ism.onSearchForFacetValues({
+          facetName: 'facetName',
+          query: 'query',
+          maxFacetHits: 125,
+        });
+
+        expect(ism.store.getState().results).toBe(null);
+
+        return Promise.resolve().then(() => {
+          const store = ism.store.getState();
+
+          expect(searchForFacetValues).toHaveBeenCalledWith(
+            'facetName',
+            'query',
+            100
+          );
+
+          expect(store.resultsFacetValues).toEqual({
+            facetName: 'results',
+            query: 'query',
+          });
+
+          expect(store.searchingForFacetValues).toBe(false);
+        });
+      });
+
+      it('updates the store and searches with maxFacetHits out of range (lower)', () => {
+        expect.assertions(4);
+
+        const searchForFacetValues = jest.fn(() =>
+          Promise.resolve({
+            facetHits: 'results',
+          })
+        );
+
+        jsHepler.mockImplementationOnce((...args) => {
+          const instance = jsHepler(...args);
+
+          instance.searchForFacetValues = searchForFacetValues;
+
+          return instance;
+        });
+
+        const ism = createInstantSearchManager({
+          indexName: 'index',
+          initialState: {},
+          searchParameters: {},
+          searchClient: client,
+        });
+
+        ism.onSearchForFacetValues({
+          facetName: 'facetName',
+          query: 'query',
+          maxFacetHits: 0,
+        });
+
+        expect(ism.store.getState().results).toBe(null);
+
+        return Promise.resolve().then(() => {
+          const store = ism.store.getState();
+
+          expect(searchForFacetValues).toHaveBeenCalledWith(
+            'facetName',
+            'query',
+            1
+          );
+
+          expect(store.resultsFacetValues).toEqual({
+            facetName: 'results',
+            query: 'query',
+          });
+
+          expect(store.searchingForFacetValues).toBe(false);
+        });
+      });
     });
   });
 });

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.result.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.result.js
@@ -157,7 +157,7 @@ describe('createInstantSearchManager', () => {
           expect(searchForFacetValues).toHaveBeenCalledWith(
             'facetName',
             'query',
-            undefined
+            10
           );
 
           expect(store.searchingForFacetValues).toBe(false);

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -272,13 +272,17 @@ export default function createInstantSearchManager({
   }
 
   function onSearchForFacetValues({ facetName, query, maxFacetHits = 10 }) {
+    // The values 1, 100 are the min / max values that the engine accepts.
+    // see: https://www.algolia.com/doc/api-reference/api-parameters/maxFacetHits
+    const maxFacetHitsWithinRange = Math.max(1, Math.min(maxFacetHits, 100));
+
     store.setState({
       ...store.getState(),
       searchingForFacetValues: true,
     });
 
     helper
-      .searchForFacetValues(facetName, query, maxFacetHits)
+      .searchForFacetValues(facetName, query, maxFacetHitsWithinRange)
       .then(
         content => {
           store.setState({

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -271,7 +271,7 @@ export default function createInstantSearchManager({
     search();
   }
 
-  function onSearchForFacetValues({ facetName, query, maxFacetHits }) {
+  function onSearchForFacetValues({ facetName, query, maxFacetHits = 10 }) {
     store.setState({
       ...store.getState(),
       searchingForFacetValues: true,


### PR DESCRIPTION
**Summary**

With the current implementation the value used for [`maxFacetHits`](https://www.algolia.com/doc/api-reference/api-parameters/maxFacetHits) is the default limit of the widget or the user provided value. It's fine for most cases, but it happens that the value provided by the user is higher than 100. This leads to an issue because the Algolia engine only accepts values between 1 - 100. When the value is not in that range the API throws an error.

I chose to fix the issue inside InstantSearch rather than in the helper because it feels odd (to me) to change the value on behalf of the user. The helper can be directly manipulate by users so it makes sense to throw an error if the value is invalid. With InstantSearch it's a bit different we use the helper, they don't have any knowledge of it. Since we allow any value for the limit it makes sense to send the correct a value to the API.

The fix clamp the provided value in the range 1, 100. I've also create a default value of 10 for the `maxFacetHits` in case no value is provided. It avoid to gets a `NaN` value from `Math.{min,max}`. It doesn't breaks anything because `10` is the default value on the engine.

**Before**

![before](https://user-images.githubusercontent.com/6513513/47596559-fb775600-d93b-11e8-82d4-3439584b829f.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/47596563-04682780-d93c-11e8-9652-3b696d6774e1.gif)