### PR TITLE
feat(indexId): refactor createInstantSearchManager [PART-3]

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/connectConfigure.js
+++ b/packages/react-instantsearch-core/src/connectors/connectConfigure.js
@@ -1,6 +1,10 @@
 import { omit, difference, keys } from 'lodash';
 import createConnector from '../core/createConnector';
-import { hasMultipleIndex, getIndex, refineValue } from '../core/indexUtils';
+import {
+  refineValue,
+  getIndexId,
+  hasMultipleIndices,
+} from '../core/indexUtils';
 
 function getId() {
   return 'configure';
@@ -29,10 +33,10 @@ export default createConnector({
   },
   cleanUp(props, searchState) {
     const id = getId();
-    const index = getIndex(this.context);
+    const indexId = getIndexId(this.context);
     const subState =
-      hasMultipleIndex(this.context) && searchState.indices
-        ? searchState.indices[index]
+      hasMultipleIndices(this.context) && searchState.indices
+        ? searchState.indices[indexId]
         : searchState;
     const configureKeys =
       subState && subState[id] ? Object.keys(subState[id]) : [];

--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -3,7 +3,7 @@ import createConnector from '../core/createConnector';
 import {
   getResults,
   getCurrentRefinementValue,
-  getIndex,
+  getIndexId,
   refineValue,
   cleanUpValue,
 } from '../core/indexUtils';
@@ -205,7 +205,7 @@ export default createConnector({
   getMetadata(props, searchState) {
     const items = [];
     const id = getBoundingBoxId();
-    const index = getIndex(this.context);
+    const index = getIndexId(this.context);
     const nextRefinement = {};
     const currentRefinement = getCurrentRefinement(
       props,

--- a/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
@@ -3,7 +3,7 @@ import { SearchParameters } from 'algoliasearch-helper';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   refineValue,
   getCurrentRefinementValue,
   getResults,
@@ -270,7 +270,7 @@ export default createConnector({
 
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items: !currentRefinement
         ? []
         : [

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -2,7 +2,7 @@ import { orderBy } from 'lodash';
 import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
-  getIndex,
+  getIndexId,
   cleanUpValue,
   refineValue,
   getCurrentRefinementValue,
@@ -222,7 +222,7 @@ export default createConnector({
     );
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items:
         currentRefinement === null
           ? []

--- a/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
@@ -6,7 +6,7 @@ import {
   refineValue,
   getCurrentRefinementValue,
   getResults,
-  getIndex,
+  getIndexId,
 } from '../core/indexUtils';
 
 function stringifyItem(item) {
@@ -209,7 +209,7 @@ export default createConnector({
     const id = getId(props);
     const value = getCurrentRefinement(props, searchState, this.context);
     const items = [];
-    const index = getIndex(this.context);
+    const index = getIndexId(this.context);
     if (value !== '') {
       const { label } = find(
         props.items,

--- a/packages/react-instantsearch-core/src/connectors/connectRange.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRange.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   refineValue,
   getCurrentRefinementValue,
   getResults,
@@ -332,7 +332,7 @@ export default createConnector({
 
     return {
       id: getId(props),
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items,
     };
   },

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   refineValue,
   getCurrentRefinementValue,
   getResults,
@@ -226,7 +226,7 @@ export default createConnector({
     const context = this.context;
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items:
         getCurrentRefinement(props, searchState, context).length > 0
           ? [

--- a/packages/react-instantsearch-core/src/connectors/connectScrollTo.js
+++ b/packages/react-instantsearch-core/src/connectors/connectScrollTo.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   getCurrentRefinementValue,
-  hasMultipleIndex,
-  getIndex,
+  hasMultipleIndices,
+  getIndexId,
 } from '../core/indexUtils';
 import { shallowEqual } from '../core/utils';
 
@@ -44,9 +44,10 @@ export default createConnector({
     }
 
     /* Get the subpart of the state that interest us*/
-    if (hasMultipleIndex(this.context)) {
-      const index = getIndex(this.context);
-      searchState = searchState.indices ? searchState.indices[index] : {};
+    if (hasMultipleIndices(this.context)) {
+      searchState = searchState.indices
+        ? searchState.indices[getIndexId(this.context)]
+        : {};
     }
 
     /*

--- a/packages/react-instantsearch-core/src/connectors/connectSearchBox.js
+++ b/packages/react-instantsearch-core/src/connectors/connectSearchBox.js
@@ -4,7 +4,7 @@ import {
   cleanUpValue,
   refineValue,
   getCurrentRefinementValue,
-  getIndex,
+  getIndexId,
 } from '../core/indexUtils';
 
 function getId() {
@@ -86,7 +86,7 @@ export default createConnector({
     );
     return {
       id,
-      index: getIndex(this.context),
+      index: getIndexId(this.context),
       items:
         currentRefinement === null
           ? []

--- a/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/connectToggleRefinement.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
-  getIndex,
+  getIndexId,
   getResults,
   refineValue,
   getCurrentRefinementValue,
@@ -149,7 +149,7 @@ export default createConnector({
     const id = getId(props);
     const checked = getCurrentRefinement(props, searchState, this.context);
     const items = [];
-    const index = getIndex(this.context);
+    const index = getIndexId(this.context);
 
     if (checked) {
       items.push({

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -150,6 +150,237 @@ describe('createInstantSearchManager', () => {
     });
   });
 
+  describe('getSearchParameters', () => {
+    it('expect a widget top level to be shared between main and derived parameters', () => {
+      // <InstantSearch indexName="index">
+      //   <SearchBox defaultRefinement="shared" />
+      //   <Index indexId="main" indexName="main" />
+      // </InstantSearch>
+
+      const ism = createInstantSearchManager({
+        indexName: 'index',
+        searchClient: createSearchClient(),
+      });
+
+      // <SearchBox defaultRefinement="shared" />
+      ism.widgetsManager.registerWidget({
+        getSearchParameters(state) {
+          return state.setQuery('shared');
+        },
+        context: {},
+        props: {},
+      });
+
+      // <Index indexId="main" indexName="main" />
+      ism.widgetsManager.registerWidget({
+        getSearchParameters(state) {
+          return state.setIndex('main');
+        },
+        props: {
+          indexId: 'main',
+        },
+      });
+
+      const { mainParameters, derivedParameters } = ism.getSearchParameters();
+
+      expect(mainParameters).toEqual(
+        expect.objectContaining({
+          index: 'index',
+          query: 'shared',
+        })
+      );
+
+      expect(derivedParameters).toEqual([
+        {
+          indexId: 'main',
+          parameters: expect.objectContaining({
+            index: 'main',
+            query: 'shared',
+          }),
+        },
+      ]);
+    });
+
+    it('expect a widget with the same id than the indexName to be a main parameters', () => {
+      // <InstantSearch indexName="index">
+      //   <Index indexId="index" indexName="main" />
+      // </InstantSearch>
+
+      const ism = createInstantSearchManager({
+        indexName: 'index',
+        searchClient: createSearchClient(),
+      });
+
+      // <Index indexId="index" indexName="main" />
+      ism.widgetsManager.registerWidget({
+        getSearchParameters(state) {
+          return state.setIndex('main');
+        },
+        context: {},
+        props: {
+          indexId: 'index',
+        },
+      });
+
+      const { mainParameters, derivedParameters } = ism.getSearchParameters();
+
+      expect(mainParameters).toEqual(
+        expect.objectContaining({
+          index: 'main',
+        })
+      );
+
+      expect(derivedParameters).toEqual([]);
+    });
+
+    it('expect a widget with a different id than the indexName to be a derived parameters', () => {
+      // <InstantSearch indexName="index">
+      //   <Index indexId="index_main" indexName="main" />
+      // </InstantSearch>
+
+      const ism = createInstantSearchManager({
+        indexName: 'index',
+        searchClient: createSearchClient(),
+      });
+
+      // <Index indexId="index_main" indexName="main" />
+      ism.widgetsManager.registerWidget({
+        getSearchParameters(state) {
+          return state.setIndex('main');
+        },
+        context: {},
+        props: {
+          indexId: 'index_main',
+        },
+      });
+
+      const { mainParameters, derivedParameters } = ism.getSearchParameters();
+
+      expect(mainParameters).toEqual(
+        expect.objectContaining({
+          index: 'index',
+        })
+      );
+
+      expect(derivedParameters).toEqual([
+        {
+          indexId: 'index_main',
+          parameters: expect.objectContaining({
+            index: 'main',
+          }),
+        },
+      ]);
+    });
+
+    it('expect a widget within a mutli index context with the same id than the indexName to be a main parameters', () => {
+      // <InstantSearch indexName="index">
+      //   <Index indexId="index" indexName="index" />
+      //     <SearchBox defaultRefinement="main" />
+      //   </Index>
+      // </InstantSearch>
+
+      const ism = createInstantSearchManager({
+        indexName: 'index',
+        searchClient: createSearchClient(),
+      });
+
+      // <Index indexId="index" indexName="index" />
+      ism.widgetsManager.registerWidget({
+        getSearchParameters(state) {
+          return state.setIndex('index');
+        },
+        context: {},
+        props: {
+          indexId: 'index',
+        },
+      });
+
+      // <Index indexId="index" indexName="index" />
+      //   <SearchBox defaultRefinement="main" />
+      // </Index>
+      ism.widgetsManager.registerWidget({
+        getSearchParameters(state) {
+          return state.setQuery('main');
+        },
+        context: {
+          multiIndexContext: {
+            targetedIndex: 'index',
+          },
+        },
+        props: {},
+      });
+
+      const { mainParameters, derivedParameters } = ism.getSearchParameters();
+
+      expect(mainParameters).toEqual(
+        expect.objectContaining({
+          index: 'index',
+          query: 'main',
+        })
+      );
+
+      expect(derivedParameters).toEqual([]);
+    });
+
+    it('expect a widget within a mutli index context with a different id than the indexName to be a derived parameters', () => {
+      // <InstantSearch indexName="index">
+      //   <Index indexId="index_with_refinement" indexName="index" />
+      //     <SearchBox defaultRefinement="dervied" />
+      //   </Index>
+      // </InstantSearch>
+
+      const ism = createInstantSearchManager({
+        indexName: 'index',
+        searchClient: createSearchClient(),
+      });
+
+      // <Index indexId="index_with_refinement" indexName="index" />
+      ism.widgetsManager.registerWidget({
+        getSearchParameters(state) {
+          return state.setIndex('index');
+        },
+        context: {},
+        props: {
+          indexId: 'index_with_refinement',
+        },
+      });
+
+      // <Index indexId="index_with_refinement" indexName="index" />
+      //   <SearchBox defaultRefinement="derived" />
+      // </Index>
+      ism.widgetsManager.registerWidget({
+        getSearchParameters(state) {
+          return state.setQuery('derived');
+        },
+        context: {
+          multiIndexContext: {
+            targetedIndex: 'index_with_refinement',
+          },
+        },
+        props: {},
+      });
+
+      const { mainParameters, derivedParameters } = ism.getSearchParameters();
+
+      expect(mainParameters).toEqual(
+        expect.objectContaining({
+          index: 'index',
+          query: '',
+        })
+      );
+
+      expect(derivedParameters).toEqual([
+        {
+          indexId: 'index_with_refinement',
+          parameters: expect.objectContaining({
+            index: 'index',
+            query: 'derived',
+          }),
+        },
+      ]);
+    });
+  });
+
   describe('searchStalled', () => {
     it('should be updated if search is stalled', async () => {
       const searchClient = createSearchClient();

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -49,7 +49,7 @@ describe('createInstantSearchManager', () => {
     expect(ism.getWidgetsIds()).toEqual([]);
   });
 
-  it('initialize with results', () => {
+  it('initializes with results', () => {
     const ism = createInstantSearchManager({
       indexName: 'index',
       resultsState: { some: 'results' },
@@ -151,7 +151,7 @@ describe('createInstantSearchManager', () => {
   });
 
   describe('getSearchParameters', () => {
-    it('expect a widget top level to be shared between main and derived parameters', () => {
+    it('expects a widget top level to be shared between main and derived parameters', () => {
       // <InstantSearch indexName="index">
       //   <SearchBox defaultRefinement="shared" />
       //   <Index indexId="main" indexName="main" />
@@ -201,7 +201,7 @@ describe('createInstantSearchManager', () => {
       ]);
     });
 
-    it('expect a widget with the same id than the indexName to be a main parameters', () => {
+    it('expects a widget with the same id than the indexName to be a main parameters', () => {
       // <InstantSearch indexName="index">
       //   <Index indexId="index" indexName="main" />
       // </InstantSearch>
@@ -233,7 +233,7 @@ describe('createInstantSearchManager', () => {
       expect(derivedParameters).toEqual([]);
     });
 
-    it('expect a widget with a different id than the indexName to be a derived parameters', () => {
+    it('expects a widget with a different id than the indexName to be a derived parameters', () => {
       // <InstantSearch indexName="index">
       //   <Index indexId="index_main" indexName="main" />
       // </InstantSearch>
@@ -272,7 +272,7 @@ describe('createInstantSearchManager', () => {
       ]);
     });
 
-    it('expect a widget within a mutli index context with the same id than the indexName to be a main parameters', () => {
+    it('expects a widget within a mutli index context with the same id than the indexName to be a main parameters', () => {
       // <InstantSearch indexName="index">
       //   <Index indexId="index" indexName="index" />
       //     <SearchBox defaultRefinement="main" />
@@ -322,7 +322,7 @@ describe('createInstantSearchManager', () => {
       expect(derivedParameters).toEqual([]);
     });
 
-    it('expect a widget within a mutli index context with a different id than the indexName to be a derived parameters', () => {
+    it('expects a widget within a mutli index context with a different id than the indexName to be a derived parameters', () => {
       // <InstantSearch indexName="index">
       //   <Index indexId="index_with_refinement" indexName="index" />
       //     <SearchBox defaultRefinement="dervied" />

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -6,15 +6,15 @@ import { HIGHLIGHT_TAGS } from './highlight';
 import { hasMultipleIndex } from './indexUtils';
 
 const isMultiIndexContext = widget => hasMultipleIndex(widget.context);
-const isTargetedIndexEqualIndex = (widget, index) =>
-  widget.context.multiIndexContext.targetedIndex === index;
+const isTargetedIndexEqualIndex = (widget, indexId) =>
+  widget.context.multiIndexContext.targetedIndex === indexId;
 
 // Relying on the `indexId` is a bit brittle to detect the `Index` widget.
 // Since it's a class we could rely on `instanceof` or similar. We never
 // had an issue though. Works for now.
 const isIndexWidget = widget => Boolean(widget.props.indexId);
-const isIndexWidgetEqualIndex = (widget, index) =>
-  widget.props.indexId === index;
+const isIndexWidgetEqualIndex = (widget, indexId) =>
+  widget.props.indexId === indexId;
 
 /**
  * Creates a new instance of the InstantSearchManager which controls the widgets and

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -1,5 +1,5 @@
 import { omit } from 'lodash';
-import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
+import algoliasearchHelper from 'algoliasearch-helper';
 import createWidgetsManager from './createWidgetsManager';
 import createStore from './createStore';
 import { HIGHLIGHT_TAGS } from './highlight';
@@ -32,14 +32,11 @@ export default function createInstantSearchManager({
   resultsState,
   stalledSearchDelay,
 }) {
-  const baseSP = new SearchParameters({
-    index: indexName,
+  const helper = algoliasearchHelper(searchClient, indexName, {
     ...HIGHLIGHT_TAGS,
   });
 
   let stalledSearchTimer = null;
-
-  const helper = algoliasearchHelper(searchClient, indexName, baseSP);
 
   helper.on('result', handleSearchSuccess({ indexId: indexName }));
   helper.on('error', handleSearchError);

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -3,9 +3,9 @@ import algoliasearchHelper from 'algoliasearch-helper';
 import createWidgetsManager from './createWidgetsManager';
 import createStore from './createStore';
 import { HIGHLIGHT_TAGS } from './highlight';
-import { hasMultipleIndex } from './indexUtils';
+import { hasMultipleIndices } from './indexUtils';
 
-const isMultiIndexContext = widget => hasMultipleIndex(widget.context);
+const isMultiIndexContext = widget => hasMultipleIndices(widget.context);
 const isTargetedIndexEqualIndex = (widget, indexId) =>
   widget.context.multiIndexContext.targetedIndex === indexId;
 

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -1,8 +1,20 @@
-import { omit, find } from 'lodash';
+import { omit } from 'lodash';
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import createWidgetsManager from './createWidgetsManager';
 import createStore from './createStore';
 import { HIGHLIGHT_TAGS } from './highlight';
+import { hasMultipleIndex } from './indexUtils';
+
+const isMultiIndexContext = widget => hasMultipleIndex(widget.context);
+const isTargetedIndexEqualIndex = (widget, index) =>
+  widget.context.multiIndexContext.targetedIndex === index;
+
+// Relying on the `indexId` is a bit brittle to detect the `Index` widget.
+// Since it's a class we could rely on `instanceof` or similar. We never
+// had an issue though. Works for now.
+const isIndexWidget = widget => Boolean(widget.props.indexId);
+const isIndexWidgetEqualIndex = (widget, index) =>
+  widget.props.indexId === index;
 
 /**
  * Creates a new instance of the InstantSearchManager which controls the widgets and
@@ -74,69 +86,75 @@ export default function createInstantSearchManager({
     const sharedParameters = widgetsManager
       .getWidgets()
       .filter(widget => Boolean(widget.getSearchParameters))
-      .filter(
-        widget =>
-          !widget.context.multiIndexContext &&
-          (!widget.props.indexId || widget.props.indexId === indexName)
-      )
+      .filter(widget => !isMultiIndexContext(widget) && !isIndexWidget(widget))
       .reduce(
         (res, widget) => widget.getSearchParameters(res),
         initialSearchParameters
       );
 
-    const mainIndexParameters = widgetsManager
+    const mainParameters = widgetsManager
       .getWidgets()
       .filter(widget => Boolean(widget.getSearchParameters))
-      .filter(
-        widget =>
-          (widget.context.multiIndexContext &&
-            widget.context.multiIndexContext.targetedIndex === indexName) ||
-          (widget.props.indexId && widget.props.indexId === indexName)
-      )
+      .filter(widget => {
+        const targetedIndexEqualMainIndex =
+          isMultiIndexContext(widget) &&
+          isTargetedIndexEqualIndex(widget, indexName);
+
+        const subIndexEqualMainIndex =
+          isIndexWidget(widget) && isIndexWidgetEqualIndex(widget, indexName);
+
+        return targetedIndexEqualMainIndex || subIndexEqualMainIndex;
+      })
       .reduce(
         (res, widget) => widget.getSearchParameters(res),
         sharedParameters
       );
 
-    const derivatedWidgets = widgetsManager
+    const derivedIndices = widgetsManager
       .getWidgets()
       .filter(widget => Boolean(widget.getSearchParameters))
-      .filter(
-        widget =>
-          (widget.context.multiIndexContext &&
-            widget.context.multiIndexContext.targetedIndex !== indexName) ||
-          (widget.props.indexId && widget.props.indexId !== indexName)
-      )
+      .filter(widget => {
+        const targetedIndexNotEqualMainIndex =
+          isMultiIndexContext(widget) &&
+          !isTargetedIndexEqualIndex(widget, indexName);
+
+        const subIndexNotEqualMainIndex =
+          isIndexWidget(widget) && !isIndexWidgetEqualIndex(widget, indexName);
+
+        return targetedIndexNotEqualMainIndex || subIndexNotEqualMainIndex;
+      })
       .reduce((indices, widget) => {
-        const targetedIndex = widget.context.multiIndexContext
+        const indexId = isMultiIndexContext(widget)
           ? widget.context.multiIndexContext.targetedIndex
           : widget.props.indexId;
 
-        const index = find(indices, i => i.targetedIndex === targetedIndex);
+        const widgets = indices[indexId] || [];
 
-        if (index) {
-          index.widgets.push(widget);
-        } else {
-          indices.push({ targetedIndex, widgets: [widget] });
-        }
+        return {
+          ...indices,
+          [indexId]: widgets.concat(widget),
+        };
+      }, {});
 
-        return indices;
-      }, []);
+    const derivedParameters = Object.keys(derivedIndices).map(indexId => ({
+      parameters: derivedIndices[indexId].reduce(
+        (res, widget) => widget.getSearchParameters(res),
+        sharedParameters
+      ),
+      indexId,
+    }));
 
     return {
-      sharedParameters,
-      mainIndexParameters,
-      derivatedWidgets,
+      mainParameters,
+      derivedParameters,
     };
   }
 
   function search() {
     if (!skip) {
-      const {
-        sharedParameters,
-        mainIndexParameters,
-        derivatedWidgets,
-      } = getSearchParameters(helper.state);
+      const { mainParameters, derivedParameters } = getSearchParameters(
+        helper.state
+      );
 
       // We have to call `slice` because the method `detach` on the derived
       // helpers mutates the value `derivedHelpers`. The `forEach` loop does
@@ -160,27 +178,15 @@ export default function createInstantSearchManager({
         derivedHelper.detach();
       });
 
-      helper.setState(sharedParameters);
+      derivedParameters.forEach(({ indexId, parameters }) => {
+        const derivedHelper = helper.derive(() => parameters);
 
-      derivatedWidgets.forEach(derivedIndex => {
-        const derivedHelper = helper.derive(() =>
-          derivedIndex.widgets.reduce(
-            (res, widget) => widget.getSearchParameters(res),
-            sharedParameters
-          )
-        );
-
-        derivedHelper.on(
-          'result',
-          handleSearchSuccess({
-            indexId: derivedIndex.targetedIndex,
-          })
-        );
-
-        derivedHelper.on('error', handleSearchError);
+        derivedHelper
+          .on('result', handleSearchSuccess({ indexId }))
+          .on('error', handleSearchError);
       });
 
-      helper.setState(mainIndexParameters);
+      helper.setState(mainParameters);
 
       helper.search();
     }
@@ -193,8 +199,9 @@ export default function createInstantSearchManager({
 
       let results = state.results ? state.results : {};
 
-      /* if switching from mono index to multi index and vice versa,
-      results needs to reset to {}*/
+      // Switching from mono index to multi index and vice versa must reset the
+      // results to an empty object, otherwise we keep reference of stalled and
+      // unused results.
       results = !isDerivedHelpersEmpty && results.getFacetByName ? {} : results;
 
       if (!isDerivedHelpersEmpty) {
@@ -228,6 +235,7 @@ export default function createInstantSearchManager({
 
   function handleSearchError(error) {
     const currentState = store.getState();
+
     let nextIsSearchStalled = currentState.isSearchStalled;
     if (!helper.hasPendingRequests()) {
       clearTimeout(stalledSearchTimer);
@@ -243,6 +251,7 @@ export default function createInstantSearchManager({
       },
       'resultsFacetValues'
     );
+
     store.setState(nextState);
   }
 
@@ -256,6 +265,7 @@ export default function createInstantSearchManager({
           },
           'resultsFacetValues'
         );
+
         store.setState(nextState);
       }, stalledSearchDelay);
     }
@@ -278,6 +288,7 @@ export default function createInstantSearchManager({
 
   function transitionState(nextSearchState) {
     const searchState = store.getState().widgets;
+
     return widgetsManager
       .getWidgets()
       .filter(widget => Boolean(widget.transitionState))
@@ -363,9 +374,10 @@ export default function createInstantSearchManager({
     store,
     widgetsManager,
     getWidgetsIds,
+    getSearchParameters,
+    onSearchForFacetValues,
     onExternalStateUpdate,
     transitionState,
-    onSearchForFacetValues,
     updateClient,
     updateIndex,
     clearCache,

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -36,12 +36,13 @@ export default function createInstantSearchManager({
     ...HIGHLIGHT_TAGS,
   });
 
+  helper
+    .on('search', handleNewSearch)
+    .on('result', handleSearchSuccess({ indexId: indexName }))
+    .on('error', handleSearchError);
+
+  let skip = false;
   let stalledSearchTimer = null;
-
-  helper.on('result', handleSearchSuccess({ indexId: indexName }));
-  helper.on('error', handleSearchError);
-  helper.on('search', handleNewSearch);
-
   let initialSearchParameters = helper.state;
 
   const widgetsManager = createWidgetsManager(onWidgetsUpdate);
@@ -55,8 +56,6 @@ export default function createInstantSearchManager({
     isSearchStalled: true,
     searchingForFacetValues: false,
   });
-
-  let skip = false;
 
   function skipSearch() {
     skip = true;

--- a/packages/react-instantsearch-core/src/core/indexUtils.js
+++ b/packages/react-instantsearch-core/src/core/indexUtils.js
@@ -1,6 +1,6 @@
 import { has, omit, get } from 'lodash';
 
-export function getIndex(context) {
+export function getIndexId(context) {
   return context && context.multiIndexContext
     ? context.multiIndexContext.targetedIndex
     : context.ais.mainTargetedIndex;
@@ -8,15 +8,15 @@ export function getIndex(context) {
 
 export function getResults(searchResults, context) {
   if (searchResults.results && !searchResults.results.hits) {
-    return searchResults.results[getIndex(context)]
-      ? searchResults.results[getIndex(context)]
+    return searchResults.results[getIndexId(context)]
+      ? searchResults.results[getIndexId(context)]
       : null;
   } else {
     return searchResults.results ? searchResults.results : null;
   }
 }
 
-export function hasMultipleIndex(context) {
+export function hasMultipleIndices(context) {
   return context && context.multiIndexContext;
 }
 
@@ -28,7 +28,7 @@ export function refineValue(
   resetPage,
   namespace
 ) {
-  if (hasMultipleIndex(context)) {
+  if (hasMultipleIndices(context)) {
     return namespace
       ? refineMultiIndexWithNamespace(
           searchState,
@@ -68,17 +68,30 @@ export function refineValue(
 
 function refineMultiIndex(searchState, nextRefinement, context, resetPage) {
   const page = resetPage ? { page: 1 } : undefined;
-  const index = getIndex(context);
-  const state = has(searchState, `indices.${index}`)
+  const indexId = getIndexId(context);
+  const state = has(searchState, `indices.${indexId}`)
     ? {
         ...searchState.indices,
-        [index]: { ...searchState.indices[index], ...nextRefinement, ...page },
+        [indexId]: {
+          ...searchState.indices[indexId],
+          ...nextRefinement,
+          ...page,
+        },
       }
     : {
         ...searchState.indices,
-        ...{ [index]: { ...nextRefinement, ...page } },
+        ...{
+          [indexId]: {
+            ...nextRefinement,
+            ...page,
+          },
+        },
       };
-  return { ...searchState, indices: state };
+
+  return {
+    ...searchState,
+    indices: state,
+  };
 }
 
 function refineSingleIndex(searchState, nextRefinement, resetPage) {
@@ -94,16 +107,16 @@ function refineMultiIndexWithNamespace(
   resetPage,
   namespace
 ) {
-  const index = getIndex(context);
+  const indexId = getIndexId(context);
   const page = resetPage ? { page: 1 } : undefined;
-  const state = has(searchState, `indices.${index}`)
+  const state = has(searchState, `indices.${indexId}`)
     ? {
         ...searchState.indices,
-        [index]: {
-          ...searchState.indices[index],
+        [indexId]: {
+          ...searchState.indices[indexId],
           ...{
             [namespace]: {
-              ...searchState.indices[index][namespace],
+              ...searchState.indices[indexId][namespace],
               ...nextRefinement,
             },
             page: 1,
@@ -112,9 +125,18 @@ function refineMultiIndexWithNamespace(
       }
     : {
         ...searchState.indices,
-        ...{ [index]: { [namespace]: nextRefinement, ...page } },
+        ...{
+          [indexId]: {
+            [namespace]: nextRefinement,
+            ...page,
+          },
+        },
       };
-  return { ...searchState, indices: state };
+
+  return {
+    ...searchState,
+    indices: state,
+  };
 }
 
 function refineSingleIndexWithNamespace(
@@ -148,28 +170,28 @@ export function getCurrentRefinementValue(
   defaultValue,
   refinementsCallback = x => x
 ) {
-  const index = getIndex(context);
+  const indexId = getIndexId(context);
   const { namespace, attributeName } = getNamespaceAndAttributeName(id);
   const refinements =
-    (hasMultipleIndex(context) &&
+    (hasMultipleIndices(context) &&
       searchState.indices &&
       namespace &&
-      searchState.indices[`${index}`] &&
-      has(searchState.indices[`${index}`][namespace], `${attributeName}`)) ||
-    (hasMultipleIndex(context) &&
+      searchState.indices[`${indexId}`] &&
+      has(searchState.indices[`${indexId}`][namespace], `${attributeName}`)) ||
+    (hasMultipleIndices(context) &&
       searchState.indices &&
-      has(searchState, `indices.${index}.${id}`)) ||
-    (!hasMultipleIndex(context) &&
+      has(searchState, `indices.${indexId}.${id}`)) ||
+    (!hasMultipleIndices(context) &&
       namespace &&
       has(searchState[namespace], attributeName)) ||
-    (!hasMultipleIndex(context) && has(searchState, id));
+    (!hasMultipleIndices(context) && has(searchState, id));
   if (refinements) {
     let currentRefinement;
 
-    if (hasMultipleIndex(context)) {
+    if (hasMultipleIndices(context)) {
       currentRefinement = namespace
-        ? get(searchState.indices[`${index}`][namespace], attributeName)
-        : get(searchState.indices[index], id);
+        ? get(searchState.indices[`${indexId}`][namespace], attributeName)
+        : get(searchState.indices[indexId], id);
     } else {
       currentRefinement = namespace
         ? get(searchState[namespace], attributeName)
@@ -187,14 +209,14 @@ export function getCurrentRefinementValue(
 }
 
 export function cleanUpValue(searchState, context, id) {
-  const index = getIndex(context);
+  const indexId = getIndexId(context);
   const { namespace, attributeName } = getNamespaceAndAttributeName(id);
 
-  if (hasMultipleIndex(context) && Boolean(searchState.indices)) {
+  if (hasMultipleIndices(context) && Boolean(searchState.indices)) {
     return cleanUpValueWithMutliIndex({
       attribute: attributeName,
       searchState,
-      index,
+      indexId,
       id,
       namespace,
     });
@@ -226,19 +248,19 @@ function cleanUpValueWithSingleIndex({
 
 function cleanUpValueWithMutliIndex({
   searchState,
-  index,
+  indexId,
   id,
   namespace,
   attribute,
 }) {
-  const indexSearchState = searchState.indices[index];
+  const indexSearchState = searchState.indices[indexId];
 
   if (namespace && indexSearchState) {
     return {
       ...searchState,
       indices: {
         ...searchState.indices,
-        [index]: {
+        [indexId]: {
           ...indexSearchState,
           [namespace]: omit(indexSearchState[namespace], attribute),
         },
@@ -246,5 +268,5 @@ function cleanUpValueWithMutliIndex({
     };
   }
 
-  return omit(searchState, `indices.${index}.${id}`);
+  return omit(searchState, `indices.${indexId}.${id}`);
 }

--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty, zipWith } from 'lodash';
 import React, { Component } from 'react';
 import { renderToString } from 'react-dom/server';
 import PropTypes from 'prop-types';
@@ -12,125 +12,126 @@ import {
   HIGHLIGHT_TAGS,
 } from 'react-instantsearch-core';
 
-const getIndex = context =>
+const getIndexId = context =>
   context && context.multiIndexContext
     ? context.multiIndexContext.targetedIndex
     : context.ais.mainTargetedIndex;
 
-const hasMultipleIndex = context => context && context.multiIndexContext;
+const hasMultipleIndices = context => context && context.multiIndexContext;
+
+const getSearchParameters = (indexName, searchParameters) => {
+  const sharedParameters = searchParameters
+    .filter(searchParameter => !hasMultipleIndices(searchParameter.context))
+    .reduce(
+      (acc, searchParameter) =>
+        searchParameter.getSearchParameters(
+          acc,
+          searchParameter.props,
+          searchParameter.searchState
+        ),
+      new SearchParameters({
+        ...HIGHLIGHT_TAGS,
+        index: indexName,
+      })
+    );
+
+  const derivedParameters = searchParameters
+    .filter(searchParameter => hasMultipleIndices(searchParameter.context))
+    .reduce((acc, searchParameter) => {
+      const indexId = getIndexId(searchParameter.context);
+
+      return {
+        ...acc,
+        [indexId]: searchParameter.getSearchParameters(
+          acc[indexId] || sharedParameters,
+          searchParameter.props,
+          searchParameter.searchState
+        ),
+      };
+    }, {});
+
+  return {
+    sharedParameters,
+    derivedParameters,
+  };
+};
+
+const singleIndexSearch = (helper, parameters) => helper.searchOnce(parameters);
+
+const multiIndexSearch = (
+  indexName,
+  client,
+  helper,
+  sharedParameters,
+  { [indexName]: mainParameters, ...derivedParameters }
+) => {
+  const search = [
+    helper.searchOnce({
+      ...sharedParameters,
+      ...mainParameters,
+    }),
+  ];
+
+  const indexIds = Object.keys(derivedParameters);
+
+  search.push(
+    ...indexIds.map(indexId => {
+      const parameters = derivedParameters[indexId];
+
+      return algoliasearchHelper(client, parameters.index).searchOnce(
+        parameters
+      );
+    })
+  );
+
+  return Promise.all(search).then(results =>
+    zipWith([indexName, ...indexIds], results, (indexId, result) =>
+      // We attach `indexId` on the results to be able to reconstruct the
+      // object client side. We cannot rely on `state.index` anymore because
+      // we may have multiple times the same index.
+      ({
+        ...result,
+        _internalIndexId: indexId,
+      })
+    )
+  );
+};
 
 const createInstantSearchServer = algoliasearch => {
   const InstantSearch = createInstantSearch(algoliasearch, {
     Root: 'div',
-    props: { className: 'ais-InstantSearch__root' },
+    props: {
+      className: 'ais-InstantSearch__root',
+    },
   });
 
-  let searchParameters = [];
-  let client;
+  let client = null;
   let indexName = '';
-
-  const onSearchParameters = (
-    getSearchParameters,
-    context,
-    props,
-    searchState
-  ) => {
-    const index = getIndex(context);
-    searchParameters.push({
-      getSearchParameters,
-      context,
-      props,
-      searchState,
-      index,
-    });
-  };
+  let searchParameters = [];
 
   const findResultsState = function(App, props) {
     searchParameters = [];
 
     renderToString(<App {...props} />);
 
-    const sharedSearchParameters = searchParameters
-      .filter(
-        searchParameter =>
-          !hasMultipleIndex(searchParameter.context) &&
-          (searchParameter.props.indexName === indexName ||
-            !searchParameter.props.indexName)
-      )
-      .reduce(
-        (acc, searchParameter) =>
-          searchParameter.getSearchParameters(
-            acc,
-            searchParameter.props,
-            searchParameter.searchState
-          ),
-        new SearchParameters({ index: indexName, ...HIGHLIGHT_TAGS })
-      );
+    const { sharedParameters, derivedParameters } = getSearchParameters(
+      indexName,
+      searchParameters
+    );
 
-    const mergedSearchParameters = searchParameters
-      .filter(searchParameter => hasMultipleIndex(searchParameter.context))
-      .reduce((acc, searchParameter) => {
-        const index = getIndex(searchParameter.context);
-        const sp = searchParameter.getSearchParameters(
-          acc[index] ? acc[index] : sharedSearchParameters,
-          searchParameter.props,
-          searchParameter.searchState
-        );
-        acc[index] = sp;
-        return acc;
-      }, {});
+    const helper = algoliasearchHelper(client, sharedParameters.index);
 
-    if (isEmpty(mergedSearchParameters)) {
-      const helper = algoliasearchHelper(client, sharedSearchParameters.index);
-      return helper.searchOnce(sharedSearchParameters);
-    } else {
-      const helper = algoliasearchHelper(client, sharedSearchParameters.index);
-      const search = [];
-
-      if (mergedSearchParameters[indexName]) {
-        search.push(
-          helper.searchOnce({
-            ...sharedSearchParameters,
-            ...mergedSearchParameters[sharedSearchParameters.index],
-            index: mergedSearchParameters[sharedSearchParameters.index].index,
-          })
-        );
-        delete mergedSearchParameters[indexName];
-      } else {
-        search.push(helper.searchOnce(sharedSearchParameters));
-      }
-
-      search.push(
-        ...Object.keys(mergedSearchParameters).map(key => {
-          const derivedHelper = algoliasearchHelper(
-            client,
-            mergedSearchParameters[key].index
-          );
-          return derivedHelper.searchOnce(mergedSearchParameters[key]);
-        })
-      );
-
-      return Promise.all(search);
-    }
-  };
-
-  const decorateResults = function(results) {
-    if (!results) {
-      return undefined;
+    if (isEmpty(derivedParameters)) {
+      return singleIndexSearch(helper, sharedParameters);
     }
 
-    return Array.isArray(results)
-      ? results.reduce((acc, result) => {
-          acc[result.state.index] = new SearchResults(
-            new SearchParameters(result.state),
-            result._originalResponse.results
-          );
-          return acc;
-        }, [])
-      : new SearchResults(
-          new SearchParameters(results.state),
-          results._originalResponse.results
-        );
+    return multiIndexSearch(
+      indexName,
+      client,
+      helper,
+      sharedParameters,
+      derivedParameters
+    );
   };
 
   class CreateInstantSearchServer extends Component {
@@ -143,18 +144,18 @@ const createInstantSearchServer = algoliasearch => {
       resultsState: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     };
 
-    constructor(props) {
-      super();
+    constructor(...args) {
+      super(...args);
 
-      if (props.searchClient) {
-        if (props.appId || props.apiKey || props.algoliaClient) {
+      if (this.props.searchClient) {
+        if (this.props.appId || this.props.apiKey || this.props.algoliaClient) {
           throw new Error(
             'react-instantsearch:: `searchClient` cannot be used with `appId`, `apiKey` or `algoliaClient`.'
           );
         }
       }
 
-      if (props.algoliaClient) {
+      if (this.props.algoliaClient) {
         // eslint-disable-next-line no-console
         console.warn(
           '`algoliaClient` option was renamed `searchClient`. Please use this new option before the next major version.'
@@ -162,30 +163,66 @@ const createInstantSearchServer = algoliasearch => {
       }
 
       client =
-        props.searchClient ||
-        props.algoliaClient ||
-        algoliasearch(props.appId, props.apiKey);
+        this.props.searchClient ||
+        this.props.algoliaClient ||
+        algoliasearch(this.props.appId, this.props.apiKey);
 
       if (typeof client.addAlgoliaAgent === 'function') {
         client.addAlgoliaAgent(`react-instantsearch ${version}`);
       }
 
-      indexName = props.indexName;
+      indexName = this.props.indexName;
+    }
+
+    onSearchParameters(getWidgetSearchParameters, context, props, searchState) {
+      searchParameters.push({
+        getSearchParameters: getWidgetSearchParameters,
+        index: getIndexId(context),
+        context,
+        props,
+        searchState,
+      });
+    }
+
+    hydrateResultsState() {
+      const { resultsState = [] } = this.props;
+
+      if (Array.isArray(resultsState)) {
+        return resultsState.reduce(
+          (acc, result) => ({
+            ...acc,
+            [result._internalIndexId]: new SearchResults(
+              new SearchParameters(result.state),
+              result._originalResponse.results
+            ),
+          }),
+          {}
+        );
+      }
+
+      return new SearchResults(
+        new SearchParameters(resultsState.state),
+        resultsState._originalResponse.results
+      );
     }
 
     render() {
-      const resultsState = decorateResults(this.props.resultsState);
+      const resultsState = this.hydrateResultsState();
+
       return (
         <InstantSearch
           {...this.props}
           resultsState={resultsState}
-          onSearchParameters={onSearchParameters}
+          onSearchParameters={this.onSearchParameters}
         />
       );
     }
   }
 
-  return { InstantSearch: CreateInstantSearchServer, findResultsState };
+  return {
+    InstantSearch: CreateInstantSearchServer,
+    findResultsState,
+  };
 };
 
 export default createInstantSearchServer;


### PR DESCRIPTION
**Summary**

This PR does not introduce new feature, it's a refactor of `createInstantSearchManager`. The logic to detect shared, main and derived parameters was hard to follow. We tried to put name on this logic to help the reader to follow what happens. Now all search parameters are computed inside the same function, previously it was spread across `getSearchParameters` and `search`.

**Changes**

- **`createInstantSearchManager`**: exposes the `getSearchParameters` function to be able to test it. We don't use this function elsewhere inside the codebase but since the logic is "sensitive" it's a viable trade off IMO.
- **`createInstantSearchManager`**: the derived search parameters are now computed directly inside `getSearchParameters`. The main impact is that the shared parameters don't have to be exposed anymore.
- **`createInstantSearchManager`**: the helper creation is now inlined, we removed the useless step that create the `SearchParameters`. The [third parameters of the helper](https://github.com/algolia/algoliasearch-helper-js/blob/5d7d915331c3b8782114be393171268e5489c6c7/src/algoliasearch.helper.js#L129) is an object that is used to create the state.
