### PR TITLE
test(createConnector): use consistent test strategies

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -442,7 +442,7 @@ describe('createConnector', () => {
     it('does not throw an error on unmount before mount', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
       })(() => null);
 
       const context = createFakeContext({
@@ -466,7 +466,7 @@ describe('createConnector', () => {
     it('does not throw an error on dispatch after unmount', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
       })(() => null);
 
       const unsubscribe = () => {};
@@ -495,7 +495,7 @@ describe('createConnector', () => {
     it('registers itself as a widget with getMetadata', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getMetadata: () => null,
       })(() => null);
 
@@ -518,7 +518,7 @@ describe('createConnector', () => {
     it('registers itself as a widget with getSearchParameters', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getSearchParameters: () => null,
       })(() => null);
 
@@ -541,7 +541,7 @@ describe('createConnector', () => {
     it('registers itself as a widget once mounted', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getSearchParameters: () => null,
       })(() => null);
 
@@ -570,7 +570,7 @@ describe('createConnector', () => {
     it('does not register itself as a widget without getMetadata nor getSearchParameters', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
       })(() => null);
 
       const registerWidget = jest.fn();
@@ -591,7 +591,7 @@ describe('createConnector', () => {
     it('calls onSearchParameters on mount with getSearchParameters', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getSearchParameters: () => null,
       })(() => null);
 
@@ -620,7 +620,7 @@ describe('createConnector', () => {
     it('does not call onSearchParameters on mount without getSearchParameters', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
       })(() => null);
 
       const onSearchParameters = jest.fn();
@@ -647,7 +647,7 @@ describe('createConnector', () => {
 
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getSearchParameters,
       })(() => null);
 
@@ -667,7 +667,7 @@ describe('createConnector', () => {
     it('triggers a widgetManager update on props change', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getMetadata: () => null,
       })(() => null);
 
@@ -699,7 +699,7 @@ describe('createConnector', () => {
     it('does not trigger a widgetManager update when props do not change', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getMetadata: () => null,
       })(() => null);
 
@@ -735,7 +735,7 @@ describe('createConnector', () => {
 
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getMetadata: () => null,
         transitionState,
       })(() => null);
@@ -781,7 +781,7 @@ describe('createConnector', () => {
     it('does not trigger an onSearchStateChange on props change wihtout transitionState', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getMetadata: () => null,
       })(() => null);
 
@@ -811,7 +811,7 @@ describe('createConnector', () => {
     it('unregisters itself on unmount', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getMetadata: () => null,
       })(() => null);
 
@@ -845,7 +845,7 @@ describe('createConnector', () => {
 
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getMetadata: () => null,
         cleanUp,
       })(() => null);
@@ -903,7 +903,7 @@ describe('createConnector', () => {
 
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getMetadata: () => null,
         cleanUp,
       })(() => null);
@@ -943,7 +943,7 @@ describe('createConnector', () => {
     it('does not throw an error on unmount before mount', () => {
       const Connected = createConnector({
         displayName: 'Connector',
-        getProvidedProps: () => null,
+        getProvidedProps: () => {},
         getMetadata: () => null,
       })(() => null);
 

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -966,6 +966,98 @@ describe('createConnector', () => {
     });
   });
 
+  describe('getSearchParameters', () => {
+    it('returns the widget search parameters when getSearchParameters is provided', () => {
+      const getSearchParameters = function(
+        searchParameters,
+        props,
+        searchState
+      ) {
+        return {
+          instanceProps: this.props,
+          providedProps: props,
+          searchParameters,
+          searchState,
+        };
+      };
+
+      const Connected = createConnector({
+        displayName: 'Connector',
+        getProvidedProps: () => {},
+        getSearchParameters,
+      })(() => null);
+
+      const searchParameters = {
+        query: '',
+        hitsPerPage: 10,
+      };
+
+      const state = createFakeState({
+        widgets: {
+          query: 'hello',
+        },
+      });
+
+      const props = {
+        hello: 'there',
+      };
+
+      const context = createFakeContext({
+        store: createFakeStore({
+          getState: () => state,
+        }),
+      });
+
+      const wrapper = shallow(<Connected {...props} />, {
+        context,
+      });
+
+      const widgetSearchParamameters = wrapper
+        .instance()
+        .getSearchParameters(searchParameters);
+
+      expect(widgetSearchParamameters).toEqual({
+        searchParameters: {
+          query: '',
+          hitsPerPage: 10,
+        },
+        instanceProps: {
+          hello: 'there',
+        },
+        providedProps: {
+          hello: 'there',
+        },
+        searchState: {
+          query: 'hello',
+        },
+      });
+    });
+
+    it('returns null when getSearchParameters is not provided', () => {
+      const Connected = createConnector({
+        displayName: 'Connector',
+        getProvidedProps: () => {},
+      })(() => null);
+
+      const searchParameters = {
+        query: '',
+        hitsPerPage: 10,
+      };
+
+      const context = createFakeContext();
+
+      const wrapper = shallow(<Connected />, {
+        context,
+      });
+
+      const widgetSearchParamameters = wrapper
+        .instance()
+        .getSearchParameters(searchParameters);
+
+      expect(widgetSearchParamameters).toBe(null);
+    });
+  });
+
   describe('refine', () => {
     it('passes a refine method to the component', () => {
       const refine = (props, searchState, next) => ({

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -1058,6 +1058,73 @@ describe('createConnector', () => {
     });
   });
 
+  describe('getMetadata', () => {
+    it('returns the widget metadata when getMetadata is provided', () => {
+      const getMetadata = function(props, searchState) {
+        return {
+          instanceProps: this.props,
+          providedProps: props,
+          searchState,
+        };
+      };
+
+      const Connected = createConnector({
+        displayName: 'Connector',
+        getProvidedProps: () => {},
+        getMetadata,
+      })(() => null);
+
+      const props = {
+        hello: 'there',
+      };
+
+      const searchState = {
+        query: 'hello',
+      };
+
+      const context = createFakeContext();
+
+      const wrapper = shallow(<Connected {...props} />, {
+        context,
+      });
+
+      const widgetMetadata = wrapper.instance().getMetadata(searchState);
+
+      expect(widgetMetadata).toEqual({
+        instanceProps: {
+          hello: 'there',
+        },
+        providedProps: {
+          hello: 'there',
+        },
+        searchState: {
+          query: 'hello',
+        },
+      });
+    });
+
+    it('returns an empty object when getMetadata is not provided', () => {
+      const Connected = createConnector({
+        displayName: 'Connector',
+        getProvidedProps: () => {},
+      })(() => null);
+
+      const searchState = {
+        query: 'hello',
+      };
+
+      const context = createFakeContext();
+
+      const wrapper = shallow(<Connected />, {
+        context,
+      });
+
+      const widgetMetadata = wrapper.instance().getMetadata(searchState);
+
+      expect(widgetMetadata).toEqual({});
+    });
+  });
+
   describe('refine', () => {
     it('passes a refine method to the component', () => {
       const refine = (props, searchState, next) => ({

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -1125,6 +1125,99 @@ describe('createConnector', () => {
     });
   });
 
+  describe('transitionState', () => {
+    it('returns the widget transitionState when transitionState is provided', () => {
+      const transitionState = function(
+        props,
+        previousSearchState,
+        nextSearchState
+      ) {
+        return {
+          instanceProps: this.props,
+          providedProps: props,
+          previousSearchState,
+          nextSearchState,
+        };
+      };
+
+      const Connected = createConnector({
+        displayName: 'Connector',
+        getProvidedProps: () => {},
+        transitionState,
+      })(() => null);
+
+      const props = {
+        hello: 'there',
+      };
+
+      const previousSearchState = {
+        query: 'hello',
+      };
+
+      const nextSearchState = {
+        query: 'hello again',
+      };
+
+      const context = createFakeContext();
+
+      const wrapper = shallow(<Connected {...props} />, {
+        context,
+      });
+
+      const widgetTransitionState = wrapper
+        .instance()
+        .transitionState(previousSearchState, nextSearchState);
+
+      expect(widgetTransitionState).toEqual({
+        instanceProps: {
+          hello: 'there',
+        },
+        providedProps: {
+          hello: 'there',
+        },
+        previousSearchState: {
+          query: 'hello',
+        },
+        nextSearchState: {
+          query: 'hello again',
+        },
+      });
+    });
+
+    it('returns the given next state when transitionState is not provided', () => {
+      const Connected = createConnector({
+        displayName: 'Connector',
+        getProvidedProps: () => {},
+      })(() => null);
+
+      const props = {
+        hello: 'there',
+      };
+
+      const previousSearchState = {
+        query: 'hello',
+      };
+
+      const nextSearchState = {
+        query: 'hello again',
+      };
+
+      const context = createFakeContext();
+
+      const wrapper = shallow(<Connected {...props} />, {
+        context,
+      });
+
+      const widgetTransitionState = wrapper
+        .instance()
+        .transitionState(previousSearchState, nextSearchState);
+
+      expect(widgetTransitionState).toEqual({
+        query: 'hello again',
+      });
+    });
+  });
+
   describe('refine', () => {
     it('passes a refine method to the component', () => {
       const refine = (props, searchState, next) => ({

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -968,117 +968,187 @@ describe('createConnector', () => {
 
   describe('refine', () => {
     it('passes a refine method to the component', () => {
-      const Dummy = () => null;
-      const nextState = {};
-      const widgets = {};
-      const refine = jest.fn(() => nextState);
-      const Connected = createConnector({
-        displayName: 'CoolConnector',
-        getProvidedProps: () => ({}),
-        refine,
-        getId,
-      })(Dummy);
-      const onInternalStateUpdate = jest.fn();
-      const props = { hello: 'there' };
-      const wrapper = mount(<Connected {...props} />, {
-        context: {
-          ais: {
-            store: {
-              getState: () => ({
-                widgets,
-              }),
-              subscribe: () => null,
-            },
-            onInternalStateUpdate,
-          },
-        },
+      const refine = (props, searchState, next) => ({
+        props,
+        searchState,
+        next,
       });
-      const passedProps = wrapper.find(Dummy).props();
-      const arg1 = {};
-      const arg2 = {};
-      passedProps.refine(arg1, arg2);
-      expect(refine.mock.calls[0][0]).toEqual(props);
-      expect(refine.mock.calls[0][1]).toBe(widgets);
-      expect(refine.mock.calls[0][2]).toBe(arg1);
-      expect(refine.mock.calls[0][3]).toBe(arg2);
-      expect(onInternalStateUpdate.mock.calls[0][0]).toBe(nextState);
-    });
 
-    it('passes a createURL method to the component', () => {
       const Dummy = () => null;
-      const nextState = {};
-      const widgets = {};
-      const refine = jest.fn(() => nextState);
       const Connected = createConnector({
-        displayName: 'CoolConnector',
-        getProvidedProps: () => ({}),
+        displayName: 'Connector',
+        getProvidedProps: () => {},
         refine,
-        getId,
       })(Dummy);
-      const createHrefForState = jest.fn();
-      const props = { hello: 'there' };
-      const wrapper = mount(<Connected {...props} />, {
-        context: {
-          ais: {
-            store: {
-              getState: () => ({
-                widgets,
-              }),
-              subscribe: () => null,
-            },
-            createHrefForState,
-          },
+
+      const onInternalStateUpdate = jest.fn();
+
+      const state = createFakeState({
+        widgets: {
+          query: 'hello',
         },
       });
-      const passedProps = wrapper.find(Dummy).props();
-      const arg1 = {};
-      const arg2 = {};
-      passedProps.createURL(arg1, arg2);
-      expect(refine.mock.calls[0][0]).toEqual(props);
-      expect(refine.mock.calls[0][1]).toBe(widgets);
-      expect(refine.mock.calls[0][2]).toBe(arg1);
-      expect(refine.mock.calls[0][3]).toBe(arg2);
-      expect(createHrefForState.mock.calls[0][0]).toBe(nextState);
+
+      const props = {
+        hello: 'there',
+      };
+
+      const context = createFakeContext({
+        store: createFakeStore({
+          getState: () => state,
+        }),
+        onInternalStateUpdate,
+      });
+
+      const wrapper = shallow(<Connected {...props} />, {
+        context,
+      });
+
+      expect(onInternalStateUpdate).toHaveBeenCalledTimes(0);
+
+      wrapper
+        .find(Dummy)
+        .props()
+        .refine({ query: 'hello world' });
+
+      expect(onInternalStateUpdate).toHaveBeenCalledTimes(1);
+      expect(onInternalStateUpdate).toHaveBeenCalledWith({
+        props: {
+          hello: 'there',
+        },
+        searchState: {
+          query: 'hello',
+        },
+        next: {
+          query: 'hello world',
+        },
+      });
+    });
+  });
+
+  describe('createURL', () => {
+    it('passes a createURL method to the component', () => {
+      const refine = (props, searchState, next) => ({
+        props,
+        searchState,
+        next,
+      });
+
+      const Dummy = () => null;
+      const Connected = createConnector({
+        displayName: 'Connector',
+        getProvidedProps: () => {},
+        refine,
+      })(Dummy);
+
+      const createHrefForState = jest.fn();
+
+      const state = createFakeState({
+        widgets: {
+          query: 'hello',
+        },
+      });
+
+      const props = {
+        hello: 'there',
+      };
+
+      const context = createFakeContext({
+        store: createFakeStore({
+          getState: () => state,
+        }),
+        createHrefForState,
+      });
+
+      const wrapper = shallow(<Connected {...props} />, {
+        context,
+      });
+
+      expect(createHrefForState).toHaveBeenCalledTimes(0);
+
+      wrapper
+        .find(Dummy)
+        .props()
+        .createURL({ query: 'hello world' });
+
+      expect(createHrefForState).toHaveBeenCalledTimes(1);
+      expect(createHrefForState).toHaveBeenCalledWith({
+        props: {
+          hello: 'there',
+        },
+        searchState: {
+          query: 'hello',
+        },
+        next: {
+          query: 'hello world',
+        },
+      });
     });
   });
 
   describe('searchForFacetValues', () => {
     it('passes a searchForItems method to the component', () => {
+      const searchForFacetValues = (props, searchState, next) => ({
+        props,
+        searchState,
+        next,
+      });
+
       const Dummy = () => null;
-      const searchState = {};
-      const widgets = {};
-      const searchForFacetValues = jest.fn(() => searchState);
       const Connected = createConnector({
-        displayName: 'CoolConnector',
-        getProvidedProps: () => ({}),
+        displayName: 'Connector',
+        getProvidedProps: () => {},
         searchForFacetValues,
-        getId,
       })(Dummy);
+
       const onSearchForFacetValues = jest.fn();
-      const props = { hello: 'there' };
-      const wrapper = mount(<Connected {...props} />, {
-        context: {
-          ais: {
-            store: {
-              getState: () => ({
-                widgets,
-              }),
-              subscribe: () => null,
-            },
-            onSearchForFacetValues,
-          },
+
+      const props = {
+        hello: 'there',
+      };
+
+      const state = createFakeState({
+        widgets: {
+          query: 'hello',
         },
       });
-      const passedProps = wrapper.find(Dummy).props();
-      const facetName = 'facetName';
-      const query = 'query';
 
-      passedProps.searchForItems(facetName, query);
-      expect(searchForFacetValues.mock.calls[0][0]).toEqual(props);
-      expect(searchForFacetValues.mock.calls[0][1]).toBe(widgets);
-      expect(searchForFacetValues.mock.calls[0][2]).toBe(facetName);
-      expect(searchForFacetValues.mock.calls[0][3]).toBe(query);
-      expect(onSearchForFacetValues.mock.calls[0][0]).toBe(searchState);
+      const context = createFakeContext({
+        store: createFakeStore({
+          getState: () => state,
+        }),
+        onSearchForFacetValues,
+      });
+
+      const wrapper = shallow(<Connected {...props} />, {
+        context,
+      });
+
+      expect(onSearchForFacetValues).toHaveBeenCalledTimes(0);
+
+      wrapper
+        .find(Dummy)
+        .props()
+        .searchForItems({
+          facetName: 'brand',
+          query: 'apple',
+          maxFacetHits: 10,
+        });
+
+      expect(onSearchForFacetValues).toHaveBeenCalledTimes(1);
+      expect(onSearchForFacetValues).toHaveBeenCalledWith({
+        props: {
+          hello: 'there',
+        },
+        searchState: {
+          query: 'hello',
+        },
+        next: {
+          facetName: 'brand',
+          query: 'apple',
+          maxFacetHits: 10,
+        },
+      });
     });
   });
 });

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -317,8 +317,6 @@ export default function createConnector(connectorDesc) {
           )
         );
 
-      cleanUp = (...args) => connectorDesc.cleanUp.call(this, ...args);
-
       render() {
         if (this.state.props === null) {
           return null;

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -151,9 +151,8 @@ export default function createConnector(connectorDesc) {
           });
 
           if (isWidget) {
-            // Since props might have changed, we need to re-run getSearchParameters
-            // and getMetadata with the new props.
             this.context.ais.widgetsManager.update();
+
             if (connectorDesc.transitionState) {
               this.context.ais.onSearchStateChange(
                 connectorDesc.transitionState.call(
@@ -199,10 +198,10 @@ export default function createConnector(connectorDesc) {
         }
 
         if (this.unregisterWidget) {
-          this.unregisterWidget(); // will schedule an update
+          this.unregisterWidget();
 
           if (hasCleanUp) {
-            const newState = connectorDesc.cleanUp.call(
+            const nextState = connectorDesc.cleanUp.call(
               this,
               this.props,
               this.context.ais.store.getState().widgets
@@ -210,10 +209,10 @@ export default function createConnector(connectorDesc) {
 
             this.context.ais.store.setState({
               ...this.context.ais.store.getState(),
-              widgets: newState,
+              widgets: nextState,
             });
 
-            this.context.ais.onSearchStateChange(removeEmptyKey(newState));
+            this.context.ais.onSearchStateChange(removeEmptyKey(nextState));
           }
         }
       }

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -299,16 +299,6 @@ export default function createConnector(connectorDesc) {
         );
       };
 
-      searchForFacetValues = (...args) => {
-        this.context.ais.onSearchForFacetValues(
-          connectorDesc.searchForFacetValues(
-            this.props,
-            this.context.ais.store.getState().widgets,
-            ...args
-          )
-        );
-      };
-
       createURL = (...args) =>
         this.context.ais.createHrefForState(
           connectorDesc.refine.call(
@@ -318,6 +308,16 @@ export default function createConnector(connectorDesc) {
             ...args
           )
         );
+
+      searchForFacetValues = (...args) => {
+        this.context.ais.onSearchForFacetValues(
+          connectorDesc.searchForFacetValues(
+            this.props,
+            this.context.ais.store.getState().widgets,
+            ...args
+          )
+        );
+      };
 
       render() {
         if (this.state.props === null) {

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -62,12 +62,12 @@ export default function createConnector(connectorDesc) {
       mounted = false;
       unmounting = false;
 
-      constructor(props, context) {
-        super(props, context);
+      constructor(...args) {
+        super(...args);
 
         this.state = {
           props: this.getProvidedProps({
-            ...props,
+            ...this.props,
             // @MAJOR: We cannot drop this beacuse it's a breaking change. The
             // prop is provided to `createConnector.getProvidedProps`. All the
             // custom connectors are impacted by this change. It should be fine
@@ -220,22 +220,22 @@ export default function createConnector(connectorDesc) {
 
       getProvidedProps(props) {
         const {
-          results,
-          searching,
-          error,
           widgets,
-          metadata,
+          results,
           resultsFacetValues,
+          searching,
           searchingForFacetValues,
           isSearchStalled,
+          metadata,
+          error,
         } = this.context.ais.store.getState();
 
         const searchResults = {
           results,
           searching,
-          error,
           searchingForFacetValues,
           isSearchStalled,
+          error,
         };
 
         return connectorDesc.getProvidedProps.call(
@@ -244,6 +244,9 @@ export default function createConnector(connectorDesc) {
           widgets,
           searchResults,
           metadata,
+          // @MAJOR: move this attribute on the `searchResults` it doesn't
+          // makes sense to have it into a separate argument. The search
+          // flags are on the object why not the resutls?
           resultsFacetValues
         );
       }


### PR DESCRIPTION
**Summary**

This PR does not introduce any features, it's a rewrite of the tests and small cosmetic changes inside the `createConnector` HOC (like re-order of the methods). We've added some tests to cover the widget API `getSearchParameters`, `getMetadata` and `transitionState`. The last significant change is that we dropped the method `cleanUp`. This method wasn't used since its creation. 