### PR TITLE
Fix Virtual Widget doc

### DIFF
--- a/docgen/src/guide/Virtual_widgets.md
+++ b/docgen/src/guide/Virtual_widgets.md
@@ -12,7 +12,8 @@ For example an online shop for clothes could have a page like `https://www.cloth
 that shows hoodies and only hoodies:
 
 ```jsx
-import { InstantSearch, SearchBox, connectMenu } from 'react-instantsearch-dom';
+import { InstantSearch, SearchBox } from 'react-instantsearch-dom';
+import { connectMenu } from "react-instantsearch/connectors";
 
 const VirtualMenu = connectMenu(() => null);
 const Hoodies = () => <VirtualMenu attribute="clothes" defaultRefinement="hoodies" />;


### PR DESCRIPTION
Fixed import of connectMenu.

**Summary**
Previous import was not failing, however the below example was raising following mounting-time error: 
```Uncaught TypeError: Object(...) is not a function```

**Result**
I have found at least two ways to import connectMenu in the repo's source : 
- react-instantsearch/connectors
- react-instantsearch-core

Both seem to work with react-instantsearch v5.3.2. 