### PR TITLE
test(createManagerError): avoid to rely on helper internal

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.error.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.error.js
@@ -44,8 +44,8 @@ describe('createInstantSearchManager with errors', () => {
       expect(ism.store.getState().error).toBe(null);
 
       return Promise.resolve()
-        .then()
-        .then()
+        .then() // flush helper.search.then
+        .then() // flush helper.search.catch
         .then(() => {
           const state = ism.store.getState();
 
@@ -59,8 +59,8 @@ describe('createInstantSearchManager with errors', () => {
 
           ism.widgetsManager.update();
         })
-        .then()
-        .then()
+        .then() // flush helper.search.then
+        .then() // flush helper.search.catch
         .then(() => {
           const state = ism.store.getState();
 
@@ -89,8 +89,8 @@ describe('createInstantSearchManager with errors', () => {
       expect(ism.store.getState().error).toBe(null);
 
       return Promise.resolve()
-        .then()
-        .then()
+        .then() // flush helper.search.then
+        .then() // flush helper.search.catch
         .then(() => {
           const state = ism.store.getState();
 
@@ -104,8 +104,8 @@ describe('createInstantSearchManager with errors', () => {
 
           ism.onExternalStateUpdate({});
         })
-        .then()
-        .then()
+        .then() // flush helper.search.then
+        .then() // flush helper.search.catch
         .then(() => {
           const state = ism.store.getState();
 
@@ -138,8 +138,8 @@ describe('createInstantSearchManager with errors', () => {
       expect(ism.store.getState().error).toBe(null);
 
       return Promise.resolve()
-        .then()
-        .then()
+        .then() // flush helper.search.then
+        .then() // flush helper.search.catch
         .then(() => {
           const state = ism.store.getState();
 

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.error.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.error.js
@@ -1,22 +1,8 @@
 import createInstantSearchManager from '../createInstantSearchManager';
 
 const createSearchClient = () => ({
-  search: jest.fn(() =>
-    Promise.resolve({
-      results: [
-        {
-          hits: [],
-        },
-      ],
-    })
-  ),
-  searchForFacetValues: jest.fn(() =>
-    Promise.resolve([
-      {
-        facetHits: [],
-      },
-    ])
-  ),
+  search: jest.fn(),
+  searchForFacetValues: jest.fn(),
 });
 
 describe('createInstantSearchManager with errors', () => {

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.error.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.error.js
@@ -83,7 +83,7 @@ describe('createInstantSearchManager with errors', () => {
       expect(ism.store.getState().results).toEqual(null);
     });
 
-    it('reset the error after a succesful search', async () => {
+    it('reset the error after a successful search', async () => {
       const searchClient = createSearchClient();
 
       searchClient.search.mockImplementation(() =>
@@ -158,7 +158,7 @@ describe('createInstantSearchManager with errors', () => {
       expect(ism.store.getState().error).toEqual(new Error('API_ERROR'));
     });
 
-    it('reset the error after a succesful search', async () => {
+    it('reset the error after a successful search', async () => {
       const searchClient = createSearchClient();
 
       searchClient.searchForFacetValues.mockImplementation(() =>

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.error.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.error.js
@@ -1,5 +1,7 @@
 import createInstantSearchManager from '../createInstantSearchManager';
 
+const flushPendingMicroTasks = () => new Promise(setImmediate);
+
 const createSearchClient = () => ({
   search: jest.fn(),
   searchForFacetValues: jest.fn(),
@@ -7,9 +9,7 @@ const createSearchClient = () => ({
 
 describe('createInstantSearchManager with errors', () => {
   describe('on search', () => {
-    it('updates the store on widget lifecycle', () => {
-      expect.assertions(7);
-
+    it('updates the store on widget lifecycle', async () => {
       const searchClient = createSearchClient();
 
       searchClient.search.mockImplementation(() =>
@@ -29,36 +29,26 @@ describe('createInstantSearchManager with errors', () => {
 
       expect(ism.store.getState().error).toBe(null);
 
-      return Promise.resolve()
-        .then() // flush helper.search.then
-        .then() // flush helper.search.catch
-        .then(() => {
-          const state = ism.store.getState();
+      await flushPendingMicroTasks();
 
-          expect(searchClient.search).toHaveBeenCalledTimes(1);
-          expect(state.error).toEqual(new Error('API_ERROR_1'));
-          expect(state.results).toEqual(null);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+      expect(ism.store.getState().error).toEqual(new Error('API_ERROR_1'));
+      expect(ism.store.getState().results).toEqual(null);
 
-          searchClient.search.mockImplementation(() =>
-            Promise.reject(new Error('API_ERROR_2'))
-          );
+      searchClient.search.mockImplementation(() =>
+        Promise.reject(new Error('API_ERROR_2'))
+      );
 
-          ism.widgetsManager.update();
-        })
-        .then() // flush helper.search.then
-        .then() // flush helper.search.catch
-        .then(() => {
-          const state = ism.store.getState();
+      ism.widgetsManager.update();
 
-          expect(searchClient.search).toHaveBeenCalledTimes(2);
-          expect(state.error).toEqual(new Error('API_ERROR_2'));
-          expect(state.results).toEqual(null);
-        });
+      await flushPendingMicroTasks();
+
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
+      expect(ism.store.getState().error).toEqual(new Error('API_ERROR_2'));
+      expect(ism.store.getState().results).toEqual(null);
     });
 
-    it('updates the store on external updates', () => {
-      expect.assertions(7);
-
+    it('updates the store on external updates', async () => {
       const searchClient = createSearchClient();
 
       searchClient.search.mockImplementation(() =>
@@ -74,36 +64,26 @@ describe('createInstantSearchManager with errors', () => {
 
       expect(ism.store.getState().error).toBe(null);
 
-      return Promise.resolve()
-        .then() // flush helper.search.then
-        .then() // flush helper.search.catch
-        .then(() => {
-          const state = ism.store.getState();
+      await flushPendingMicroTasks();
 
-          expect(searchClient.search).toHaveBeenCalledTimes(1);
-          expect(state.error).toEqual(new Error('API_ERROR_1'));
-          expect(state.results).toEqual(null);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+      expect(ism.store.getState().error).toEqual(new Error('API_ERROR_1'));
+      expect(ism.store.getState().results).toEqual(null);
 
-          searchClient.search.mockImplementation(() =>
-            Promise.reject(new Error('API_ERROR_2'))
-          );
+      searchClient.search.mockImplementation(() =>
+        Promise.reject(new Error('API_ERROR_2'))
+      );
 
-          ism.onExternalStateUpdate({});
-        })
-        .then() // flush helper.search.then
-        .then() // flush helper.search.catch
-        .then(() => {
-          const state = ism.store.getState();
+      ism.onExternalStateUpdate({});
 
-          expect(searchClient.search).toHaveBeenCalledTimes(2);
-          expect(state.error).toEqual(new Error('API_ERROR_2'));
-          expect(state.results).toEqual(null);
-        });
+      await flushPendingMicroTasks();
+
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
+      expect(ism.store.getState().error).toEqual(new Error('API_ERROR_2'));
+      expect(ism.store.getState().results).toEqual(null);
     });
 
-    it('reset the error after a succesful search', () => {
-      expect.assertions(5);
-
+    it('reset the error after a succesful search', async () => {
       const searchClient = createSearchClient();
 
       searchClient.search.mockImplementation(() =>
@@ -123,45 +103,36 @@ describe('createInstantSearchManager with errors', () => {
 
       expect(ism.store.getState().error).toBe(null);
 
-      return Promise.resolve()
-        .then() // flush helper.search.then
-        .then() // flush helper.search.catch
-        .then(() => {
-          const state = ism.store.getState();
+      await flushPendingMicroTasks();
 
-          expect(state.error).toEqual(new Error('API_ERROR'));
-          expect(state.results).toEqual(null);
+      expect(ism.store.getState().error).toEqual(new Error('API_ERROR'));
+      expect(ism.store.getState().results).toEqual(null);
 
-          searchClient.search.mockImplementation(() =>
-            Promise.resolve({
-              results: [
-                {
-                  hits: [],
-                },
-              ],
-            })
-          );
-
-          ism.widgetsManager.update();
-        })
-        .then()
-        .then(() => {
-          const state = ism.store.getState();
-
-          expect(state.error).toEqual(null);
-          expect(state.results).toEqual(
-            expect.objectContaining({
+      searchClient.search.mockImplementation(() =>
+        Promise.resolve({
+          results: [
+            {
               hits: [],
-            })
-          );
-        });
+            },
+          ],
+        })
+      );
+
+      ism.widgetsManager.update();
+
+      await flushPendingMicroTasks();
+
+      expect(ism.store.getState().error).toEqual(null);
+      expect(ism.store.getState().results).toEqual(
+        expect.objectContaining({
+          hits: [],
+        })
+      );
     });
   });
 
   describe('on search for facet values', () => {
-    it('updates the store on function call', () => {
-      expect.assertions(4);
-
+    it('updates the store on function call', async () => {
       const searchClient = createSearchClient();
 
       searchClient.searchForFacetValues.mockImplementation(() =>
@@ -181,17 +152,13 @@ describe('createInstantSearchManager with errors', () => {
       expect(ism.store.getState().searchingForFacetValues).toBe(true);
       expect(ism.store.getState().error).toBe(null);
 
-      return Promise.resolve()
-        .then()
-        .then(() => {
-          expect(ism.store.getState().searchingForFacetValues).toBe(false);
-          expect(ism.store.getState().error).toEqual(new Error('API_ERROR'));
-        });
+      await flushPendingMicroTasks();
+
+      expect(ism.store.getState().searchingForFacetValues).toBe(false);
+      expect(ism.store.getState().error).toEqual(new Error('API_ERROR'));
     });
 
-    it('reset the error after a succesful search', () => {
-      expect.assertions(5);
-
+    it('reset the error after a succesful search', async () => {
       const searchClient = createSearchClient();
 
       searchClient.searchForFacetValues.mockImplementation(() =>
@@ -210,35 +177,33 @@ describe('createInstantSearchManager with errors', () => {
 
       expect(ism.store.getState().error).toBe(null);
 
-      return Promise.resolve()
-        .then()
-        .then(() => {
-          expect(ism.store.getState().error).toEqual(new Error('API_ERROR'));
-          expect(ism.store.getState().resultsFacetValues).toBeUndefined();
+      await flushPendingMicroTasks();
 
-          searchClient.searchForFacetValues.mockImplementation(() =>
-            Promise.resolve([
-              {
-                facetHits: [],
-              },
-            ])
-          );
+      expect(ism.store.getState().error).toEqual(new Error('API_ERROR'));
+      expect(ism.store.getState().resultsFacetValues).toBeUndefined();
 
-          ism.onSearchForFacetValues({
-            facetName: 'facetName',
-            query: 'query',
-          });
+      searchClient.searchForFacetValues.mockImplementation(() =>
+        Promise.resolve([
+          {
+            facetHits: [],
+          },
+        ])
+      );
+
+      ism.onSearchForFacetValues({
+        facetName: 'facetName',
+        query: 'query',
+      });
+
+      await flushPendingMicroTasks();
+
+      expect(ism.store.getState().error).toBe(null);
+      expect(ism.store.getState().resultsFacetValues).toEqual(
+        expect.objectContaining({
+          facetName: [],
+          query: 'query',
         })
-        .then()
-        .then(() => {
-          expect(ism.store.getState().error).toBe(null);
-          expect(ism.store.getState().resultsFacetValues).toEqual(
-            expect.objectContaining({
-              facetName: [],
-              query: 'query',
-            })
-          );
-        });
+      );
     });
   });
 });

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -287,19 +287,20 @@ export default function createInstantSearchManager({
         content => {
           store.setState({
             ...store.getState(),
+            error: null,
+            searchingForFacetValues: false,
             resultsFacetValues: {
               ...store.getState().resultsFacetValues,
               [facetName]: content.facetHits,
               query,
             },
-            searchingForFacetValues: false,
           });
         },
         error => {
           store.setState({
             ...store.getState(),
-            error,
             searchingForFacetValues: false,
+            error,
           });
         }
       )


### PR DESCRIPTION
The previous tests were relying on the internal implementation of the helper (like the `_dispatch` method). We don't have a direct access to it at the moment (it's created by the manager itself). We can mock the import etc... But for the moment I rewrote the test with a mocked client. I don't have to update the implementation only the test.

A possible improvement for the future is to provide the helper as an argument to allow a mocked version easily. It could simplify the tests since the mock part would be closer to the implementation with less indirections.

I've create one PR for each of the manager test file:

- results: https://github.com/algolia/react-instantsearch/pull/1823
- derived: https://github.com/algolia/react-instantsearch/pull/1824
- raw: https://github.com/algolia/react-instantsearch/pull/1827