### PR TITLE
feat(indexId): rely on indexId rather than indexName [PART-2]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,8 @@ module.exports = {
   extends: ['algolia/react', 'algolia/jest'],
   rules: {
     'no-param-reassign': 'off',
+    // @TODO: to remove once `eslint-config-algolia` ships the change
+    'valid-jsdoc': 'off',
   },
   settings: {
     react: {

--- a/packages/react-instantsearch-core/src/components/Index.js
+++ b/packages/react-instantsearch-core/src/components/Index.js
@@ -1,5 +1,3 @@
-/* eslint valid-jsdoc: 0 */
-
 import React, { Component, Children } from 'react';
 import PropTypes from 'prop-types';
 

--- a/packages/react-instantsearch-core/src/components/Index.js
+++ b/packages/react-instantsearch-core/src/components/Index.js
@@ -1,7 +1,8 @@
+/* eslint valid-jsdoc: 0 */
+
 import React, { Component, Children } from 'react';
 import PropTypes from 'prop-types';
 
-/* eslint valid-jsdoc: 0 */
 /**
  * @description
  * `<Index>` is the component that allows you to apply widgets to a dedicated index. It's
@@ -32,18 +33,17 @@ import PropTypes from 'prop-types';
  * );
  */
 class Index extends Component {
-  constructor(props, context) {
-    super(props);
-    const {
-      ais: { widgetsManager },
-    } = context;
+  constructor(...args) {
+    super(...args);
 
     /*
      we want <Index> to be seen as a regular widget.
      It means that with only <Index> present a new query will be sent to Algolia.
      That way you don't need a virtual hits widget to use the connectAutoComplete.
     */
-    this.unregisterWidget = widgetsManager.registerWidget(this);
+    this.unregisterWidget = this.context.ais.widgetsManager.registerWidget(
+      this
+    );
   }
 
   componentWillMount() {
@@ -67,7 +67,7 @@ class Index extends Component {
   getChildContext() {
     return {
       multiIndexContext: {
-        targetedIndex: this.props.indexName,
+        targetedIndex: this.props.indexId,
       },
     };
   }
@@ -89,6 +89,7 @@ class Index extends Component {
 Index.propTypes = {
   // @TODO: These props are currently constant.
   indexName: PropTypes.string.isRequired,
+  indexId: PropTypes.string.isRequired,
   children: PropTypes.node,
   root: PropTypes.shape({
     Root: PropTypes.oneOfType([

--- a/packages/react-instantsearch-core/src/components/InstantSearch.js
+++ b/packages/react-instantsearch-core/src/components/InstantSearch.js
@@ -14,7 +14,6 @@ function validateNextProps(props, nextProps) {
   }
 }
 
-/* eslint valid-jsdoc: 0 */
 /**
  * @description
  * `<InstantSearch>` is the root component of all React InstantSearch implementations.

--- a/packages/react-instantsearch-core/src/components/__tests__/Index.js
+++ b/packages/react-instantsearch-core/src/components/__tests__/Index.js
@@ -1,100 +1,160 @@
 import React from 'react';
-import Enzyme, { mount } from 'enzyme';
+import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { SearchParameters } from 'algoliasearch-helper';
 import Index from '../Index';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('Index', () => {
-  const DEFAULT_PROPS = {
-    indexName: 'foobar',
+  const createContext = () => ({
+    ais: {
+      onSearchParameters: jest.fn(),
+      widgetsManager: {
+        registerWidget: jest.fn(),
+        update: jest.fn(),
+      },
+    },
+  });
+
+  const requiredProps = {
+    indexName: 'indexName',
+    indexId: 'indexId',
     root: {
       Root: 'div',
     },
   };
 
-  const registerWidget = jest.fn();
-  const update = jest.fn();
-  const widgetsManager = { registerWidget, update };
+  it('register itself on mount', () => {
+    const context = createContext();
 
-  let context = {
-    ais: {
-      widgetsManager,
-      onSearchParameters: () => {},
-      update,
-    },
-  };
-
-  it('validates its props', () => {
-    expect(() => {
-      mount(
-        <Index {...DEFAULT_PROPS}>
-          <div />
-        </Index>,
-        { context }
-      );
-    }).not.toThrow();
-
-    expect(() => {
-      mount(<Index {...DEFAULT_PROPS} />, { context });
-    }).not.toThrow();
-
-    expect(() => {
-      mount(
-        <Index {...DEFAULT_PROPS}>
-          <div />
-          <div />
-        </Index>,
-        { context }
-      );
-    }).not.toThrow();
-
-    expect(registerWidget.mock.calls).toHaveLength(3);
-  });
-
-  it('exposes multi index context', () => {
-    const wrapper = mount(
-      <Index {...DEFAULT_PROPS}>
+    const wrapper = shallow(
+      <Index {...requiredProps}>
         <div />
       </Index>,
-      { context }
+      {
+        context,
+      }
     );
 
-    const childContext = wrapper.instance().getChildContext();
-    expect(childContext.multiIndexContext.targetedIndex).toBe(
-      DEFAULT_PROPS.indexName
+    expect(context.ais.widgetsManager.registerWidget).toHaveBeenCalledTimes(1);
+    expect(context.ais.widgetsManager.registerWidget).toHaveBeenCalledWith(
+      wrapper.instance()
     );
   });
 
-  it('update search if indexName prop change', () => {
-    const wrapper = mount(
-      <Index {...DEFAULT_PROPS}>
+  it('calls onSearchParameters on mount', () => {
+    const context = createContext();
+
+    shallow(
+      <Index {...requiredProps}>
         <div />
       </Index>,
-      { context }
+      {
+        context,
+      }
     );
+
+    expect(context.ais.onSearchParameters).toHaveBeenCalledTimes(1);
+  });
+
+  it('call update if indexName prop change', () => {
+    const context = createContext();
+
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    expect(context.ais.widgetsManager.update).toHaveBeenCalledTimes(0);
 
     wrapper.setProps({ indexName: 'newIndexName' });
 
-    expect(update.mock.calls).toHaveLength(1);
+    expect(context.ais.widgetsManager.update).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onSearchParameters when mounted', () => {
-    const onSearchParameters = jest.fn();
-    context = {
-      ais: {
-        widgetsManager,
-        onSearchParameters,
-      },
-    };
+  it('unregister itself on unmount', () => {
+    const unregister = jest.fn();
+    const context = createContext();
 
-    mount(
-      <Index {...DEFAULT_PROPS}>
-        <div />
-      </Index>,
-      { context }
+    context.ais.widgetsManager.registerWidget.mockImplementation(
+      () => unregister
     );
 
-    expect(onSearchParameters.mock.calls).toHaveLength(1);
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    expect(unregister).toHaveBeenCalledTimes(0);
+
+    wrapper.unmount();
+
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes multi index context', () => {
+    const context = createContext();
+
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    const childContext = wrapper.instance().getChildContext();
+
+    expect(childContext.multiIndexContext.targetedIndex).toBe('indexId');
+  });
+
+  it('provides search parameters from instance props', () => {
+    const context = createContext();
+
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    const parameters = wrapper
+      .instance()
+      .getSearchParameters(new SearchParameters());
+
+    expect(parameters.index).toBe('indexName');
+  });
+
+  it('provides search parameters from argument props when instance props are not available', () => {
+    const context = createContext();
+
+    const wrapper = shallow(
+      <Index {...requiredProps}>
+        <div />
+      </Index>,
+      {
+        context,
+      }
+    );
+
+    const parameters = wrapper
+      .instance()
+      .getSearchParameters.call({}, new SearchParameters(), {
+        indexName: 'otherIndexName',
+      });
+
+    expect(parameters.index).toBe('otherIndexName');
   });
 });

--- a/packages/react-instantsearch-core/src/components/__tests__/Index.js
+++ b/packages/react-instantsearch-core/src/components/__tests__/Index.js
@@ -25,7 +25,7 @@ describe('Index', () => {
     },
   };
 
-  it('register itself on mount', () => {
+  it('registers itself on mount', () => {
     const context = createContext();
 
     const wrapper = shallow(
@@ -58,7 +58,7 @@ describe('Index', () => {
     expect(context.ais.onSearchParameters).toHaveBeenCalledTimes(1);
   });
 
-  it('call update if indexName prop change', () => {
+  it('calls update if indexName prop changes', () => {
     const context = createContext();
 
     const wrapper = shallow(
@@ -77,7 +77,7 @@ describe('Index', () => {
     expect(context.ais.widgetsManager.update).toHaveBeenCalledTimes(1);
   });
 
-  it('unregister itself on unmount', () => {
+  it('unregisters itself on unmount', () => {
     const unregister = jest.fn();
     const context = createContext();
 

--- a/packages/react-instantsearch-core/src/connectors/connectConfigure.js
+++ b/packages/react-instantsearch-core/src/connectors/connectConfigure.js
@@ -1,6 +1,10 @@
 import { omit, difference, keys } from 'lodash';
 import createConnector from '../core/createConnector';
-import { hasMultipleIndex, getIndex, refineValue } from '../core/indexUtils';
+import {
+  refineValue,
+  getIndexId,
+  hasMultipleIndices,
+} from '../core/indexUtils';
 
 function getId() {
   return 'configure';
@@ -29,10 +33,10 @@ export default createConnector({
   },
   cleanUp(props, searchState) {
     const id = getId();
-    const index = getIndex(this.context);
+    const indexId = getIndexId(this.context);
     const subState =
-      hasMultipleIndex(this.context) && searchState.indices
-        ? searchState.indices[index]
+      hasMultipleIndices(this.context) && searchState.indices
+        ? searchState.indices[indexId]
         : searchState;
     const configureKeys =
       subState && subState[id] ? Object.keys(subState[id]) : [];

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -3,7 +3,7 @@ import createConnector from '../core/createConnector';
 import {
   getResults,
   getCurrentRefinementValue,
-  getIndex,
+  getIndexId,
   refineValue,
   cleanUpValue,
 } from '../core/indexUtils';
@@ -205,7 +205,7 @@ export default createConnector({
   getMetadata(props, searchState) {
     const items = [];
     const id = getBoundingBoxId();
-    const index = getIndex(this.context);
+    const index = getIndexId(this.context);
     const nextRefinement = {};
     const currentRefinement = getCurrentRefinement(
       props,

--- a/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
@@ -3,7 +3,7 @@ import { SearchParameters } from 'algoliasearch-helper';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   refineValue,
   getCurrentRefinementValue,
   getResults,
@@ -270,7 +270,7 @@ export default createConnector({
 
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items: !currentRefinement
         ? []
         : [

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -2,7 +2,7 @@ import { orderBy } from 'lodash';
 import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
-  getIndex,
+  getIndexId,
   cleanUpValue,
   refineValue,
   getCurrentRefinementValue,
@@ -222,7 +222,7 @@ export default createConnector({
     );
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items:
         currentRefinement === null
           ? []

--- a/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
@@ -6,7 +6,7 @@ import {
   refineValue,
   getCurrentRefinementValue,
   getResults,
-  getIndex,
+  getIndexId,
 } from '../core/indexUtils';
 
 function stringifyItem(item) {
@@ -209,7 +209,7 @@ export default createConnector({
     const id = getId(props);
     const value = getCurrentRefinement(props, searchState, this.context);
     const items = [];
-    const index = getIndex(this.context);
+    const index = getIndexId(this.context);
     if (value !== '') {
       const { label } = find(
         props.items,

--- a/packages/react-instantsearch-core/src/connectors/connectRange.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRange.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   refineValue,
   getCurrentRefinementValue,
   getResults,
@@ -332,7 +332,7 @@ export default createConnector({
 
     return {
       id: getId(props),
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items,
     };
   },

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   refineValue,
   getCurrentRefinementValue,
   getResults,
@@ -226,7 +226,7 @@ export default createConnector({
     const context = this.context;
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items:
         getCurrentRefinement(props, searchState, context).length > 0
           ? [

--- a/packages/react-instantsearch-core/src/connectors/connectScrollTo.js
+++ b/packages/react-instantsearch-core/src/connectors/connectScrollTo.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   getCurrentRefinementValue,
-  hasMultipleIndex,
-  getIndex,
+  hasMultipleIndices,
+  getIndexId,
 } from '../core/indexUtils';
 import { shallowEqual } from '../core/utils';
 
@@ -44,9 +44,10 @@ export default createConnector({
     }
 
     /* Get the subpart of the state that interest us*/
-    if (hasMultipleIndex(this.context)) {
-      const index = getIndex(this.context);
-      searchState = searchState.indices ? searchState.indices[index] : {};
+    if (hasMultipleIndices(this.context)) {
+      searchState = searchState.indices
+        ? searchState.indices[getIndexId(this.context)]
+        : {};
     }
 
     /*

--- a/packages/react-instantsearch-core/src/connectors/connectSearchBox.js
+++ b/packages/react-instantsearch-core/src/connectors/connectSearchBox.js
@@ -4,7 +4,7 @@ import {
   cleanUpValue,
   refineValue,
   getCurrentRefinementValue,
-  getIndex,
+  getIndexId,
 } from '../core/indexUtils';
 
 function getId() {
@@ -86,7 +86,7 @@ export default createConnector({
     );
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items:
         currentRefinement === null
           ? []

--- a/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   getResults,
   refineValue,
   getCurrentRefinementValue,
@@ -149,7 +149,7 @@ export default createConnector({
     const id = getId(props);
     const checked = getCurrentRefinement(props, searchState, this.context);
     const items = [];
-    const index = getIndex(this.context);
+    const index = getIndexId(this.context);
 
     if (checked) {
       items.push({

--- a/packages/react-instantsearch-core/src/core/__tests__/__snapshots__/createIndex.js.snap
+++ b/packages/react-instantsearch-core/src/core/__tests__/__snapshots__/createIndex.js.snap
@@ -1,24 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createIndex expect to create Index with a custom root props 1`] = `
+exports[`createIndex expect to create an Index 1`] = `
 <Index
-  indexName="name"
-  root={
-    Object {
-      "Root": "span",
-      "props": Object {
-        "style": Object {
-          "flex": 1,
-        },
-      },
-    }
-  }
-/>
-`;
-
-exports[`createIndex wraps Index 1`] = `
-<Index
-  indexName="name"
+  indexId="indexName"
+  indexName="indexName"
   root={
     Object {
       "Root": "div",

--- a/packages/react-instantsearch-core/src/core/__tests__/__snapshots__/createIndex.js.snap
+++ b/packages/react-instantsearch-core/src/core/__tests__/__snapshots__/createIndex.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createIndex expect to create an Index 1`] = `
+exports[`createIndex expects to create an Index 1`] = `
 <Index
   indexId="indexName"
   indexName="indexName"

--- a/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
@@ -9,26 +9,76 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('createIndex', () => {
   const CustomIndex = createIndex({ Root: 'div' });
 
-  it('wraps Index', () => {
-    const wrapper = shallow(<CustomIndex indexName="name" />);
+  const requiredProps = {
+    indexName: 'indexName',
+  };
+
+  it('expect to create an Index', () => {
+    const props = {
+      ...requiredProps,
+    };
+
+    const wrapper = shallow(<CustomIndex {...props} />);
+
     expect(wrapper.is(Index)).toBe(true);
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('expect to create Index with a custom root props', () => {
-    const root = {
+  it('expect to create an Index with the default root', () => {
+    const props = {
+      ...requiredProps,
+    };
+
+    const wrapper = shallow(<CustomIndex {...props} />);
+
+    expect(wrapper.props().root).toEqual({
+      Root: 'div',
+    });
+  });
+
+  it('expect to create an Index with a custom root props', () => {
+    const props = {
+      ...requiredProps,
+      root: {
+        Root: 'span',
+        props: {
+          style: {
+            flex: 1,
+          },
+        },
+      },
+    };
+
+    const wrapper = shallow(<CustomIndex {...props} />);
+
+    expect(wrapper.props().root).toEqual({
       Root: 'span',
       props: {
         style: {
           flex: 1,
         },
       },
+    });
+  });
+
+  it('expect to create an Index with an indexId when provided', () => {
+    const props = {
+      ...requiredProps,
+      indexId: 'indexId',
     };
 
-    const wrapper = shallow(<CustomIndex indexName="name" root={root} />);
+    const wrapper = shallow(<CustomIndex {...props} />);
 
-    expect(wrapper.is(Index)).toBe(true);
-    expect(wrapper.props().root).toEqual(root);
-    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.props().indexId).toBe('indexId');
+  });
+
+  it("expect to create an Index with an indexId that fallback to indexName when it's not provided", () => {
+    const props = {
+      ...requiredProps,
+    };
+
+    const wrapper = shallow(<CustomIndex {...props} />);
+
+    expect(wrapper.props().indexId).toBe('indexName');
   });
 });

--- a/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
@@ -13,7 +13,7 @@ describe('createIndex', () => {
     indexName: 'indexName',
   };
 
-  it('expect to create an Index', () => {
+  it('expects to create an Index', () => {
     const props = {
       ...requiredProps,
     };
@@ -24,7 +24,7 @@ describe('createIndex', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('expect to create an Index with the default root', () => {
+  it('expects to create an Index with the default root', () => {
     const props = {
       ...requiredProps,
     };
@@ -36,7 +36,7 @@ describe('createIndex', () => {
     });
   });
 
-  it('expect to create an Index with a custom root props', () => {
+  it('expects to create an Index with a custom root props', () => {
     const props = {
       ...requiredProps,
       root: {
@@ -61,7 +61,7 @@ describe('createIndex', () => {
     });
   });
 
-  it('expect to create an Index with an indexId when provided', () => {
+  it('expects to create an Index with an indexId when provided', () => {
     const props = {
       ...requiredProps,
       indexId: 'indexId',
@@ -72,7 +72,7 @@ describe('createIndex', () => {
     expect(wrapper.props().indexId).toBe('indexId');
   });
 
-  it("expect to create an Index with an indexId that fallback to indexName when it's not provided", () => {
+  it("expects to create an Index with an indexId that fallback to indexName when it's not provided", () => {
     const props = {
       ...requiredProps,
     };

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
@@ -9,6 +9,7 @@ const createSearchClient = () => ({
         index: request.indexName,
         query: request.params.query,
         page: request.params.page,
+        hitsPerPage: request.params.hitsPerPage,
         hits: [],
       })),
     })
@@ -27,11 +28,11 @@ describe('createInstantSearchManager with multi index', () => {
     // <InstantSearch indexName="first">
     //   <SearchBox defaultRefinement="first query 1" />
     //
-    //   <Index indexName="first">
+    //   <Index indexName="first" indexId="first">
     //     <Pagination defaultRefinement={3} />
     //   </Index>
     //
-    //   <Index indexName="second">
+    //   <Index indexName="second" indexId="second">
     //     <SearchBox defaultRefinement="second query 1" />
     //   </Index>
     // </InstantSearch>
@@ -50,39 +51,49 @@ describe('createInstantSearchManager with multi index', () => {
       props: {},
     });
 
-    // <Index indexName="first" />
+    // <Index indexName="first" indexId="first" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('first'),
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
-    // <Index indexName="first">
+    // <Index indexName="first" indexId="first">
     //   <Pagination defaultRefinement={3} />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setPage(3),
-      context: { multiIndexContext: { targetedIndex: 'first' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first',
+        },
+      },
       props: {},
     });
 
-    // <Index indexName="second" />
+    // <Index indexName="second" indexId="second" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('second'),
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
-    // <Index indexName="second">
+    // <Index indexName="second" indexId="second">
     //   <SearchBox defaultRefinement="second query 1" />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setQuery('second query 1'),
-      context: { multiIndexContext: { targetedIndex: 'second' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'second',
+        },
+      },
       props: {},
     });
 
@@ -112,7 +123,7 @@ describe('createInstantSearchManager with multi index', () => {
     ism.widgetsManager.getWidgets()[0].getSearchParameters = params =>
       params.setQuery('first query 2');
 
-    // <Index indexName="second">
+    // <Index indexName="second" indexId="second">
     //   <SearchBox defaultRefinement="second query 2" />
     // </Index>
     ism.widgetsManager.getWidgets()[4].getSearchParameters = params =>
@@ -143,11 +154,11 @@ describe('createInstantSearchManager with multi index', () => {
     // <InstantSearch indexName="first">
     //   <SearchBox defaultRefinement="query" />
     //
-    //   <Index indexName="first">
+    //   <Index indexName="first" indexId="first">
     //     <SortBy defaultRefinement="third" />
     //   </Index>
     //
-    //   <Index indexName="second" />
+    //   <Index indexName="second" indexId="second" />
     // </InstantSearch>;
 
     const ism = createInstantSearchManager({
@@ -164,30 +175,36 @@ describe('createInstantSearchManager with multi index', () => {
       props: {},
     });
 
-    // <Index indexName="first" />
+    // <Index indexName="first" indexId="first" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: x => x.setIndex('first'),
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
-    // <Index indexName="first">
+    // <Index indexName="first" indexId="first">
     //   <SortBy defaultRefinement="third" />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: x => x.setIndex('third'),
-      context: { multiIndexContext: { targetedIndex: 'first' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first',
+        },
+      },
       props: {},
     });
 
-    // <Index indexName="second" />
+    // <Index indexName="second" indexId="second" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: x => x.setIndex('second'),
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
@@ -235,6 +252,7 @@ describe('createInstantSearchManager with multi index', () => {
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
@@ -244,6 +262,7 @@ describe('createInstantSearchManager with multi index', () => {
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
@@ -253,6 +272,7 @@ describe('createInstantSearchManager with multi index', () => {
       context: {},
       props: {
         indexName: 'third',
+        indexId: 'third',
       },
     });
 
@@ -262,6 +282,7 @@ describe('createInstantSearchManager with multi index', () => {
       context: {},
       props: {
         indexName: 'four',
+        indexId: 'four',
       },
     });
 
@@ -276,15 +297,110 @@ describe('createInstantSearchManager with multi index', () => {
     expect(searchClient.search.mock.calls[1][0]).toHaveLength(4);
   });
 
+  it('searches with same index but different params', async () => {
+    // <InstantSearch indexName="first">
+    //   <SearchBox defaultRefinement="first query" />
+    //
+    //   <Index indexName="first" indexId="first_5_hits">
+    //     <Configure hitsPerPage={5} />
+    //   </Index>
+    //
+    //   <Index indexName="first" indexId="first_10_hits">
+    //     <Configure hitsPerPage={10} />
+    //   </Index>
+    // </InstantSearch>
+
+    const ism = createInstantSearchManager({
+      indexName: 'first',
+      initialState: {},
+      searchParameters: {},
+      searchClient: createSearchClient(),
+    });
+
+    // <SearchBox defaultRefinement="first query" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params => params.setQuery('first query'),
+      context: {},
+      props: {},
+    });
+
+    // <Index indexName="first" indexId="first_5_hits" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params => params.setIndex('first'),
+      context: {},
+      props: {
+        indexName: 'first',
+        indexId: 'first_5_hits',
+      },
+    });
+
+    // <Index indexName="first" indexId="first_5_hits">
+    //   <Configure hitsPerPage={5} />
+    // </Index>
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params => params.setQueryParameter('hitsPerPage', 5),
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first_5_hits',
+        },
+      },
+      props: {},
+    });
+
+    // <Index indexName="first" indexId="first_10_hits" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params => params.setIndex('first'),
+      context: {},
+      props: {
+        indexName: 'first',
+        indexId: 'first_10_hits',
+      },
+    });
+
+    // <Index indexName="first" indexId="first_10_hits">
+    //   <Configure hitsPerPage={10} />
+    // </Index>
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: params =>
+        params.setQueryParameter('hitsPerPage', 10),
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first_10_hits',
+        },
+      },
+      props: {},
+    });
+
+    expect(ism.store.getState().results).toBe(null);
+
+    await runAllMicroTasks();
+
+    expect(ism.store.getState().results.first_5_hits).toEqual(
+      expect.objectContaining({
+        query: 'first query',
+        index: 'first',
+        hitsPerPage: 5,
+      })
+    );
+
+    expect(ism.store.getState().results.first_10_hits).toEqual(
+      expect.objectContaining({
+        query: 'first query',
+        index: 'first',
+        hitsPerPage: 10,
+      })
+    );
+  });
+
   it('switching from mono to multi index', async () => {
     // <InstantSearch indexName="first">
     //   <SearchBox defaultRefinement="first query 1" />
     //
-    //   <Index indexName="first">
+    //   <Index indexName="first" indexId="first">
     //     <Pagination defaultRefinement={3} />
     //   </Index>
     //
-    //   <Index indexName="second">
+    //   <Index indexName="second" indexId="second">
     //     <SearchBox defaultRefinement="second query 1" />
     //   </Index>
     // </InstantSearch>
@@ -303,39 +419,49 @@ describe('createInstantSearchManager with multi index', () => {
       props: {},
     });
 
-    // <Index indexName="first" />
+    // <Index indexName="first" indexId="first" />
     const unregisterFirstIndexWidget = ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('first'),
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
-    // <Index indexName="first">
+    // <Index indexName="first" indexId="first">
     //   <Pagination defaultRefinement={3} />
     // </Index>
     const unregisterPaginationWidget = ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setPage(3),
-      context: { multiIndexContext: { targetedIndex: 'first' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first',
+        },
+      },
       props: {},
     });
 
-    // <Index indexName="second" />
+    // <Index indexName="second" indexId="second" />
     const unregisterSecondIndexWidget = ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('second'),
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
-    // <Index indexName="second">
+    // <Index indexName="second" indexId="second">
     //   <SearchBox defaultRefinement="second query 1" />
     // </Index>
     const unregisterSecondSearchBoxWidget = ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setQuery('second query 1'),
-      context: { multiIndexContext: { targetedIndex: 'second' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'second',
+        },
+      },
       props: {},
     });
 
@@ -377,39 +503,49 @@ describe('createInstantSearchManager with multi index', () => {
       })
     );
 
-    // <Index indexName="first" />
+    // <Index indexName="first" indexId="first" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('first'),
       context: {},
       props: {
         indexName: 'first',
+        indexId: 'first',
       },
     });
 
-    // <Index indexName="first">
+    // <Index indexName="first" indexId="first">
     //   <Pagination defaultRefinement={3} />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setPage(3),
-      context: { multiIndexContext: { targetedIndex: 'first' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'first',
+        },
+      },
       props: {},
     });
 
-    // <Index indexName="second" />
+    // <Index indexName="second" indexId="second" />
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setIndex('second'),
       context: {},
       props: {
         indexName: 'second',
+        indexId: 'second',
       },
     });
 
-    // <Index indexName="second">
+    // <Index indexName="second" indexId="second">
     //   <SearchBox defaultRefinement="second query 1" />
     // </Index>
     ism.widgetsManager.registerWidget({
       getSearchParameters: params => params.setQuery('second query 2'),
-      context: { multiIndexContext: { targetedIndex: 'second' } },
+      context: {
+        multiIndexContext: {
+          targetedIndex: 'second',
+        },
+      },
       props: {},
     });
 

--- a/packages/react-instantsearch-core/src/core/createIndex.js
+++ b/packages/react-instantsearch-core/src/core/createIndex.js
@@ -9,14 +9,16 @@ import Index from '../components/Index';
  * @return {object} a Index root
  */
 const createIndex = defaultRoot => {
-  const CreateIndex = ({ indexName, root, children }) => (
-    <Index indexName={indexName} root={root}>
+  const CreateIndex = ({ indexName, indexId, root, children }) => (
+    <Index indexName={indexName} indexId={indexId || indexName} root={root}>
       {children}
     </Index>
   );
 
   CreateIndex.propTypes = {
     indexName: PropTypes.string.isRequired,
+    // @MAJOR: indexId must be required
+    indexId: PropTypes.string,
     root: PropTypes.shape({
       Root: PropTypes.oneOfType([
         PropTypes.string,

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -1,8 +1,20 @@
-import { omit, find } from 'lodash';
-import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
+import { omit } from 'lodash';
+import algoliasearchHelper from 'algoliasearch-helper';
 import createWidgetsManager from './createWidgetsManager';
 import createStore from './createStore';
 import { HIGHLIGHT_TAGS } from './highlight';
+import { hasMultipleIndices } from './indexUtils';
+
+const isMultiIndexContext = widget => hasMultipleIndices(widget.context);
+const isTargetedIndexEqualIndex = (widget, indexId) =>
+  widget.context.multiIndexContext.targetedIndex === indexId;
+
+// Relying on the `indexId` is a bit brittle to detect the `Index` widget.
+// Since it's a class we could rely on `instanceof` or similar. We never
+// had an issue though. Works for now.
+const isIndexWidget = widget => Boolean(widget.props.indexId);
+const isIndexWidgetEqualIndex = (widget, indexId) =>
+  widget.props.indexId === indexId;
 
 /**
  * Creates a new instance of the InstantSearchManager which controls the widgets and
@@ -20,19 +32,17 @@ export default function createInstantSearchManager({
   resultsState,
   stalledSearchDelay,
 }) {
-  const baseSP = new SearchParameters({
-    index: indexName,
+  const helper = algoliasearchHelper(searchClient, indexName, {
     ...HIGHLIGHT_TAGS,
   });
 
+  helper
+    .on('search', handleNewSearch)
+    .on('result', handleSearchSuccess({ indexId: indexName }))
+    .on('error', handleSearchError);
+
+  let skip = false;
   let stalledSearchTimer = null;
-
-  const helper = algoliasearchHelper(searchClient, indexName, baseSP);
-
-  helper.on('result', handleSearchSuccess({ indexId: indexName }));
-  helper.on('error', handleSearchError);
-  helper.on('search', handleNewSearch);
-
   let initialSearchParameters = helper.state;
 
   const widgetsManager = createWidgetsManager(onWidgetsUpdate);
@@ -46,8 +56,6 @@ export default function createInstantSearchManager({
     isSearchStalled: true,
     searchingForFacetValues: false,
   });
-
-  let skip = false;
 
   function skipSearch() {
     skip = true;
@@ -74,69 +82,75 @@ export default function createInstantSearchManager({
     const sharedParameters = widgetsManager
       .getWidgets()
       .filter(widget => Boolean(widget.getSearchParameters))
-      .filter(
-        widget =>
-          !widget.context.multiIndexContext &&
-          (!widget.props.indexId || widget.props.indexId === indexName)
-      )
+      .filter(widget => !isMultiIndexContext(widget) && !isIndexWidget(widget))
       .reduce(
         (res, widget) => widget.getSearchParameters(res),
         initialSearchParameters
       );
 
-    const mainIndexParameters = widgetsManager
+    const mainParameters = widgetsManager
       .getWidgets()
       .filter(widget => Boolean(widget.getSearchParameters))
-      .filter(
-        widget =>
-          (widget.context.multiIndexContext &&
-            widget.context.multiIndexContext.targetedIndex === indexName) ||
-          (widget.props.indexId && widget.props.indexId === indexName)
-      )
+      .filter(widget => {
+        const targetedIndexEqualMainIndex =
+          isMultiIndexContext(widget) &&
+          isTargetedIndexEqualIndex(widget, indexName);
+
+        const subIndexEqualMainIndex =
+          isIndexWidget(widget) && isIndexWidgetEqualIndex(widget, indexName);
+
+        return targetedIndexEqualMainIndex || subIndexEqualMainIndex;
+      })
       .reduce(
         (res, widget) => widget.getSearchParameters(res),
         sharedParameters
       );
 
-    const derivatedWidgets = widgetsManager
+    const derivedIndices = widgetsManager
       .getWidgets()
       .filter(widget => Boolean(widget.getSearchParameters))
-      .filter(
-        widget =>
-          (widget.context.multiIndexContext &&
-            widget.context.multiIndexContext.targetedIndex !== indexName) ||
-          (widget.props.indexId && widget.props.indexId !== indexName)
-      )
+      .filter(widget => {
+        const targetedIndexNotEqualMainIndex =
+          isMultiIndexContext(widget) &&
+          !isTargetedIndexEqualIndex(widget, indexName);
+
+        const subIndexNotEqualMainIndex =
+          isIndexWidget(widget) && !isIndexWidgetEqualIndex(widget, indexName);
+
+        return targetedIndexNotEqualMainIndex || subIndexNotEqualMainIndex;
+      })
       .reduce((indices, widget) => {
-        const targetedIndex = widget.context.multiIndexContext
+        const indexId = isMultiIndexContext(widget)
           ? widget.context.multiIndexContext.targetedIndex
           : widget.props.indexId;
 
-        const index = find(indices, i => i.targetedIndex === targetedIndex);
+        const widgets = indices[indexId] || [];
 
-        if (index) {
-          index.widgets.push(widget);
-        } else {
-          indices.push({ targetedIndex, widgets: [widget] });
-        }
+        return {
+          ...indices,
+          [indexId]: widgets.concat(widget),
+        };
+      }, {});
 
-        return indices;
-      }, []);
+    const derivedParameters = Object.keys(derivedIndices).map(indexId => ({
+      parameters: derivedIndices[indexId].reduce(
+        (res, widget) => widget.getSearchParameters(res),
+        sharedParameters
+      ),
+      indexId,
+    }));
 
     return {
-      sharedParameters,
-      mainIndexParameters,
-      derivatedWidgets,
+      mainParameters,
+      derivedParameters,
     };
   }
 
   function search() {
     if (!skip) {
-      const {
-        sharedParameters,
-        mainIndexParameters,
-        derivatedWidgets,
-      } = getSearchParameters(helper.state);
+      const { mainParameters, derivedParameters } = getSearchParameters(
+        helper.state
+      );
 
       // We have to call `slice` because the method `detach` on the derived
       // helpers mutates the value `derivedHelpers`. The `forEach` loop does
@@ -160,27 +174,15 @@ export default function createInstantSearchManager({
         derivedHelper.detach();
       });
 
-      helper.setState(sharedParameters);
+      derivedParameters.forEach(({ indexId, parameters }) => {
+        const derivedHelper = helper.derive(() => parameters);
 
-      derivatedWidgets.forEach(derivedIndex => {
-        const derivedHelper = helper.derive(() =>
-          derivedIndex.widgets.reduce(
-            (res, widget) => widget.getSearchParameters(res),
-            sharedParameters
-          )
-        );
-
-        derivedHelper.on(
-          'result',
-          handleSearchSuccess({
-            indexId: derivedIndex.targetedIndex,
-          })
-        );
-
-        derivedHelper.on('error', handleSearchError);
+        derivedHelper
+          .on('result', handleSearchSuccess({ indexId }))
+          .on('error', handleSearchError);
       });
 
-      helper.setState(mainIndexParameters);
+      helper.setState(mainParameters);
 
       helper.search();
     }
@@ -193,8 +195,9 @@ export default function createInstantSearchManager({
 
       let results = state.results ? state.results : {};
 
-      /* if switching from mono index to multi index and vice versa,
-      results needs to reset to {}*/
+      // Switching from mono index to multi index and vice versa must reset the
+      // results to an empty object, otherwise we keep reference of stalled and
+      // unused results.
       results = !isDerivedHelpersEmpty && results.getFacetByName ? {} : results;
 
       if (!isDerivedHelpersEmpty) {
@@ -228,6 +231,7 @@ export default function createInstantSearchManager({
 
   function handleSearchError(error) {
     const currentState = store.getState();
+
     let nextIsSearchStalled = currentState.isSearchStalled;
     if (!helper.hasPendingRequests()) {
       clearTimeout(stalledSearchTimer);
@@ -243,6 +247,7 @@ export default function createInstantSearchManager({
       },
       'resultsFacetValues'
     );
+
     store.setState(nextState);
   }
 
@@ -256,6 +261,7 @@ export default function createInstantSearchManager({
           },
           'resultsFacetValues'
         );
+
         store.setState(nextState);
       }, stalledSearchDelay);
     }
@@ -278,6 +284,7 @@ export default function createInstantSearchManager({
 
   function transitionState(nextSearchState) {
     const searchState = store.getState().widgets;
+
     return widgetsManager
       .getWidgets()
       .filter(widget => Boolean(widget.transitionState))
@@ -363,9 +370,10 @@ export default function createInstantSearchManager({
     store,
     widgetsManager,
     getWidgetsIds,
+    getSearchParameters,
+    onSearchForFacetValues,
     onExternalStateUpdate,
     transitionState,
-    onSearchForFacetValues,
     updateClient,
     updateIndex,
     clearCache,

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -84,6 +84,20 @@ export default function createInstantSearchManager({
         initialSearchParameters
       );
 
+    const mainIndexParameters = widgetsManager
+      .getWidgets()
+      .filter(widget => Boolean(widget.getSearchParameters))
+      .filter(
+        widget =>
+          (widget.context.multiIndexContext &&
+            widget.context.multiIndexContext.targetedIndex === indexName) ||
+          (widget.props.indexName && widget.props.indexName === indexName)
+      )
+      .reduce(
+        (res, widget) => widget.getSearchParameters(res),
+        sharedParameters
+      );
+
     const derivatedWidgets = widgetsManager
       .getWidgets()
       .filter(widget => Boolean(widget.getSearchParameters))
@@ -106,21 +120,11 @@ export default function createInstantSearchManager({
         return indices;
       }, []);
 
-    const mainIndexParameters = widgetsManager
-      .getWidgets()
-      .filter(widget => Boolean(widget.getSearchParameters))
-      .filter(
-        widget =>
-          (widget.context.multiIndexContext &&
-            widget.context.multiIndexContext.targetedIndex === indexName) ||
-          (widget.props.indexName && widget.props.indexName === indexName)
-      )
-      .reduce(
-        (res, widget) => widget.getSearchParameters(res),
-        sharedParameters
-      );
-
-    return { sharedParameters, mainIndexParameters, derivatedWidgets };
+    return {
+      sharedParameters,
+      mainIndexParameters,
+      derivatedWidgets,
+    };
   }
 
   function search() {

--- a/packages/react-instantsearch-core/src/core/indexUtils.js
+++ b/packages/react-instantsearch-core/src/core/indexUtils.js
@@ -187,14 +187,14 @@ export function getCurrentRefinementValue(
 }
 
 export function cleanUpValue(searchState, context, id) {
-  const indexName = getIndex(context);
+  const index = getIndex(context);
   const { namespace, attributeName } = getNamespaceAndAttributeName(id);
 
   if (hasMultipleIndex(context) && Boolean(searchState.indices)) {
     return cleanUpValueWithMutliIndex({
       attribute: attributeName,
       searchState,
-      indexName,
+      index,
       id,
       namespace,
     });
@@ -226,25 +226,25 @@ function cleanUpValueWithSingleIndex({
 
 function cleanUpValueWithMutliIndex({
   searchState,
-  indexName,
+  index,
   id,
   namespace,
   attribute,
 }) {
-  const index = searchState.indices[indexName];
+  const indexSearchState = searchState.indices[index];
 
-  if (namespace && index) {
+  if (namespace && indexSearchState) {
     return {
       ...searchState,
       indices: {
         ...searchState.indices,
-        [indexName]: {
-          ...index,
-          [namespace]: omit(index[namespace], attribute),
+        [index]: {
+          ...indexSearchState,
+          [namespace]: omit(indexSearchState[namespace], attribute),
         },
       },
     };
   }
 
-  return omit(searchState, `indices.${indexName}.${id}`);
+  return omit(searchState, `indices.${index}.${id}`);
 }

--- a/packages/react-instantsearch-core/src/core/indexUtils.js
+++ b/packages/react-instantsearch-core/src/core/indexUtils.js
@@ -1,6 +1,6 @@
 import { has, omit, get } from 'lodash';
 
-export function getIndex(context) {
+export function getIndexId(context) {
   return context && context.multiIndexContext
     ? context.multiIndexContext.targetedIndex
     : context.ais.mainTargetedIndex;
@@ -8,15 +8,15 @@ export function getIndex(context) {
 
 export function getResults(searchResults, context) {
   if (searchResults.results && !searchResults.results.hits) {
-    return searchResults.results[getIndex(context)]
-      ? searchResults.results[getIndex(context)]
+    return searchResults.results[getIndexId(context)]
+      ? searchResults.results[getIndexId(context)]
       : null;
   } else {
     return searchResults.results ? searchResults.results : null;
   }
 }
 
-export function hasMultipleIndex(context) {
+export function hasMultipleIndices(context) {
   return context && context.multiIndexContext;
 }
 
@@ -28,7 +28,7 @@ export function refineValue(
   resetPage,
   namespace
 ) {
-  if (hasMultipleIndex(context)) {
+  if (hasMultipleIndices(context)) {
     return namespace
       ? refineMultiIndexWithNamespace(
           searchState,
@@ -68,17 +68,30 @@ export function refineValue(
 
 function refineMultiIndex(searchState, nextRefinement, context, resetPage) {
   const page = resetPage ? { page: 1 } : undefined;
-  const index = getIndex(context);
-  const state = has(searchState, `indices.${index}`)
+  const indexId = getIndexId(context);
+  const state = has(searchState, `indices.${indexId}`)
     ? {
         ...searchState.indices,
-        [index]: { ...searchState.indices[index], ...nextRefinement, ...page },
+        [indexId]: {
+          ...searchState.indices[indexId],
+          ...nextRefinement,
+          ...page,
+        },
       }
     : {
         ...searchState.indices,
-        ...{ [index]: { ...nextRefinement, ...page } },
+        ...{
+          [indexId]: {
+            ...nextRefinement,
+            ...page,
+          },
+        },
       };
-  return { ...searchState, indices: state };
+
+  return {
+    ...searchState,
+    indices: state,
+  };
 }
 
 function refineSingleIndex(searchState, nextRefinement, resetPage) {
@@ -94,16 +107,16 @@ function refineMultiIndexWithNamespace(
   resetPage,
   namespace
 ) {
-  const index = getIndex(context);
+  const indexId = getIndexId(context);
   const page = resetPage ? { page: 1 } : undefined;
-  const state = has(searchState, `indices.${index}`)
+  const state = has(searchState, `indices.${indexId}`)
     ? {
         ...searchState.indices,
-        [index]: {
-          ...searchState.indices[index],
+        [indexId]: {
+          ...searchState.indices[indexId],
           ...{
             [namespace]: {
-              ...searchState.indices[index][namespace],
+              ...searchState.indices[indexId][namespace],
               ...nextRefinement,
             },
             page: 1,
@@ -112,9 +125,18 @@ function refineMultiIndexWithNamespace(
       }
     : {
         ...searchState.indices,
-        ...{ [index]: { [namespace]: nextRefinement, ...page } },
+        ...{
+          [indexId]: {
+            [namespace]: nextRefinement,
+            ...page,
+          },
+        },
       };
-  return { ...searchState, indices: state };
+
+  return {
+    ...searchState,
+    indices: state,
+  };
 }
 
 function refineSingleIndexWithNamespace(
@@ -148,28 +170,28 @@ export function getCurrentRefinementValue(
   defaultValue,
   refinementsCallback = x => x
 ) {
-  const index = getIndex(context);
+  const indexId = getIndexId(context);
   const { namespace, attributeName } = getNamespaceAndAttributeName(id);
   const refinements =
-    (hasMultipleIndex(context) &&
+    (hasMultipleIndices(context) &&
       searchState.indices &&
       namespace &&
-      searchState.indices[`${index}`] &&
-      has(searchState.indices[`${index}`][namespace], `${attributeName}`)) ||
-    (hasMultipleIndex(context) &&
+      searchState.indices[`${indexId}`] &&
+      has(searchState.indices[`${indexId}`][namespace], `${attributeName}`)) ||
+    (hasMultipleIndices(context) &&
       searchState.indices &&
-      has(searchState, `indices.${index}.${id}`)) ||
-    (!hasMultipleIndex(context) &&
+      has(searchState, `indices.${indexId}.${id}`)) ||
+    (!hasMultipleIndices(context) &&
       namespace &&
       has(searchState[namespace], attributeName)) ||
-    (!hasMultipleIndex(context) && has(searchState, id));
+    (!hasMultipleIndices(context) && has(searchState, id));
   if (refinements) {
     let currentRefinement;
 
-    if (hasMultipleIndex(context)) {
+    if (hasMultipleIndices(context)) {
       currentRefinement = namespace
-        ? get(searchState.indices[`${index}`][namespace], attributeName)
-        : get(searchState.indices[index], id);
+        ? get(searchState.indices[`${indexId}`][namespace], attributeName)
+        : get(searchState.indices[indexId], id);
     } else {
       currentRefinement = namespace
         ? get(searchState[namespace], attributeName)
@@ -187,14 +209,14 @@ export function getCurrentRefinementValue(
 }
 
 export function cleanUpValue(searchState, context, id) {
-  const index = getIndex(context);
+  const indexId = getIndexId(context);
   const { namespace, attributeName } = getNamespaceAndAttributeName(id);
 
-  if (hasMultipleIndex(context) && Boolean(searchState.indices)) {
+  if (hasMultipleIndices(context) && Boolean(searchState.indices)) {
     return cleanUpValueWithMutliIndex({
       attribute: attributeName,
       searchState,
-      index,
+      indexId,
       id,
       namespace,
     });
@@ -226,19 +248,19 @@ function cleanUpValueWithSingleIndex({
 
 function cleanUpValueWithMutliIndex({
   searchState,
-  index,
+  indexId,
   id,
   namespace,
   attribute,
 }) {
-  const indexSearchState = searchState.indices[index];
+  const indexSearchState = searchState.indices[indexId];
 
   if (namespace && indexSearchState) {
     return {
       ...searchState,
       indices: {
         ...searchState.indices,
-        [index]: {
+        [indexId]: {
           ...indexSearchState,
           [namespace]: omit(indexSearchState[namespace], attribute),
         },
@@ -246,5 +268,5 @@ function cleanUpValueWithMutliIndex({
     };
   }
 
-  return omit(searchState, `indices.${index}.${id}`);
+  return omit(searchState, `indices.${indexId}.${id}`);
 }

--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty, zipWith } from 'lodash';
 import React, { Component } from 'react';
 import { renderToString } from 'react-dom/server';
 import PropTypes from 'prop-types';
@@ -12,125 +12,126 @@ import {
   HIGHLIGHT_TAGS,
 } from 'react-instantsearch-core';
 
-const getIndex = context =>
+const getIndexId = context =>
   context && context.multiIndexContext
     ? context.multiIndexContext.targetedIndex
     : context.ais.mainTargetedIndex;
 
-const hasMultipleIndex = context => context && context.multiIndexContext;
+const hasMultipleIndices = context => context && context.multiIndexContext;
+
+const getSearchParameters = (indexName, searchParameters) => {
+  const sharedParameters = searchParameters
+    .filter(searchParameter => !hasMultipleIndices(searchParameter.context))
+    .reduce(
+      (acc, searchParameter) =>
+        searchParameter.getSearchParameters(
+          acc,
+          searchParameter.props,
+          searchParameter.searchState
+        ),
+      new SearchParameters({
+        ...HIGHLIGHT_TAGS,
+        index: indexName,
+      })
+    );
+
+  const derivedParameters = searchParameters
+    .filter(searchParameter => hasMultipleIndices(searchParameter.context))
+    .reduce((acc, searchParameter) => {
+      const indexId = getIndexId(searchParameter.context);
+
+      return {
+        ...acc,
+        [indexId]: searchParameter.getSearchParameters(
+          acc[indexId] || sharedParameters,
+          searchParameter.props,
+          searchParameter.searchState
+        ),
+      };
+    }, {});
+
+  return {
+    sharedParameters,
+    derivedParameters,
+  };
+};
+
+const singleIndexSearch = (helper, parameters) => helper.searchOnce(parameters);
+
+const multiIndexSearch = (
+  indexName,
+  client,
+  helper,
+  sharedParameters,
+  { [indexName]: mainParameters, ...derivedParameters }
+) => {
+  const search = [
+    helper.searchOnce({
+      ...sharedParameters,
+      ...mainParameters,
+    }),
+  ];
+
+  const indexIds = Object.keys(derivedParameters);
+
+  search.push(
+    ...indexIds.map(indexId => {
+      const parameters = derivedParameters[indexId];
+
+      return algoliasearchHelper(client, parameters.index).searchOnce(
+        parameters
+      );
+    })
+  );
+
+  return Promise.all(search).then(results =>
+    zipWith([indexName, ...indexIds], results, (indexId, result) =>
+      // We attach `indexId` on the results to be able to reconstruct the
+      // object client side. We cannot rely on `state.index` anymore because
+      // we may have multiple times the same index.
+      ({
+        ...result,
+        _internalIndexId: indexId,
+      })
+    )
+  );
+};
 
 const createInstantSearchServer = algoliasearch => {
   const InstantSearch = createInstantSearch(algoliasearch, {
     Root: 'div',
-    props: { className: 'ais-InstantSearch__root' },
+    props: {
+      className: 'ais-InstantSearch__root',
+    },
   });
 
-  let searchParameters = [];
-  let client;
+  let client = null;
   let indexName = '';
-
-  const onSearchParameters = (
-    getSearchParameters,
-    context,
-    props,
-    searchState
-  ) => {
-    const index = getIndex(context);
-    searchParameters.push({
-      getSearchParameters,
-      context,
-      props,
-      searchState,
-      index,
-    });
-  };
+  let searchParameters = [];
 
   const findResultsState = function(App, props) {
     searchParameters = [];
 
     renderToString(<App {...props} />);
 
-    const sharedSearchParameters = searchParameters
-      .filter(
-        searchParameter =>
-          !hasMultipleIndex(searchParameter.context) &&
-          (searchParameter.props.indexName === indexName ||
-            !searchParameter.props.indexName)
-      )
-      .reduce(
-        (acc, searchParameter) =>
-          searchParameter.getSearchParameters(
-            acc,
-            searchParameter.props,
-            searchParameter.searchState
-          ),
-        new SearchParameters({ index: indexName, ...HIGHLIGHT_TAGS })
-      );
+    const { sharedParameters, derivedParameters } = getSearchParameters(
+      indexName,
+      searchParameters
+    );
 
-    const mergedSearchParameters = searchParameters
-      .filter(searchParameter => hasMultipleIndex(searchParameter.context))
-      .reduce((acc, searchParameter) => {
-        const index = getIndex(searchParameter.context);
-        const sp = searchParameter.getSearchParameters(
-          acc[index] ? acc[index] : sharedSearchParameters,
-          searchParameter.props,
-          searchParameter.searchState
-        );
-        acc[index] = sp;
-        return acc;
-      }, {});
+    const helper = algoliasearchHelper(client, sharedParameters.index);
 
-    if (isEmpty(mergedSearchParameters)) {
-      const helper = algoliasearchHelper(client, sharedSearchParameters.index);
-      return helper.searchOnce(sharedSearchParameters);
-    } else {
-      const helper = algoliasearchHelper(client, sharedSearchParameters.index);
-      const search = [];
-
-      if (mergedSearchParameters[indexName]) {
-        search.push(
-          helper.searchOnce({
-            ...sharedSearchParameters,
-            ...mergedSearchParameters[sharedSearchParameters.index],
-            index: mergedSearchParameters[sharedSearchParameters.index].index,
-          })
-        );
-        delete mergedSearchParameters[indexName];
-      } else {
-        search.push(helper.searchOnce(sharedSearchParameters));
-      }
-
-      search.push(
-        ...Object.keys(mergedSearchParameters).map(key => {
-          const derivedHelper = algoliasearchHelper(
-            client,
-            mergedSearchParameters[key].index
-          );
-          return derivedHelper.searchOnce(mergedSearchParameters[key]);
-        })
-      );
-
-      return Promise.all(search);
-    }
-  };
-
-  const decorateResults = function(results) {
-    if (!results) {
-      return undefined;
+    if (isEmpty(derivedParameters)) {
+      return singleIndexSearch(helper, sharedParameters);
     }
 
-    return Array.isArray(results)
-      ? results.reduce((acc, result) => {
-          acc[result.state.index] = new SearchResults(
-            new SearchParameters(result.state),
-            result._originalResponse.results
-          );
-          return acc;
-        }, [])
-      : new SearchResults(
-          new SearchParameters(results.state),
-          results._originalResponse.results
-        );
+    return multiIndexSearch(
+      indexName,
+      client,
+      helper,
+      sharedParameters,
+      derivedParameters
+    );
   };
 
   class CreateInstantSearchServer extends Component {
@@ -143,18 +144,18 @@ const createInstantSearchServer = algoliasearch => {
       resultsState: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     };
 
-    constructor(props) {
-      super();
+    constructor(...args) {
+      super(...args);
 
-      if (props.searchClient) {
-        if (props.appId || props.apiKey || props.algoliaClient) {
+      if (this.props.searchClient) {
+        if (this.props.appId || this.props.apiKey || this.props.algoliaClient) {
           throw new Error(
             'react-instantsearch:: `searchClient` cannot be used with `appId`, `apiKey` or `algoliaClient`.'
           );
         }
       }
 
-      if (props.algoliaClient) {
+      if (this.props.algoliaClient) {
         // eslint-disable-next-line no-console
         console.warn(
           '`algoliaClient` option was renamed `searchClient`. Please use this new option before the next major version.'
@@ -162,30 +163,66 @@ const createInstantSearchServer = algoliasearch => {
       }
 
       client =
-        props.searchClient ||
-        props.algoliaClient ||
-        algoliasearch(props.appId, props.apiKey);
+        this.props.searchClient ||
+        this.props.algoliaClient ||
+        algoliasearch(this.props.appId, this.props.apiKey);
 
       if (typeof client.addAlgoliaAgent === 'function') {
         client.addAlgoliaAgent(`react-instantsearch ${version}`);
       }
 
-      indexName = props.indexName;
+      indexName = this.props.indexName;
+    }
+
+    onSearchParameters(getWidgetSearchParameters, context, props, searchState) {
+      searchParameters.push({
+        getSearchParameters: getWidgetSearchParameters,
+        index: getIndexId(context),
+        context,
+        props,
+        searchState,
+      });
+    }
+
+    hydrateResultsState() {
+      const { resultsState = [] } = this.props;
+
+      if (Array.isArray(resultsState)) {
+        return resultsState.reduce(
+          (acc, result) => ({
+            ...acc,
+            [result._internalIndexId]: new SearchResults(
+              new SearchParameters(result.state),
+              result._originalResponse.results
+            ),
+          }),
+          {}
+        );
+      }
+
+      return new SearchResults(
+        new SearchParameters(resultsState.state),
+        resultsState._originalResponse.results
+      );
     }
 
     render() {
-      const resultsState = decorateResults(this.props.resultsState);
+      const resultsState = this.hydrateResultsState();
+
       return (
         <InstantSearch
           {...this.props}
           resultsState={resultsState}
-          onSearchParameters={onSearchParameters}
+          onSearchParameters={this.onSearchParameters}
         />
       );
     }
   }
 
-  return { InstantSearch: CreateInstantSearchServer, findResultsState };
+  return {
+    InstantSearch: CreateInstantSearchServer,
+    findResultsState,
+  };
 };
 
 export default createInstantSearchServer;

--- a/packages/react-instantsearch-dom/src/core/findResultsState.js
+++ b/packages/react-instantsearch-dom/src/core/findResultsState.js
@@ -16,7 +16,6 @@
  */
 export function findResultsState() {}
 
-/* eslint valid-jsdoc: 0 */
 /**
  * The `createInstantSearch` let's you create a server-side compatible `<InstantSearch>` component along with a `findResultsState` function tied to this component. You'll use this component on both the server and client.
  * @name createInstantSearch

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -23,30 +23,49 @@ stories
     <InstantSearch
       appId="latency"
       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
-      indexName="categories"
+      indexName="instant_search"
     >
       <SearchBox />
-      <div className="multi-index_content">
-        <div className="multi-index_categories-or-brands">
-          <Index indexName="categories">
-            <div>Categories: </div>
-            <Configure hitsPerPage={3} />
-            <CustomCategoriesOrBrands />
-          </Index>
-          <Index indexName="brands">
-            <div>Brand: </div>
-            <Configure hitsPerPage={3} />
-            <CustomCategoriesOrBrands />
-          </Index>
-        </div>
-        <div className="multi-index_products">
-          <Index indexName="products">
-            <div>Products: </div>
-            <Configure hitsPerPage={5} />
-            <CustomProducts />
-          </Index>
-        </div>
-      </div>
+
+      <Index indexName="bestbuy">
+        <h3>
+          index: <code>bestbuy</code>
+        </h3>
+        <Configure hitsPerPage={3} />
+        <CustomCategoriesOrBrands />
+      </Index>
+
+      <Index indexName="instant_search">
+        <h3>
+          index: <code>instant_search</code>
+        </h3>
+        <Configure hitsPerPage={3} />
+        <CustomCategoriesOrBrands />
+      </Index>
+
+      <Index indexId="instant_search_apple" indexName="instant_search">
+        <h3>
+          index: <code>instant_search</code> with <code>brand:Apple</code>
+        </h3>
+        <Configure hitsPerPage={3} filters="brand:Apple" />
+        <CustomCategoriesOrBrands />
+      </Index>
+
+      <Index indexId="instant_search_samsung" indexName="instant_search">
+        <h3>
+          index: <code>instant_search</code> with <code>brand:Samsung</code>
+        </h3>
+        <Configure hitsPerPage={3} filters="brand:Samsung" />
+        <CustomCategoriesOrBrands />
+      </Index>
+
+      <Index indexId="instant_search_microsoft" indexName="instant_search">
+        <h3>
+          index: <code>instant_search</code> with <code>brand:Microsoft</code>
+        </h3>
+        <Configure hitsPerPage={3} filters="brand:Microsoft" />
+        <CustomCategoriesOrBrands />
+      </Index>
     </InstantSearch>
   ))
   .add('AutoComplete', () => (


### PR DESCRIPTION
**Summary**

This is the second part of the work to support multi-index search on the same index. The PR introduce a new prop on the `Index` component called `indexId`. This prop is a unique identifier for the index. It has to be unique inside the App to let the manager linked an index, a request and the results. With different identifiers we are able to target the same index with different parameters:

```jsx
<InstantSearch indexName="instant_search" searchClient={searchClient}>
  <SearchBox />

  <Index indexId="instant_search_default" indexName="instant_search">
    <Configure hitsPerPage={3} />
    <Hits />
  </Index>

  <Index indexId="instant_search_apple" indexName="instant_search">
    <Configure hitsPerPage={3} filters="brand:Apple" />
    <Hits />
  </Index>

  <Index indexId="instant_search_samsung" indexName="instant_search">
    <Configure hitsPerPage={3} filters="brand:Samsung" />
    <Hits />
  </Index>
</InstantSearch>
```

The prop `indexId` should be required but it's a breaking change. The solution we came up with is to fallback the `indexId` to the `indexName` when it's not provided (we'll add a warning in a next PR). Then on the next major we can move the prop to be required. When the fallback happen it doesn't have an impact for our users because it's the exact same behaviour as before (`indexName` was the key). 

Internally the value exposes though the `Index` context has changed: it's now the `indexId` not the `indexName`. It should not have an impact neither because the places where we use the value from the context we actually want the identifier (we can expose both of them at some point if needed).

You can test the changes with the updated [multi-index stories](https://deploy-preview-1835--react-instantsearch.netlify.com/react-instantsearch/storybook/?selectedKind=%3CIndex%3E&selectedStory=MultiHits&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs). Only the client side code is working the SSR support will come in a next PR. Otherwise this PR would have embed too much changes.

**Changes**

- **`createInstantSearchManager`**: rely on `props.indexId` rather than `props.indexName`
- **`createIndex`**: provide `indexId` to the `Index` component with a fallback on `indexName`
- **`Index`**: expose the `indexId` through the context rather than `indexName`