### PR TITLE
chore: avoid to use fake named import

### DIFF
--- a/packages/react-instantsearch-core/rollup.config.js
+++ b/packages/react-instantsearch-core/rollup.config.js
@@ -23,17 +23,7 @@ const plugins = [
     browser: true,
     preferBuiltins: false,
   }),
-  commonjs({
-    namedExports: {
-      'algoliasearch-helper': [
-        'version',
-        'AlgoliaSearchHelper',
-        'SearchParameters',
-        'SearchResults',
-        'url',
-      ],
-    },
-  }),
+  commonjs(),
   globals(),
   replace({
     'process.env.NODE_ENV': JSON.stringify('production'),

--- a/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { SearchParameters } from 'algoliasearch-helper';
+import algoliasearchHelper from 'algoliasearch-helper';
 import createConnector from '../core/createConnector';
 import {
   cleanUpValue,
@@ -38,7 +38,7 @@ function getValue(path, props, searchState, context) {
   if (currentRefinement === null) {
     nextRefinement = path;
   } else {
-    const tmpSearchParameters = new SearchParameters({
+    const tmpSearchParameters = new algoliasearchHelper.SearchParameters({
       hierarchicalFacets: [
         {
           name: id,

--- a/packages/react-instantsearch-dom-maps/rollup.config.js
+++ b/packages/react-instantsearch-dom-maps/rollup.config.js
@@ -23,17 +23,7 @@ const plugins = [
     browser: true,
     preferBuiltins: false,
   }),
-  commonjs({
-    namedExports: {
-      'algoliasearch-helper': [
-        'version',
-        'AlgoliaSearchHelper',
-        'SearchParameters',
-        'SearchResults',
-        'url',
-      ],
-    },
-  }),
+  commonjs(),
   globals(),
   replace({
     'process.env.NODE_ENV': JSON.stringify('production'),

--- a/packages/react-instantsearch-dom/rollup.config.js
+++ b/packages/react-instantsearch-dom/rollup.config.js
@@ -23,17 +23,7 @@ const plugins = [
     browser: true,
     preferBuiltins: false,
   }),
-  commonjs({
-    namedExports: {
-      'algoliasearch-helper': [
-        'version',
-        'AlgoliaSearchHelper',
-        'SearchParameters',
-        'SearchResults',
-        'url',
-      ],
-    },
-  }),
+  commonjs(),
   globals(),
   replace({
     'process.env.NODE_ENV': JSON.stringify('production'),

--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -2,10 +2,7 @@ import { isEmpty, zipWith } from 'lodash';
 import React, { Component } from 'react';
 import { renderToString } from 'react-dom/server';
 import PropTypes from 'prop-types';
-import algoliasearchHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
+import algoliasearchHelper from 'algoliasearch-helper';
 import {
   createInstantSearch,
   version,
@@ -29,7 +26,7 @@ const getSearchParameters = (indexName, searchParameters) => {
           searchParameter.props,
           searchParameter.searchState
         ),
-      new SearchParameters({
+      new algoliasearchHelper.SearchParameters({
         ...HIGHLIGHT_TAGS,
         index: indexName,
       })
@@ -191,8 +188,8 @@ const createInstantSearchServer = algoliasearch => {
         return resultsState.reduce(
           (acc, result) => ({
             ...acc,
-            [result._internalIndexId]: new SearchResults(
-              new SearchParameters(result.state),
+            [result._internalIndexId]: new algoliasearchHelper.SearchResults(
+              new algoliasearchHelper.SearchParameters(result.state),
               result._originalResponse.results
             ),
           }),
@@ -200,8 +197,8 @@ const createInstantSearchServer = algoliasearch => {
         );
       }
 
-      return new SearchResults(
-        new SearchParameters(resultsState.state),
+      return new algoliasearchHelper.SearchResults(
+        new algoliasearchHelper.SearchParameters(resultsState.state),
         resultsState._originalResponse.results
       );
     }

--- a/packages/react-instantsearch/rollup.config.js
+++ b/packages/react-instantsearch/rollup.config.js
@@ -23,17 +23,7 @@ const plugins = [
     browser: true,
     preferBuiltins: false,
   }),
-  commonjs({
-    namedExports: {
-      'algoliasearch-helper': [
-        'version',
-        'AlgoliaSearchHelper',
-        'SearchParameters',
-        'SearchResults',
-        'url',
-      ],
-    },
-  }),
+  commonjs(),
   globals(),
   replace({
     'process.env.NODE_ENV': JSON.stringify('production'),


### PR DESCRIPTION
**Summary**

Rollup is not able to find the named exports from a `cjs` module, because it's actually not "real" named exports. There is an option inside `rollup-plugin-commonjs` to fill the exports but it does fail in some occasions. The PR removes named imports for traditional default imports inside the code built with Rollup (it works for Jest).