### PR TITLE
refactor(createConnector): update subscriptions mechanism

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectPoweredBy.jsdom.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectPoweredBy.jsdom.js
@@ -6,7 +6,7 @@ describe('connectPoweredBy', () => {
   const { getProvidedProps } = connect;
 
   it('provides the correct props to the component', () => {
-    const props = getProvidedProps({ canRender: true });
+    const props = getProvidedProps();
 
     expect(props).toEqual({
       url:

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectPoweredBy.node.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectPoweredBy.node.js
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment node
+ */
+
+import connect from '../connectPoweredBy';
+
+jest.mock('../../core/createConnector', () => x => x);
+
+describe('connectPoweredBy', () => {
+  const { getProvidedProps } = connect;
+
+  it('provides the correct props to the component', () => {
+    const props = getProvidedProps();
+
+    expect(props).toEqual({
+      url:
+        'https://www.algolia.com/?utm_source=react-instantsearch&utm_medium=website&utm_content=&utm_campaign=poweredby',
+    });
+  });
+});

--- a/packages/react-instantsearch-core/src/connectors/connectPoweredBy.js
+++ b/packages/react-instantsearch-core/src/connectors/connectPoweredBy.js
@@ -10,15 +10,18 @@ import createConnector from '../core/createConnector';
 export default createConnector({
   displayName: 'AlgoliaPoweredBy',
 
-  propTypes: {},
+  getProvidedProps() {
+    const isServer = typeof window === 'undefined';
 
-  getProvidedProps(props) {
     const url =
       'https://www.algolia.com/?' +
       'utm_source=react-instantsearch&' +
       'utm_medium=website&' +
-      `utm_content=${props.canRender ? location.hostname : ''}&` +
+      `utm_content=${!isServer ? window.location.hostname : ''}&` +
       'utm_campaign=poweredby';
-    return { url };
+
+    return {
+      url,
+    };
   },
 });

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -314,7 +314,7 @@ describe('createConnector', () => {
       expect(subscribe).toHaveBeenCalledTimes(1);
     });
 
-    it('unsubscribes from the store on willUnmount', () => {
+    it('unsubscribes from the store on unmount', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
         getProvidedProps: () => null,
@@ -580,7 +580,7 @@ describe('createConnector', () => {
       expect(registerWidget).toHaveBeenCalledWith(wrapper.instance());
     });
 
-    it('calls onSearchParameters on willMount', () => {
+    it('calls onSearchParameters on mount', () => {
       const getSearchParameters = jest.fn(() => null);
       const onSearchParameters = jest.fn(() => null);
       let Connected = createConnector({
@@ -628,7 +628,7 @@ describe('createConnector', () => {
       expect(onSearchParameters.mock.calls).toHaveLength(1);
     });
 
-    it('binds getSearchParameters to its own instance when calling onSearchParameters in componentWillMount', () => {
+    it('binds getSearchParameters to its own instance when calling onSearchParameters on mount', () => {
       const getSearchParameters = jest.fn(() => null);
       const onSearchParameters = jest.fn(boundGetSearchParameters =>
         // The bound getSearchParameters function must be invoked in order for it

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -101,6 +101,54 @@ describe('createConnector', () => {
       });
     });
 
+    it('uses the correct value for `canRender` on props change', () => {
+      const getProvidedProps = jest.fn(() => {});
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps,
+        getId,
+      })(() => null);
+
+      const props = {
+        hello: 'there',
+      };
+
+      const wrapper = shallow(<Connected {...props} />, {
+        disableLifecycleMethods: true,
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => {},
+            },
+            onSearchParameters: () => {},
+          },
+        },
+      });
+
+      // Simulate props change before mount
+      wrapper.setProps({ hello: 'here' });
+
+      expect(getProvidedProps.mock.calls[1][0]).toEqual({
+        hello: 'here',
+        canRender: false,
+      });
+
+      // Simulate mount lifecycle
+      wrapper.instance().componentDidMount();
+
+      // Simulate props change after mount
+      wrapper.setProps({ hello: 'again' });
+
+      expect(getProvidedProps.mock.calls[2][0]).toEqual({
+        hello: 'again',
+        canRender: true,
+      });
+    });
+
     it('updates on state change', () => {
       const getProvidedProps = jest.fn((props, state) => state);
       const Dummy = () => null;
@@ -350,7 +398,7 @@ describe('createConnector', () => {
       expect(() => trigger()).not.toThrow();
     });
 
-    it("doesn't update the component when passed props don't change", () => {
+    it("does not update the component when passed props don't change", () => {
       const getProvidedProps = jest.fn(() => {});
       const getSearchParameters = jest.fn(() => {});
       const onSearchStateChange = jest.fn();

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -288,6 +288,34 @@ describe('createConnector', () => {
       expect(unsubscribe.mock.calls).toHaveLength(1);
     });
 
+    it('does not throw an error on unmount before mount', () => {
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps: () => null,
+        getId,
+      })(() => null);
+
+      const wrapper = shallow(<Connected />, {
+        disableLifecycleMethods: true,
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe() {
+                return () => {
+                  // unsubscribe
+                };
+              },
+            },
+          },
+        },
+      });
+
+      const trigger = () => wrapper.unmount();
+
+      expect(() => trigger()).not.toThrow();
+    });
+
     it("doesn't update the component when passed props don't change", () => {
       const getProvidedProps = jest.fn(() => {});
       const getSearchParameters = jest.fn(() => {});
@@ -724,6 +752,7 @@ describe('createConnector', () => {
       const unregister = jest.fn();
       const setState = jest.fn();
       const onSearchStateChange = jest.fn();
+
       it('unregisters itself on unmount', () => {
         const wrapper = mount(<Connected />, {
           context: {
@@ -756,6 +785,28 @@ describe('createConnector', () => {
           another: { state: 'state' },
         });
       });
+
+      it('does not throw an error on unmount before mount', () => {
+        const wrapper = shallow(<Connected />, {
+          disableLifecycleMethods: true,
+          context: {
+            ais: {
+              store: {
+                getState: () => ({}),
+                subscribe: () => {},
+              },
+              widgetsManager: {
+                registerWidget: () => {},
+              },
+            },
+          },
+        });
+
+        const trigger = () => wrapper.unmount();
+
+        expect(() => trigger()).not.toThrow();
+      });
+
       it('empty key from the search state should be removed', () => {
         const wrapper = mount(<Connected />, {
           context: {

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -316,6 +316,40 @@ describe('createConnector', () => {
       expect(() => trigger()).not.toThrow();
     });
 
+    it('does not throw an error on dispatch after unmount', () => {
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps: () => null,
+        getId,
+      })(() => null);
+
+      const subscribe = jest.fn(() => {
+        const unsubscribe = () => {};
+
+        return unsubscribe;
+      });
+
+      const wrapper = shallow(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe,
+            },
+          },
+        },
+      });
+
+      const trigger = () => {
+        wrapper.unmount();
+
+        // Simulate a dispatch
+        subscribe.mock.calls[0][0]();
+      };
+
+      expect(() => trigger()).not.toThrow();
+    });
+
     it("doesn't update the component when passed props don't change", () => {
       const getProvidedProps = jest.fn(() => {});
       const getSearchParameters = jest.fn(() => {});

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -70,7 +70,7 @@ export default function createConnector(connectorDesc) {
             ...props,
             // @MAJOR: We cannot drop this beacuse it's a breaking change. The
             // prop is provided to `createConnector.getProvidedProps`. All the
-            // custom connector are impacted by this change. It should be fine
+            // custom connectors are impacted by this change. It should be fine
             // to drop it in the next major though.
             canRender: false,
           }),

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -59,6 +59,8 @@ export default function createConnector(connectorDesc) {
         multiIndexContext: PropTypes.object,
       };
 
+      isUnmounting = false;
+
       constructor(props, context) {
         super(props, context);
 
@@ -142,13 +144,15 @@ export default function createConnector(connectorDesc) {
 
       componentDidMount() {
         this.unsubscribe = this.context.ais.store.subscribe(() => {
-          this.setState({
-            props: this.getProvidedProps({
-              ...this.props,
-              // @MAJOR: see constructor
-              canRender: true,
-            }),
-          });
+          if (!this.isUnmounting) {
+            this.setState({
+              props: this.getProvidedProps({
+                ...this.props,
+                // @MAJOR: see constructor
+                canRender: true,
+              }),
+            });
+          }
         });
 
         if (isWidget) {
@@ -197,6 +201,8 @@ export default function createConnector(connectorDesc) {
       }
 
       componentWillUnmount() {
+        this.isUnmounting = true;
+
         if (this.unsubscribe) {
           this.unsubscribe();
         }

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -65,6 +65,10 @@ export default function createConnector(connectorDesc) {
         this.state = {
           props: this.getProvidedProps({
             ...props,
+            // @MAJOR: We cannot drop this beacuse it's a breaking change. The
+            // prop is provided to `createConnector.getProvidedProps`. All the
+            // custom connector are impacted by this change. It should be fine
+            // to drop it in the next major though.
             canRender: false,
           }),
         };
@@ -141,6 +145,7 @@ export default function createConnector(connectorDesc) {
           this.setState({
             props: this.getProvidedProps({
               ...this.props,
+              // @MAJOR: see constructor
               canRender: true,
             }),
           });
@@ -168,6 +173,7 @@ export default function createConnector(connectorDesc) {
           this.setState({
             props: this.getProvidedProps({
               ...nextProps,
+              // @MAJOR: see constructor
               canRender: true,
             }),
           });

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -59,6 +59,7 @@ export default function createConnector(connectorDesc) {
         multiIndexContext: PropTypes.object,
       };
 
+      mounted = false;
       isUnmounting = false;
 
       constructor(props, context) {
@@ -143,6 +144,8 @@ export default function createConnector(connectorDesc) {
       }
 
       componentDidMount() {
+        this.mounted = true;
+
         this.unsubscribe = this.context.ais.store.subscribe(() => {
           if (!this.isUnmounting) {
             this.setState({
@@ -178,7 +181,7 @@ export default function createConnector(connectorDesc) {
             props: this.getProvidedProps({
               ...nextProps,
               // @MAJOR: see constructor
-              canRender: true,
+              canRender: this.mounted,
             }),
           });
 

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -197,19 +197,25 @@ export default function createConnector(connectorDesc) {
       }
 
       componentWillUnmount() {
-        this.unsubscribe();
-        if (isWidget) {
+        if (this.unsubscribe) {
+          this.unsubscribe();
+        }
+
+        if (this.unregisterWidget) {
           this.unregisterWidget(); // will schedule an update
+
           if (hasCleanUp) {
             const newState = connectorDesc.cleanUp.call(
               this,
               this.props,
               this.context.ais.store.getState().widgets
             );
+
             this.context.ais.store.setState({
               ...this.context.ais.store.getState(),
               widgets: newState,
             });
+
             this.context.ais.onSearchStateChange(removeEmptyKey(newState));
           }
         }

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -60,7 +60,7 @@ export default function createConnector(connectorDesc) {
       };
 
       mounted = false;
-      isUnmounting = false;
+      unmounting = false;
 
       constructor(props, context) {
         super(props, context);
@@ -147,7 +147,7 @@ export default function createConnector(connectorDesc) {
         this.mounted = true;
 
         this.unsubscribe = this.context.ais.store.subscribe(() => {
-          if (!this.isUnmounting) {
+          if (!this.unmounting) {
             this.setState({
               props: this.getProvidedProps({
                 ...this.props,
@@ -204,7 +204,7 @@ export default function createConnector(connectorDesc) {
       }
 
       componentWillUnmount() {
-        this.isUnmounting = true;
+        this.unmounting = true;
 
         if (this.unsubscribe) {
           this.unsubscribe();

--- a/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
@@ -265,19 +265,13 @@ describe('createInstantSearchServer', () => {
 
         await findResultsState(App);
 
-        // It's called two times because of an issue we have inside
-        // `createConnector`. We register the widget inside the constructor it
-        // means that it's executed on the server. But on the server we already
-        // have the hook `onSearchParamters` that collect `getSearchParameters`
-        // on all the widgets. At the end both are executed it should be fixed
-        // once we move the registration inside `componentDidMount`.
-        expect(getSearchParameters).toHaveBeenCalledTimes(2);
+        expect(getSearchParameters).toHaveBeenCalledTimes(1);
 
         getSearchParameters.mockClear();
 
         await findResultsState(App);
 
-        expect(getSearchParameters).toHaveBeenCalledTimes(2);
+        expect(getSearchParameters).toHaveBeenCalledTimes(1);
       });
 
       it('without search state', async () => {
@@ -433,19 +427,13 @@ describe('createInstantSearchServer', () => {
 
         await findResultsState(App);
 
-        // It's called two times because of an issue we have inside
-        // `createConnector`. We register the widget inside the constructor it
-        // means that it's executed on the server. But on the server we already
-        // have the hook `onSearchParamters` that collect `getSearchParameters`
-        // on all the widgets. At the end both are executed it should be fixed
-        // once we move the registration inside `componentDidMount`.
-        expect(getSearchParameters).toHaveBeenCalledTimes(2);
+        expect(getSearchParameters).toHaveBeenCalledTimes(1);
 
         getSearchParameters.mockClear();
 
         await findResultsState(App);
 
-        expect(getSearchParameters).toHaveBeenCalledTimes(2);
+        expect(getSearchParameters).toHaveBeenCalledTimes(1);
       });
 
       it('without search state - first API', async () => {


### PR DESCRIPTION
**Summary**

The PR changes the way we subscribe to the `store` and `widgetManager`. Until now the subscriptions was done inside the constructor. It leads to some issues with our implementation. 

The first issue occurs with SSR. We have a callback (`onSearchParameters`) to collect and compute search parameters on the server. The callback is called inside `componentWillMount` only when it's provided. The issue is that the constructor is also executed on the server. It means that we trigger at least two requests on the server: one scheduled by the SSR (this is expected) and the others by the manager (this is **not** expected). The latter is not expected because we have no way to "wait" for it and use its results to re-render the App. Only the request schedules by the SSR is required.

The other issue comes from the `canRender` prop. This prop is used to detect whether or not we are on the client or the server. The value is initialised to `false` in the constructor and then we call `setState` inside `componentDidMount`. This lifecycle is only called on the client. It means that we are now safe to access browser API like `window.location`. The issue with it is that we schedule an extra useless render to set the value to `true`. React triggers a warning inside the flame graph (see below).

**Solution**

To solve both issues we can move the subscription from the constructor to `componentDidMount`. The listeners are now only attached on the client once the component is actually mounted on the page. It solves the first issue because the manager doesn't schedule a new request on the server, only the one scheduled by the SSR is sent. It solves also our second issue because now the listeners are called on the client only. It means that we can provide directly the value to `canRefine` rather than relying on internal state. It's also the recommended way to handle subscriptions [by the React team](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#adding-event-listeners-or-subscriptions).

The `canRender` prop is almost useless though because we can rely on something else to detect whether or not we are on the server. We dropped his usage inside the connectors but we have to keep it until the next major inside `createConnector`. It's a public API so every users that rely on this value inside a custom connector could be impacted.

**Result**

![screenshot 2019-01-02 at 12 02 19](https://user-images.githubusercontent.com/6513513/50591928-4f4d7080-0e92-11e9-93b7-42ce5be2a2d3.png)

![screenshot 2019-01-02 at 11 59 55](https://user-images.githubusercontent.com/6513513/50591931-53798e00-0e92-11e9-8d6d-492a4a18292d.png)