### PR TITLE
feat(indexId): warn about usage of Index without indexId [PART-6]

### DIFF
--- a/examples/autocomplete/src/App-Multi-Index.js
+++ b/examples/autocomplete/src/App-Multi-Index.js
@@ -17,8 +17,8 @@ const App = () => (
   >
     <AutoComplete />
     <Configure hitsPerPage={1} />
-    <Index indexName="bestbuy" />
-    <Index indexName="airbnb" />
+    <Index indexId="bestbuy" indexName="bestbuy" />
+    <Index indexId="airbnb" indexName="airbnb" />
   </InstantSearch>
 );
 

--- a/examples/multi-index/src/App.js
+++ b/examples/multi-index/src/App.js
@@ -10,7 +10,7 @@ const App = () => (
     <SearchBox />
     <p>Results in first dataset</p>
     <Hits />
-    <Index indexName="instant_search">
+    <Index indexId="instant_search" indexName="instant_search">
       <p>Results in second dataset</p>
       <Hits />
     </Index>

--- a/examples/react-native-query-suggestions/App.js
+++ b/examples/react-native-query-suggestions/App.js
@@ -167,11 +167,15 @@ export default class App extends React.Component {
             defaultRefinement={this.state.query}
             clearFilter={this.clearFilter}
           />
-          <Index indexName="instant_search_demo_query_suggestions">
+          <Index
+            indexId="instant_search_demo_query_suggestions"
+            indexName="instant_search_demo_query_suggestions"
+          >
             <Configure hitsPerPage={5} />
             {suggestions}
           </Index>
           <Index
+            indexId="instant_search"
             indexName="instant_search"
             root={{
               Root: View,

--- a/packages/react-instantsearch-core/src/core/__tests__/__snapshots__/createIndex.js.snap
+++ b/packages/react-instantsearch-core/src/core/__tests__/__snapshots__/createIndex.js.snap
@@ -2,7 +2,7 @@
 
 exports[`createIndex expects to create an Index 1`] = `
 <Index
-  indexId="indexName"
+  indexId="indexId"
   indexName="indexName"
   root={
     Object {

--- a/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
@@ -8,6 +8,7 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('createIndex', () => {
   const requiredProps = {
+    indexId: 'indexId',
     indexName: 'indexName',
   };
 
@@ -83,6 +84,7 @@ describe('createIndex', () => {
 
     const props = {
       ...requiredProps,
+      indexId: undefined,
     };
 
     const wrapper = shallow(<CustomIndex {...props} />);
@@ -97,6 +99,7 @@ describe('createIndex', () => {
 
     const props = {
       ...requiredProps,
+      indexId: undefined,
     };
 
     shallow(<CustomIndex {...props} />);
@@ -115,6 +118,7 @@ describe('createIndex', () => {
 
     const props = {
       ...requiredProps,
+      indexId: undefined,
     };
 
     shallow(<CustomIndex {...props} />);

--- a/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createIndex.js
@@ -7,13 +7,13 @@ import createIndex from '../createIndex';
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('createIndex', () => {
-  const CustomIndex = createIndex({ Root: 'div' });
-
   const requiredProps = {
     indexName: 'indexName',
   };
 
   it('expects to create an Index', () => {
+    const CustomIndex = createIndex({ Root: 'div' });
+
     const props = {
       ...requiredProps,
     };
@@ -25,6 +25,8 @@ describe('createIndex', () => {
   });
 
   it('expects to create an Index with the default root', () => {
+    const CustomIndex = createIndex({ Root: 'div' });
+
     const props = {
       ...requiredProps,
     };
@@ -37,6 +39,8 @@ describe('createIndex', () => {
   });
 
   it('expects to create an Index with a custom root props', () => {
+    const CustomIndex = createIndex({ Root: 'div' });
+
     const props = {
       ...requiredProps,
       root: {
@@ -62,6 +66,8 @@ describe('createIndex', () => {
   });
 
   it('expects to create an Index with an indexId when provided', () => {
+    const CustomIndex = createIndex({ Root: 'div' });
+
     const props = {
       ...requiredProps,
       indexId: 'indexId',
@@ -73,6 +79,8 @@ describe('createIndex', () => {
   });
 
   it("expects to create an Index with an indexId that fallback to indexName when it's not provided", () => {
+    const CustomIndex = createIndex({ Root: 'div' });
+
     const props = {
       ...requiredProps,
     };
@@ -80,5 +88,58 @@ describe('createIndex', () => {
     const wrapper = shallow(<CustomIndex {...props} />);
 
     expect(wrapper.props().indexId).toBe('indexName');
+  });
+
+  it('expect to warn when an Index is used without an indexId', () => {
+    const CustomIndex = createIndex({ Root: 'div' });
+
+    const warn = jest.spyOn(console, 'warn');
+
+    const props = {
+      ...requiredProps,
+    };
+
+    shallow(<CustomIndex {...props} />);
+
+    expect(warn).toHaveBeenCalledWith(
+      '[React InstantSearch]: `indexId` is required for the `Index` component. Please use this prop before the next major version.'
+    );
+
+    warn.mockRestore();
+  });
+
+  it('expect to warn only once when an Index is used without an indexId', () => {
+    const CustomIndex = createIndex({ Root: 'div' });
+
+    const warn = jest.spyOn(console, 'warn');
+
+    const props = {
+      ...requiredProps,
+    };
+
+    shallow(<CustomIndex {...props} />);
+    shallow(<CustomIndex {...props} />);
+    shallow(<CustomIndex {...props} />);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    warn.mockRestore();
+  });
+
+  it('expect to not warn when an Index is used with an indexId', () => {
+    const CustomIndex = createIndex({ Root: 'div' });
+
+    const warn = jest.spyOn(console, 'warn');
+
+    const props = {
+      ...requiredProps,
+      indexId: 'indexId',
+    };
+
+    shallow(<CustomIndex {...props} />);
+
+    expect(warn).not.toHaveBeenCalled();
+
+    warn.mockRestore();
   });
 });

--- a/packages/react-instantsearch-core/src/core/createIndex.js
+++ b/packages/react-instantsearch-core/src/core/createIndex.js
@@ -9,11 +9,22 @@ import Index from '../components/Index';
  * @return {object} a Index root
  */
 const createIndex = defaultRoot => {
-  const CreateIndex = ({ indexName, indexId, root, children }) => (
-    <Index indexName={indexName} indexId={indexId || indexName} root={root}>
-      {children}
-    </Index>
-  );
+  let hasAlreadyWarn = false;
+  const CreateIndex = ({ indexName, indexId, root, children }) => {
+    if (process.env.NODE_ENV !== 'production' && !hasAlreadyWarn && !indexId) {
+      hasAlreadyWarn = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[React InstantSearch]: `indexId` is required for the `Index` component. Please use this prop before the next major version.'
+      );
+    }
+
+    return (
+      <Index indexName={indexName} indexId={indexId || indexName} root={root}>
+        {children}
+      </Index>
+    );
+  };
 
   CreateIndex.propTypes = {
     indexName: PropTypes.string.isRequired,

--- a/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
@@ -397,7 +397,7 @@ describe('createInstantSearchServer', () => {
 
         const App = () => (
           <InstantSearch {...props}>
-            <Index indexName="index2">
+            <Index indexId="index2" indexName="index2">
               <Connected />
             </Index>
           </InstantSearch>
@@ -425,7 +425,7 @@ describe('createInstantSearchServer', () => {
 
         const App = () => (
           <InstantSearch {...props}>
-            <Index indexName="index2">
+            <Index indexId="index2" indexName="index2">
               <Connected />
             </Index>
           </InstantSearch>

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -27,7 +27,7 @@ stories
     >
       <SearchBox />
 
-      <Index indexName="bestbuy">
+      <Index indexId="bestbuy" indexName="bestbuy">
         <h3>
           index: <code>bestbuy</code>
         </h3>
@@ -35,7 +35,7 @@ stories
         <CustomCategoriesOrBrands />
       </Index>
 
-      <Index indexName="instant_search">
+      <Index indexId="instant_search" indexName="instant_search">
         <h3>
           index: <code>instant_search</code>
         </h3>
@@ -75,8 +75,8 @@ stories
       indexName="categories"
     >
       <Configure hitsPerPage={3} />
-      <Index indexName="brands" />
-      <Index indexName="products">
+      <Index indexId="brands" indexName="brands" />
+      <Index indexId="products" indexName="products">
         <Configure hitsPerPage={5} />
       </Index>
       <AutoComplete />
@@ -92,7 +92,7 @@ stories
 
       <div className="multi-index_content">
         <div className="multi-index_categories-or-brands">
-          <Index indexName="categories">
+          <Index indexId="categories" indexName="categories">
             <Configure hitsPerPage={3} />
 
             <SortBy
@@ -106,7 +106,7 @@ stories
             <CustomCategoriesOrBrands />
           </Index>
 
-          <Index indexName="products">
+          <Index indexId="products" indexName="products">
             <Configure hitsPerPage={3} />
 
             <SortBy
@@ -133,7 +133,7 @@ stories
       <Results>
         <div className="multi-index_content">
           <div className="multi-index_categories-or-brands">
-            <Index indexName="categories">
+            <Index indexId="categories" indexName="categories">
               <Content>
                 <div>
                   <div>Categories: </div>
@@ -142,7 +142,7 @@ stories
                 </div>
               </Content>
             </Index>
-            <Index indexName="brands">
+            <Index indexId="brands" indexName="brands">
               <Content>
                 <div>
                   <div>Brand: </div>
@@ -153,7 +153,7 @@ stories
             </Index>
           </div>
           <div className="multi-index_products">
-            <Index indexName="products">
+            <Index indexId="products" indexName="products">
               <Content>
                 <div>
                   <div>Products: </div>
@@ -179,7 +179,7 @@ stories
       <CustomCategoriesOrBrands />
       <Pagination />
 
-      <Index indexName="products">
+      <Index indexId="products" indexName="products">
         <CustomProducts />
         <Pagination />
       </Index>
@@ -197,6 +197,7 @@ stories
 
         <SearchBox />
         <Index
+          indexId="products"
           indexName="products"
           root={{
             Root: 'div',
@@ -311,9 +312,9 @@ const Results = connectStateResults(({ allSearchResults, children }) => {
   return noResults ? (
     <div>
       <div>No results in category, products or brand</div>
-      <Index indexName="categories" />
-      <Index indexName="brands" />
-      <Index indexName="products" />
+      <Index indexId="categories" indexName="categories" />
+      <Index indexId="brands" indexName="brands" />
+      <Index indexId="products" indexName="products" />
     </div>
   ) : (
     children


### PR DESCRIPTION
**Summary**

This PR introduces a warning when the `Index` component is used without an `indexId`. One question though: do we want the `indexId` to be required at some point? Right now the value fallback on the `indexName` and for most cases it's fine. The id is only used for a multi-index search on the same index. It means that users that don't use this feature pay the cost of this prop. Naming things is hard so they will probably do the same as we do in the PR: use the same value for the id and the name. WDYT?

**Changes**

- **`createIndex`**: warn about the usage of `Index` without `indexId`
- update the usage of `Index` with the `indexId` across the codebase

**Result**

![screenshot 2018-12-28 at 17 29 00](https://user-images.githubusercontent.com/6513513/50521458-1abe6b00-0ac6-11e9-8804-d0e6ceea7438.png)