### PR TITLE
feat(indexId): avoid to rely on the results.index  [PART-1]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,8 @@ module.exports = {
   extends: ['algolia/react', 'algolia/jest'],
   rules: {
     'no-param-reassign': 'off',
+    // @TODO: to remove once `eslint-config-algolia` ships the change
+    'valid-jsdoc': 'off',
   },
   settings: {
     react: {

--- a/packages/react-instantsearch-core/src/components/Index.js
+++ b/packages/react-instantsearch-core/src/components/Index.js
@@ -1,7 +1,6 @@
 import React, { Component, Children } from 'react';
 import PropTypes from 'prop-types';
 
-/* eslint valid-jsdoc: 0 */
 /**
  * @description
  * `<Index>` is the component that allows you to apply widgets to a dedicated index. It's
@@ -32,18 +31,17 @@ import PropTypes from 'prop-types';
  * );
  */
 class Index extends Component {
-  constructor(props, context) {
-    super(props);
-    const {
-      ais: { widgetsManager },
-    } = context;
+  constructor(...args) {
+    super(...args);
 
     /*
      we want <Index> to be seen as a regular widget.
      It means that with only <Index> present a new query will be sent to Algolia.
      That way you don't need a virtual hits widget to use the connectAutoComplete.
     */
-    this.unregisterWidget = widgetsManager.registerWidget(this);
+    this.unregisterWidget = this.context.ais.widgetsManager.registerWidget(
+      this
+    );
   }
 
   componentWillMount() {
@@ -67,7 +65,7 @@ class Index extends Component {
   getChildContext() {
     return {
       multiIndexContext: {
-        targetedIndex: this.props.indexName,
+        targetedIndex: this.props.indexId,
       },
     };
   }
@@ -89,6 +87,7 @@ class Index extends Component {
 Index.propTypes = {
   // @TODO: These props are currently constant.
   indexName: PropTypes.string.isRequired,
+  indexId: PropTypes.string.isRequired,
   children: PropTypes.node,
   root: PropTypes.shape({
     Root: PropTypes.oneOfType([

--- a/packages/react-instantsearch-core/src/components/InstantSearch.js
+++ b/packages/react-instantsearch-core/src/components/InstantSearch.js
@@ -14,7 +14,6 @@ function validateNextProps(props, nextProps) {
   }
 }
 
-/* eslint valid-jsdoc: 0 */
 /**
  * @description
  * `<InstantSearch>` is the root component of all React InstantSearch implementations.

--- a/packages/react-instantsearch-core/src/components/__tests__/Index.js
+++ b/packages/react-instantsearch-core/src/components/__tests__/Index.js
@@ -1,100 +1,160 @@
 import React from 'react';
-import Enzyme, { mount } from 'enzyme';
+import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { SearchParameters } from 'algoliasearch-helper';
 import Index from '../Index';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('Index', () => {
-  const DEFAULT_PROPS = {
-    indexName: 'foobar',
+  const createContext = () => ({
+    ais: {
+      onSearchParameters: jest.fn(),
+      widgetsManager: {
+        registerWidget: jest.fn(),
+        update: jest.fn(),
+      },
+    },
+  });
+
+  const requiredProps = {
+    indexName: 'indexName',
+    indexId: 'indexId',
     root: {
       Root: 'div',
     },
   };
 
-  const registerWidget = jest.fn();
-  const update = jest.fn();
-  const widgetsManager = { registerWidget, update };
+  it('registers itself on mount', () => {
+    const context = createContext();
 
-  let context = {
-    ais: {
-      widgetsManager,
-      onSearchParameters: () => {},
-      update,
-    },
-  };
-
-  it('validates its props', () => {
-    expect(() => {
-      mount(
-        <Index {...DEFAULT_PROPS}>
-          <div />
-        </Index>,
-        { context }
-      );
-    }).not.toThrow();
-
-    expect(() => {
-      mount(<Index {...DEFAULT_PROPS} />, { context });
-    }).not.toThrow();
-
-    expect(() => {
-      mount(
-        <Index {...DEFAULT_PROPS}>
-          <div />
-          <div />
-        </Index>,
-        { context }
-      );
-    }).not.toThrow();
-
-    expect(registerWidget.mock.calls).toHaveLength(3);
-  });
-
-  it('exposes multi index context', () => {
-    const wrapper = mount(
-      <Index {...DEFAULT_PROPS}>
+    const wrapper = shallow(
+      <Index {...requiredProps}>
         <div />
       </Index>,
-      { context }
+      {
+        context,
+      }
     );
 
-    const childContext = wrapper.instance().getChildContext();
-    expect(childContext.multiIndexContext.targetedIndex).toBe(
-      DEFAULT_PROPS.indexName
+    expect(context.ais.widgetsManager.registerWidget).toHaveBeenCalledTimes(1);
+    expect(context.ais.widgetsManager.registerWidget).toHaveBeenCalledWith(
+      wrapper.instance()
     );
   });
 
-  it('update search if indexName prop change', () => {
-    const wrapper = mount(
-      <Index {...DEFAULT_PROPS}>
+  it('calls onSearchParameters on mount', () => {
+    const context = createContext();
+
+    shallow(
+      <Index {...requiredProps}>
         <div />
       </Index>,
-      { context }
+      {
+        context,
+      }
     );
+
+    expect(context.ais.onSearchParameters).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls update if indexName prop changes', () => {
+    const context = createContext();
+
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    expect(context.ais.widgetsManager.update).toHaveBeenCalledTimes(0);
 
     wrapper.setProps({ indexName: 'newIndexName' });
 
-    expect(update.mock.calls).toHaveLength(1);
+    expect(context.ais.widgetsManager.update).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onSearchParameters when mounted', () => {
-    const onSearchParameters = jest.fn();
-    context = {
-      ais: {
-        widgetsManager,
-        onSearchParameters,
-      },
-    };
+  it('unregisters itself on unmount', () => {
+    const unregister = jest.fn();
+    const context = createContext();
 
-    mount(
-      <Index {...DEFAULT_PROPS}>
-        <div />
-      </Index>,
-      { context }
+    context.ais.widgetsManager.registerWidget.mockImplementation(
+      () => unregister
     );
 
-    expect(onSearchParameters.mock.calls).toHaveLength(1);
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    expect(unregister).toHaveBeenCalledTimes(0);
+
+    wrapper.unmount();
+
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes multi index context', () => {
+    const context = createContext();
+
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    const childContext = wrapper.instance().getChildContext();
+
+    expect(childContext.multiIndexContext.targetedIndex).toBe('indexId');
+  });
+
+  it('provides search parameters from instance props', () => {
+    const context = createContext();
+
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    const parameters = wrapper
+      .instance()
+      .getSearchParameters(new SearchParameters());
+
+    expect(parameters.index).toBe('indexName');
+  });
+
+  it('provides search parameters from argument props when instance props are not available', () => {
+    const context = createContext();
+
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    const parameters = wrapper
+      .instance()
+      .getSearchParameters.call({}, new SearchParameters(), {
+        indexName: 'otherIndexName',
+      });
+
+    expect(parameters.index).toBe('otherIndexName');
   });
 });

--- a/packages/react-instantsearch-core/src/connectors/connectConfigure.js
+++ b/packages/react-instantsearch-core/src/connectors/connectConfigure.js
@@ -1,6 +1,10 @@
 import { omit, difference, keys } from 'lodash';
 import createConnector from '../core/createConnector';
-import { hasMultipleIndex, getIndex, refineValue } from '../core/indexUtils';
+import {
+  refineValue,
+  getIndexId,
+  hasMultipleIndices,
+} from '../core/indexUtils';
 
 function getId() {
   return 'configure';
@@ -29,10 +33,10 @@ export default createConnector({
   },
   cleanUp(props, searchState) {
     const id = getId();
-    const index = getIndex(this.context);
+    const indexId = getIndexId(this.context);
     const subState =
-      hasMultipleIndex(this.context) && searchState.indices
-        ? searchState.indices[index]
+      hasMultipleIndices(this.context) && searchState.indices
+        ? searchState.indices[indexId]
         : searchState;
     const configureKeys =
       subState && subState[id] ? Object.keys(subState[id]) : [];

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -3,7 +3,7 @@ import createConnector from '../core/createConnector';
 import {
   getResults,
   getCurrentRefinementValue,
-  getIndex,
+  getIndexId,
   refineValue,
   cleanUpValue,
 } from '../core/indexUtils';
@@ -205,7 +205,7 @@ export default createConnector({
   getMetadata(props, searchState) {
     const items = [];
     const id = getBoundingBoxId();
-    const index = getIndex(this.context);
+    const index = getIndexId(this.context);
     const nextRefinement = {};
     const currentRefinement = getCurrentRefinement(
       props,

--- a/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
@@ -3,7 +3,7 @@ import { SearchParameters } from 'algoliasearch-helper';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   refineValue,
   getCurrentRefinementValue,
   getResults,
@@ -270,7 +270,7 @@ export default createConnector({
 
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items: !currentRefinement
         ? []
         : [

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -2,7 +2,7 @@ import { orderBy } from 'lodash';
 import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
-  getIndex,
+  getIndexId,
   cleanUpValue,
   refineValue,
   getCurrentRefinementValue,
@@ -222,7 +222,7 @@ export default createConnector({
     );
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items:
         currentRefinement === null
           ? []

--- a/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
@@ -6,7 +6,7 @@ import {
   refineValue,
   getCurrentRefinementValue,
   getResults,
-  getIndex,
+  getIndexId,
 } from '../core/indexUtils';
 
 function stringifyItem(item) {
@@ -209,7 +209,7 @@ export default createConnector({
     const id = getId(props);
     const value = getCurrentRefinement(props, searchState, this.context);
     const items = [];
-    const index = getIndex(this.context);
+    const index = getIndexId(this.context);
     if (value !== '') {
       const { label } = find(
         props.items,

--- a/packages/react-instantsearch-core/src/connectors/connectRange.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRange.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   refineValue,
   getCurrentRefinementValue,
   getResults,
@@ -332,7 +332,7 @@ export default createConnector({
 
     return {
       id: getId(props),
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items,
     };
   },

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   refineValue,
   getCurrentRefinementValue,
   getResults,
@@ -226,7 +226,7 @@ export default createConnector({
     const context = this.context;
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items:
         getCurrentRefinement(props, searchState, context).length > 0
           ? [

--- a/packages/react-instantsearch-core/src/connectors/connectScrollTo.js
+++ b/packages/react-instantsearch-core/src/connectors/connectScrollTo.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   getCurrentRefinementValue,
-  hasMultipleIndex,
-  getIndex,
+  hasMultipleIndices,
+  getIndexId,
 } from '../core/indexUtils';
 import { shallowEqual } from '../core/utils';
 
@@ -44,9 +44,10 @@ export default createConnector({
     }
 
     /* Get the subpart of the state that interest us*/
-    if (hasMultipleIndex(this.context)) {
-      const index = getIndex(this.context);
-      searchState = searchState.indices ? searchState.indices[index] : {};
+    if (hasMultipleIndices(this.context)) {
+      searchState = searchState.indices
+        ? searchState.indices[getIndexId(this.context)]
+        : {};
     }
 
     /*

--- a/packages/react-instantsearch-core/src/connectors/connectSearchBox.js
+++ b/packages/react-instantsearch-core/src/connectors/connectSearchBox.js
@@ -4,7 +4,7 @@ import {
   cleanUpValue,
   refineValue,
   getCurrentRefinementValue,
-  getIndex,
+  getIndexId,
 } from '../core/indexUtils';
 
 function getId() {
@@ -86,7 +86,7 @@ export default createConnector({
     );
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items:
         currentRefinement === null
           ? []

--- a/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   getResults,
   refineValue,
   getCurrentRefinementValue,
@@ -149,7 +149,7 @@ export default createConnector({
     const id = getId(props);
     const checked = getCurrentRefinement(props, searchState, this.context);
     const items = [];
-    const index = getIndex(this.context);
+    const index = getIndexId(this.context);
 
     if (checked) {
       items.push({

--- a/packages/react-instantsearch-core/src/core/__tests__/__snapshots__/createIndex.js.snap
+++ b/packages/react-instantsearch-core/src/core/__tests__/__snapshots__/createIndex.js.snap
@@ -1,24 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createIndex expect to create Index with a custom root props 1`] = `
+exports[`createIndex expects to create an Index 1`] = `
 <Index
-  indexName="name"
-  root={
-    Object {
-      "Root": "span",
-      "props": Object {
-        "style": Object {
-          "flex": 1,
-        },
-      },
-    }
-  }
-/>
-`;
-
-exports[`createIndex wraps Index 1`] = `
-<Index
-  indexName="name"
+  indexId="indexName"
+  indexName="indexName"
   root={
     Object {
       "Root": "div",

--- a/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
@@ -9,26 +9,76 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('createIndex', () => {
   const CustomIndex = createIndex({ Root: 'div' });
 
-  it('wraps Index', () => {
-    const wrapper = shallow(<CustomIndex indexName="name" />);
+  const requiredProps = {
+    indexName: 'indexName',
+  };
+
+  it('expects to create an Index', () => {
+    const props = {
+      ...requiredProps,
+    };
+
+    const wrapper = shallow(<CustomIndex {...props} />);
+
     expect(wrapper.is(Index)).toBe(true);
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('expect to create Index with a custom root props', () => {
-    const root = {
+  it('expects to create an Index with the default root', () => {
+    const props = {
+      ...requiredProps,
+    };
+
+    const wrapper = shallow(<CustomIndex {...props} />);
+
+    expect(wrapper.props().root).toEqual({
+      Root: 'div',
+    });
+  });
+
+  it('expects to create an Index with a custom root props', () => {
+    const props = {
+      ...requiredProps,
+      root: {
+        Root: 'span',
+        props: {
+          style: {
+            flex: 1,
+          },
+        },
+      },
+    };
+
+    const wrapper = shallow(<CustomIndex {...props} />);
+
+    expect(wrapper.props().root).toEqual({
       Root: 'span',
       props: {
         style: {
           flex: 1,
         },
       },
+    });
+  });
+
+  it('expects to create an Index with an indexId when provided', () => {
+    const props = {
+      ...requiredProps,
+      indexId: 'indexId',
     };
 
-    const wrapper = shallow(<CustomIndex indexName="name" root={root} />);
+    const wrapper = shallow(<CustomIndex {...props} />);
 
-    expect(wrapper.is(Index)).toBe(true);
-    expect(wrapper.props().root).toEqual(root);
-    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.props().indexId).toBe('indexId');
+  });
+
+  it("expects to create an Index with an indexId that fallback to indexName when it's not provided", () => {
+    const props = {
+      ...requiredProps,
+    };
+
+    const wrapper = shallow(<CustomIndex {...props} />);
+
+    expect(wrapper.props().indexId).toBe('indexName');
   });
 });

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
@@ -9,6 +9,7 @@ const createSearchClient = () => ({
         index: request.indexName,
         query: request.params.query,
         page: request.params.page,
+        hitsPerPage: request.params.hitsPerPage,
         hits: [],
       })),
     })
@@ -27,11 +28,11 @@ describe('createInstantSearchManager with multi index', () => {
     // <InstantSearch indexName="first">
     //   <SearchBox defaultRefinement="first query 1" />
     //
-    //   <Index indexName="first">
+    //   <Index indexName="first" indexId="first">
     //     <Pagination defaultRefinement={3} />
     //   </Index>
     //
-    //   <Index indexName="second">
+    //   <Index indexName="second" indexId="second">
     //     <SearchBox defaultRefinement="second query 1" />
     //   </Index>
     // </InstantSearch>
@@ -50,39 +51,49 @@ describe('createInstantSearchManager with multi index', () => {
       props: {},
     });
 
-    // <Index indexName="first" />
+    // <Index indexName="first" indexId="first" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('first'),
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
-    // <Index indexName="first">
+    // <Index indexName="first" indexId="first">
     //   <Pagination defaultRefinement={3} />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setPage(3),
-      context: { multiIndexContext: { targetedIndex: 'first' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first',
+        },
+      },
       props: {},
     });
 
-    // <Index indexName="second" />
+    // <Index indexName="second" indexId="second" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('second'),
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
-    // <Index indexName="second">
+    // <Index indexName="second" indexId="second">
     //   <SearchBox defaultRefinement="second query 1" />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setQuery('second query 1'),
-      context: { multiIndexContext: { targetedIndex: 'second' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'second',
+        },
+      },
       props: {},
     });
 
@@ -112,7 +123,7 @@ describe('createInstantSearchManager with multi index', () => {
     ism.widgetsManager.getWidgets()[0].getSearchParameters = params =>
       params.setQuery('first query 2');
 
-    // <Index indexName="second">
+    // <Index indexName="second" indexId="second">
     //   <SearchBox defaultRefinement="second query 2" />
     // </Index>
     ism.widgetsManager.getWidgets()[4].getSearchParameters = params =>
@@ -143,11 +154,11 @@ describe('createInstantSearchManager with multi index', () => {
     // <InstantSearch indexName="first">
     //   <SearchBox defaultRefinement="query" />
     //
-    //   <Index indexName="first">
+    //   <Index indexName="first" indexId="first">
     //     <SortBy defaultRefinement="third" />
     //   </Index>
     //
-    //   <Index indexName="second" />
+    //   <Index indexName="second" indexId="second" />
     // </InstantSearch>;
 
     const ism = createInstantSearchManager({
@@ -164,30 +175,36 @@ describe('createInstantSearchManager with multi index', () => {
       props: {},
     });
 
-    // <Index indexName="first" />
+    // <Index indexName="first" indexId="first" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: x => x.setIndex('first'),
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
-    // <Index indexName="first">
+    // <Index indexName="first" indexId="first">
     //   <SortBy defaultRefinement="third" />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: x => x.setIndex('third'),
-      context: { multiIndexContext: { targetedIndex: 'first' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first',
+        },
+      },
       props: {},
     });
 
-    // <Index indexName="second" />
+    // <Index indexName="second" indexId="second" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: x => x.setIndex('second'),
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
@@ -235,6 +252,7 @@ describe('createInstantSearchManager with multi index', () => {
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
@@ -244,6 +262,7 @@ describe('createInstantSearchManager with multi index', () => {
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
@@ -253,6 +272,7 @@ describe('createInstantSearchManager with multi index', () => {
       context: {},
       props: {
         indexName: 'third',
+        indexId: 'third',
       },
     });
 
@@ -262,6 +282,7 @@ describe('createInstantSearchManager with multi index', () => {
       context: {},
       props: {
         indexName: 'four',
+        indexId: 'four',
       },
     });
 
@@ -276,15 +297,110 @@ describe('createInstantSearchManager with multi index', () => {
     expect(searchClient.search.mock.calls[1][0]).toHaveLength(4);
   });
 
+  it('searches with same index but different params', async () => {
+    // <InstantSearch indexName="first">
+    //   <SearchBox defaultRefinement="first query" />
+    //
+    //   <Index indexName="first" indexId="first_5_hits">
+    //     <Configure hitsPerPage={5} />
+    //   </Index>
+    //
+    //   <Index indexName="first" indexId="first_10_hits">
+    //     <Configure hitsPerPage={10} />
+    //   </Index>
+    // </InstantSearch>
+
+    const ism = createInstantSearchManager({
+      indexName: 'first',
+      initialState: {},
+      searchParameters: {},
+      searchClient: createSearchClient(),
+    });
+
+    // <SearchBox defaultRefinement="first query" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params => params.setQuery('first query'),
+      context: {},
+      props: {},
+    });
+
+    // <Index indexName="first" indexId="first_5_hits" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params => params.setIndex('first'),
+      context: {},
+      props: {
+        indexName: 'first',
+        indexId: 'first_5_hits',
+      },
+    });
+
+    // <Index indexName="first" indexId="first_5_hits">
+    //   <Configure hitsPerPage={5} />
+    // </Index>
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params => params.setQueryParameter('hitsPerPage', 5),
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first_5_hits',
+        },
+      },
+      props: {},
+    });
+
+    // <Index indexName="first" indexId="first_10_hits" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params => params.setIndex('first'),
+      context: {},
+      props: {
+        indexName: 'first',
+        indexId: 'first_10_hits',
+      },
+    });
+
+    // <Index indexName="first" indexId="first_10_hits">
+    //   <Configure hitsPerPage={10} />
+    // </Index>
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params =>
+        params.setQueryParameter('hitsPerPage', 10),
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first_10_hits',
+        },
+      },
+      props: {},
+    });
+
+    expect(ism.store.getState().results).toBe(null);
+
+    await runAllMicroTasks();
+
+    expect(ism.store.getState().results.first_5_hits).toEqual(
+      expect.objectContaining({
+        query: 'first query',
+        index: 'first',
+        hitsPerPage: 5,
+      })
+    );
+
+    expect(ism.store.getState().results.first_10_hits).toEqual(
+      expect.objectContaining({
+        query: 'first query',
+        index: 'first',
+        hitsPerPage: 10,
+      })
+    );
+  });
+
   it('switching from mono to multi index', async () => {
     // <InstantSearch indexName="first">
     //   <SearchBox defaultRefinement="first query 1" />
     //
-    //   <Index indexName="first">
+    //   <Index indexName="first" indexId="first">
     //     <Pagination defaultRefinement={3} />
     //   </Index>
     //
-    //   <Index indexName="second">
+    //   <Index indexName="second" indexId="second">
     //     <SearchBox defaultRefinement="second query 1" />
     //   </Index>
     // </InstantSearch>
@@ -303,39 +419,49 @@ describe('createInstantSearchManager with multi index', () => {
       props: {},
     });
 
-    // <Index indexName="first" />
+    // <Index indexName="first" indexId="first" />
     const unregisterFirstIndexWidget = ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('first'),
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
-    // <Index indexName="first">
+    // <Index indexName="first" indexId="first">
     //   <Pagination defaultRefinement={3} />
     // </Index>
     const unregisterPaginationWidget = ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setPage(3),
-      context: { multiIndexContext: { targetedIndex: 'first' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first',
+        },
+      },
       props: {},
     });
 
-    // <Index indexName="second" />
+    // <Index indexName="second" indexId="second" />
     const unregisterSecondIndexWidget = ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('second'),
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
-    // <Index indexName="second">
+    // <Index indexName="second" indexId="second">
     //   <SearchBox defaultRefinement="second query 1" />
     // </Index>
     const unregisterSecondSearchBoxWidget = ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setQuery('second query 1'),
-      context: { multiIndexContext: { targetedIndex: 'second' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'second',
+        },
+      },
       props: {},
     });
 
@@ -377,39 +503,49 @@ describe('createInstantSearchManager with multi index', () => {
       })
     );
 
-    // <Index indexName="first" />
+    // <Index indexName="first" indexId="first" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('first'),
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
-    // <Index indexName="first">
+    // <Index indexName="first" indexId="first">
     //   <Pagination defaultRefinement={3} />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setPage(3),
-      context: { multiIndexContext: { targetedIndex: 'first' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first',
+        },
+      },
       props: {},
     });
 
-    // <Index indexName="second" />
+    // <Index indexName="second" indexId="second" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('second'),
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
-    // <Index indexName="second">
+    // <Index indexName="second" indexId="second">
     //   <SearchBox defaultRefinement="second query 1" />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setQuery('second query 2'),
-      context: { multiIndexContext: { targetedIndex: 'second' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'second',
+        },
+      },
       props: {},
     });
 

--- a/packages/react-instantsearch-core/src/core/createIndex.js
+++ b/packages/react-instantsearch-core/src/core/createIndex.js
@@ -9,14 +9,16 @@ import Index from '../components/Index';
  * @return {object} a Index root
  */
 const createIndex = defaultRoot => {
-  const CreateIndex = ({ indexName, root, children }) => (
-    <Index indexName={indexName} root={root}>
+  const CreateIndex = ({ indexName, indexId, root, children }) => (
+    <Index indexName={indexName} indexId={indexId || indexName} root={root}>
       {children}
     </Index>
   );
 
   CreateIndex.propTypes = {
     indexName: PropTypes.string.isRequired,
+    // @MAJOR: indexId must be required
+    indexId: PropTypes.string,
     root: PropTypes.shape({
       Root: PropTypes.oneOfType([
         PropTypes.string,

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -131,15 +131,15 @@ export default function createInstantSearchManager({
         derivatedWidgets,
       } = getSearchParameters(helper.state);
 
-      // We have to call slice because the method `detach` on the dervied
-      // helpers mutate the value `derivedHelpers`. The forEach loop does
-      // not iterate on each value and we're not able to correctly clear
-      // the previous derived helpers (memory leak + useless requests).
+      // We have to call `slice` because the method `detach` on the derived
+      // helpers mutates the value `derivedHelpers`. The `forEach` loop does
+      // not iterate on each value and we're not able to correctly clear the
+      // previous derived helpers (memory leak + useless requests).
       helper.derivedHelpers.slice().forEach(derivedHelper => {
-        // Since we detach the derived helpers on **every** new search
-        // they won't receive intermediate results in case of a stalled search.
-        // Only the last results is dispatch by the derived helper beause they
-        // are not detached yet:
+        // Since we detach the derived helpers on **every** new search they
+        // won't receive intermediate results in case of a stalled search.
+        // Only the last result is dispatched by the derived helper because
+        // they are not detached yet:
         //
         // - a -> main helper receives results
         // - ap -> main helper receives results
@@ -147,7 +147,7 @@ export default function createInstantSearchManager({
         //
         // The quick fix is to avoid to detatch them on search but only once they
         // received the results. But it means that in case of a stalled search
-        // all the derived helper not detached yet register a new search inside
+        // all the derived helpers not detached yet register a new search inside
         // the helper. The number grows fast in case of a bad network and it's
         // not deterministic.
         derivedHelper.detach();

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -136,6 +136,21 @@ export default function createInstantSearchManager({
         mainIndexParameters,
         derivatedWidgets,
       } = getSearchParameters(helper.state);
+
+      // Since we detach the derived helpers on **every** new search
+      // they won't receive intermediate resutls in case of a stalled search.
+      // Only the last results is dispatch by the derived helper beause they
+      // are not detached yet:
+      //
+      // - a -> main helper receives results
+      // - ap -> main helper receives results
+      // - app -> main helper + derived helpers receive results
+      //
+      // The quick fix is to avoid to detatch them on search but only once they
+      // received the resutls. But it means that in case of a stalled search
+      // all the derived helper not detached yet register a new search inside
+      // the helper. The number grows fast in case of a bad network and it's
+      // not deterministic.
       Object.keys(derivedHelpers).forEach(key => derivedHelpers[key].detach());
       derivedHelpers = {};
 

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -137,7 +137,7 @@ export default function createInstantSearchManager({
       // the previous derived helpers (memory leak + useless requests).
       helper.derivedHelpers.slice().forEach(derivedHelper => {
         // Since we detach the derived helpers on **every** new search
-        // they won't receive intermediate resutls in case of a stalled search.
+        // they won't receive intermediate results in case of a stalled search.
         // Only the last results is dispatch by the derived helper beause they
         // are not detached yet:
         //
@@ -146,7 +146,7 @@ export default function createInstantSearchManager({
         // - app -> main helper + derived helpers receive results
         //
         // The quick fix is to avoid to detatch them on search but only once they
-        // received the resutls. But it means that in case of a stalled search
+        // received the results. But it means that in case of a stalled search
         // all the derived helper not detached yet register a new search inside
         // the helper. The number grows fast in case of a bad network and it's
         // not deterministic.

--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty, zipWith } from 'lodash';
 import React, { Component } from 'react';
 import { renderToString } from 'react-dom/server';
 import PropTypes from 'prop-types';
@@ -12,125 +12,126 @@ import {
   HIGHLIGHT_TAGS,
 } from 'react-instantsearch-core';
 
-const getIndex = context =>
+const getIndexId = context =>
   context && context.multiIndexContext
     ? context.multiIndexContext.targetedIndex
     : context.ais.mainTargetedIndex;
 
-const hasMultipleIndex = context => context && context.multiIndexContext;
+const hasMultipleIndices = context => context && context.multiIndexContext;
+
+const getSearchParameters = (indexName, searchParameters) => {
+  const sharedParameters = searchParameters
+    .filter(searchParameter => !hasMultipleIndices(searchParameter.context))
+    .reduce(
+      (acc, searchParameter) =>
+        searchParameter.getSearchParameters(
+          acc,
+          searchParameter.props,
+          searchParameter.searchState
+        ),
+      new SearchParameters({
+        ...HIGHLIGHT_TAGS,
+        index: indexName,
+      })
+    );
+
+  const derivedParameters = searchParameters
+    .filter(searchParameter => hasMultipleIndices(searchParameter.context))
+    .reduce((acc, searchParameter) => {
+      const indexId = getIndexId(searchParameter.context);
+
+      return {
+        ...acc,
+        [indexId]: searchParameter.getSearchParameters(
+          acc[indexId] || sharedParameters,
+          searchParameter.props,
+          searchParameter.searchState
+        ),
+      };
+    }, {});
+
+  return {
+    sharedParameters,
+    derivedParameters,
+  };
+};
+
+const singleIndexSearch = (helper, parameters) => helper.searchOnce(parameters);
+
+const multiIndexSearch = (
+  indexName,
+  client,
+  helper,
+  sharedParameters,
+  { [indexName]: mainParameters, ...derivedParameters }
+) => {
+  const search = [
+    helper.searchOnce({
+      ...sharedParameters,
+      ...mainParameters,
+    }),
+  ];
+
+  const indexIds = Object.keys(derivedParameters);
+
+  search.push(
+    ...indexIds.map(indexId => {
+      const parameters = derivedParameters[indexId];
+
+      return algoliasearchHelper(client, parameters.index).searchOnce(
+        parameters
+      );
+    })
+  );
+
+  return Promise.all(search).then(results =>
+    zipWith([indexName, ...indexIds], results, (indexId, result) =>
+      // We attach `indexId` on the results to be able to reconstruct the
+      // object client side. We cannot rely on `state.index` anymore because
+      // we may have multiple times the same index.
+      ({
+        ...result,
+        _internalIndexId: indexId,
+      })
+    )
+  );
+};
 
 const createInstantSearchServer = algoliasearch => {
   const InstantSearch = createInstantSearch(algoliasearch, {
     Root: 'div',
-    props: { className: 'ais-InstantSearch__root' },
+    props: {
+      className: 'ais-InstantSearch__root',
+    },
   });
 
-  let searchParameters = [];
-  let client;
+  let client = null;
   let indexName = '';
-
-  const onSearchParameters = (
-    getSearchParameters,
-    context,
-    props,
-    searchState
-  ) => {
-    const index = getIndex(context);
-    searchParameters.push({
-      getSearchParameters,
-      context,
-      props,
-      searchState,
-      index,
-    });
-  };
+  let searchParameters = [];
 
   const findResultsState = function(App, props) {
     searchParameters = [];
 
     renderToString(<App {...props} />);
 
-    const sharedSearchParameters = searchParameters
-      .filter(
-        searchParameter =>
-          !hasMultipleIndex(searchParameter.context) &&
-          (searchParameter.props.indexName === indexName ||
-            !searchParameter.props.indexName)
-      )
-      .reduce(
-        (acc, searchParameter) =>
-          searchParameter.getSearchParameters(
-            acc,
-            searchParameter.props,
-            searchParameter.searchState
-          ),
-        new SearchParameters({ index: indexName, ...HIGHLIGHT_TAGS })
-      );
+    const { sharedParameters, derivedParameters } = getSearchParameters(
+      indexName,
+      searchParameters
+    );
 
-    const mergedSearchParameters = searchParameters
-      .filter(searchParameter => hasMultipleIndex(searchParameter.context))
-      .reduce((acc, searchParameter) => {
-        const index = getIndex(searchParameter.context);
-        const sp = searchParameter.getSearchParameters(
-          acc[index] ? acc[index] : sharedSearchParameters,
-          searchParameter.props,
-          searchParameter.searchState
-        );
-        acc[index] = sp;
-        return acc;
-      }, {});
+    const helper = algoliasearchHelper(client, sharedParameters.index);
 
-    if (isEmpty(mergedSearchParameters)) {
-      const helper = algoliasearchHelper(client, sharedSearchParameters.index);
-      return helper.searchOnce(sharedSearchParameters);
-    } else {
-      const helper = algoliasearchHelper(client, sharedSearchParameters.index);
-      const search = [];
-
-      if (mergedSearchParameters[indexName]) {
-        search.push(
-          helper.searchOnce({
-            ...sharedSearchParameters,
-            ...mergedSearchParameters[sharedSearchParameters.index],
-            index: mergedSearchParameters[sharedSearchParameters.index].index,
-          })
-        );
-        delete mergedSearchParameters[indexName];
-      } else {
-        search.push(helper.searchOnce(sharedSearchParameters));
-      }
-
-      search.push(
-        ...Object.keys(mergedSearchParameters).map(key => {
-          const derivedHelper = algoliasearchHelper(
-            client,
-            mergedSearchParameters[key].index
-          );
-          return derivedHelper.searchOnce(mergedSearchParameters[key]);
-        })
-      );
-
-      return Promise.all(search);
-    }
-  };
-
-  const decorateResults = function(results) {
-    if (!results) {
-      return undefined;
+    if (isEmpty(derivedParameters)) {
+      return singleIndexSearch(helper, sharedParameters);
     }
 
-    return Array.isArray(results)
-      ? results.reduce((acc, result) => {
-          acc[result.state.index] = new SearchResults(
-            new SearchParameters(result.state),
-            result._originalResponse.results
-          );
-          return acc;
-        }, [])
-      : new SearchResults(
-          new SearchParameters(results.state),
-          results._originalResponse.results
-        );
+    return multiIndexSearch(
+      indexName,
+      client,
+      helper,
+      sharedParameters,
+      derivedParameters
+    );
   };
 
   class CreateInstantSearchServer extends Component {
@@ -143,18 +144,18 @@ const createInstantSearchServer = algoliasearch => {
       resultsState: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     };
 
-    constructor(props) {
-      super();
+    constructor(...args) {
+      super(...args);
 
-      if (props.searchClient) {
-        if (props.appId || props.apiKey || props.algoliaClient) {
+      if (this.props.searchClient) {
+        if (this.props.appId || this.props.apiKey || this.props.algoliaClient) {
           throw new Error(
             'react-instantsearch:: `searchClient` cannot be used with `appId`, `apiKey` or `algoliaClient`.'
           );
         }
       }
 
-      if (props.algoliaClient) {
+      if (this.props.algoliaClient) {
         // eslint-disable-next-line no-console
         console.warn(
           '`algoliaClient` option was renamed `searchClient`. Please use this new option before the next major version.'
@@ -162,30 +163,66 @@ const createInstantSearchServer = algoliasearch => {
       }
 
       client =
-        props.searchClient ||
-        props.algoliaClient ||
-        algoliasearch(props.appId, props.apiKey);
+        this.props.searchClient ||
+        this.props.algoliaClient ||
+        algoliasearch(this.props.appId, this.props.apiKey);
 
       if (typeof client.addAlgoliaAgent === 'function') {
         client.addAlgoliaAgent(`react-instantsearch ${version}`);
       }
 
-      indexName = props.indexName;
+      indexName = this.props.indexName;
+    }
+
+    onSearchParameters(getWidgetSearchParameters, context, props, searchState) {
+      searchParameters.push({
+        getSearchParameters: getWidgetSearchParameters,
+        index: getIndexId(context),
+        context,
+        props,
+        searchState,
+      });
+    }
+
+    hydrateResultsState() {
+      const { resultsState = [] } = this.props;
+
+      if (Array.isArray(resultsState)) {
+        return resultsState.reduce(
+          (acc, result) => ({
+            ...acc,
+            [result._internalIndexId]: new SearchResults(
+              new SearchParameters(result.state),
+              result._originalResponse.results
+            ),
+          }),
+          {}
+        );
+      }
+
+      return new SearchResults(
+        new SearchParameters(resultsState.state),
+        resultsState._originalResponse.results
+      );
     }
 
     render() {
-      const resultsState = decorateResults(this.props.resultsState);
+      const resultsState = this.hydrateResultsState();
+
       return (
         <InstantSearch
           {...this.props}
           resultsState={resultsState}
-          onSearchParameters={onSearchParameters}
+          onSearchParameters={this.onSearchParameters}
         />
       );
     }
   }
 
-  return { InstantSearch: CreateInstantSearchServer, findResultsState };
+  return {
+    InstantSearch: CreateInstantSearchServer,
+    findResultsState,
+  };
 };
 
 export default createInstantSearchServer;

--- a/packages/react-instantsearch-dom/src/core/findResultsState.js
+++ b/packages/react-instantsearch-dom/src/core/findResultsState.js
@@ -16,7 +16,6 @@
  */
 export function findResultsState() {}
 
-/* eslint valid-jsdoc: 0 */
 /**
  * The `createInstantSearch` let's you create a server-side compatible `<InstantSearch>` component along with a `findResultsState` function tied to this component. You'll use this component on both the server and client.
  * @name createInstantSearch

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -23,30 +23,49 @@ stories
     <InstantSearch
       appId="latency"
       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
-      indexName="categories"
+      indexName="instant_search"
     >
       <SearchBox />
-      <div className="multi-index_content">
-        <div className="multi-index_categories-or-brands">
-          <Index indexName="categories">
-            <div>Categories: </div>
-            <Configure hitsPerPage={3} />
-            <CustomCategoriesOrBrands />
-          </Index>
-          <Index indexName="brands">
-            <div>Brand: </div>
-            <Configure hitsPerPage={3} />
-            <CustomCategoriesOrBrands />
-          </Index>
-        </div>
-        <div className="multi-index_products">
-          <Index indexName="products">
-            <div>Products: </div>
-            <Configure hitsPerPage={5} />
-            <CustomProducts />
-          </Index>
-        </div>
-      </div>
+
+      <Index indexName="bestbuy">
+        <h3>
+          index: <code>bestbuy</code>
+        </h3>
+        <Configure hitsPerPage={3} />
+        <CustomCategoriesOrBrands />
+      </Index>
+
+      <Index indexName="instant_search">
+        <h3>
+          index: <code>instant_search</code>
+        </h3>
+        <Configure hitsPerPage={3} />
+        <CustomCategoriesOrBrands />
+      </Index>
+
+      <Index indexId="instant_search_apple" indexName="instant_search">
+        <h3>
+          index: <code>instant_search</code> with <code>brand:Apple</code>
+        </h3>
+        <Configure hitsPerPage={3} filters="brand:Apple" />
+        <CustomCategoriesOrBrands />
+      </Index>
+
+      <Index indexId="instant_search_samsung" indexName="instant_search">
+        <h3>
+          index: <code>instant_search</code> with <code>brand:Samsung</code>
+        </h3>
+        <Configure hitsPerPage={3} filters="brand:Samsung" />
+        <CustomCategoriesOrBrands />
+      </Index>
+
+      <Index indexId="instant_search_microsoft" indexName="instant_search">
+        <h3>
+          index: <code>instant_search</code> with <code>brand:Microsoft</code>
+        </h3>
+        <Configure hitsPerPage={3} filters="brand:Microsoft" />
+        <CustomCategoriesOrBrands />
+      </Index>
     </InstantSearch>
   ))
   .add('AutoComplete', () => (


### PR DESCRIPTION
**Summary**

This is the first part of the work to support multi-index search on the same index. The PR doesn't add any feature to the lib, it's only an internal refactor to allow the support of the same index search. The previous implementation rely on an object like the one below to keep track of which results match which index:

```
{
  <indexNameSearchParameters>: <indexNameReactInstantSearchContext>
}
```

Then inside the success handler of the helper we rely on `content.index` to find which index match which content:

https://github.com/algolia/react-instantsearch/blob/07ad0390e1ca21024289b7f38ce7a7d129a00441/packages/react-instantsearch-core/src/core/createInstantSearchManager.js#L174

This solution doesn't work with a multi-index search on the same index because the value of `content.index` is the same for all the results. We have to use an external value to find back which results match which index.

**Solution**

We now bind the index identifier to the helper success handler. This identifier comes from the outside and it's not bound to the results. We can get rid of the map `indexMapping` because we now use the `indexId`. We also get rid of the `derivedHelpers` object because this information is already inside the helper.

We have the same issue as before though because we use the index name as identifier. But we gonna introduce the `indexId` property in a next PR. 