### PR TITLE
chore: move examples to DOM package

### DIFF
--- a/examples/autocomplete/package.json
+++ b/examples/autocomplete/package.json
@@ -19,6 +19,6 @@
     "react": "16.7.0",
     "react-autosuggest": "9.3.2",
     "react-dom": "16.7.0",
-    "react-instantsearch": "5.4.0-beta.1"
+    "react-instantsearch-dom": "5.4.0-beta.1"
   }
 }

--- a/examples/autocomplete/src/App-Mentions.js
+++ b/examples/autocomplete/src/App-Mentions.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Mention from 'antd/lib/mention';
-import { InstantSearch } from 'react-instantsearch/dom';
-import { connectAutoComplete } from 'react-instantsearch/connectors';
+import { InstantSearch, connectAutoComplete } from 'react-instantsearch-dom';
 import 'antd/lib/mention/style/css';
 
 const AsyncMention = ({ hits, refine }) => (

--- a/examples/autocomplete/src/App-Multi-Index.js
+++ b/examples/autocomplete/src/App-Multi-Index.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Autosuggest from 'react-autosuggest';
 import {
   InstantSearch,
   Configure,
   Index,
   Highlight,
-} from 'react-instantsearch/dom';
-import { connectAutoComplete } from 'react-instantsearch/connectors';
-import Autosuggest from 'react-autosuggest';
+  connectAutoComplete,
+} from 'react-instantsearch-dom';
 
 const App = () => (
   <InstantSearch

--- a/examples/autocomplete/yarn.lock
+++ b/examples/autocomplete/yarn.lock
@@ -7200,7 +7200,7 @@ react-instantsearch-core@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
-react-instantsearch-dom@^5.4.0-beta.1:
+react-instantsearch-dom@5.4.0-beta.1:
   version "5.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/react-instantsearch-dom/-/react-instantsearch-dom-5.4.0-beta.1.tgz#75f466a215887a0c2ee1a649239a57602658e49d"
   integrity sha512-v+rlVD8YRE+rMUhVJvvI5tJ7OzuZcLy5DPf6342BnSXIAEfaDMuwo9L0jXkChwJh1k+Hi7JWX9dz5ZqboON3Kw==
@@ -7211,23 +7211,6 @@ react-instantsearch-dom@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
     react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch-native@^5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-native/-/react-instantsearch-native-5.4.0-beta.1.tgz#629eeda8cca93b1c52b19fa467768827e69b346a"
-  integrity sha512-FbZPEQD0csE+dff+y5Ng7fplQsojOmEmBzS2HG2HRe8knNU4ln+0IKyRae4vvvqOXI1MryrSNkb/lKMK57lFgQ==
-  dependencies:
-    algoliasearch "^3.27.1"
-    react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch@5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-5.4.0-beta.1.tgz#632bb5ca90695cb7223c36f645ef176280affced"
-  integrity sha512-cIqT7dfF3FyHQX8hW/K0a4jTztqeg0AZyBF1iJQiTRy9hviBMI6h2LkcxxqdRYblQ4ESQF5Ko7QMtqOD2kFhCg==
-  dependencies:
-    react-instantsearch-core "^5.4.0-beta.1"
-    react-instantsearch-dom "^5.4.0-beta.1"
-    react-instantsearch-native "^5.4.0-beta.1"
 
 react-lazy-load@^3.0.12:
   version "3.0.13"

--- a/examples/geo-search/package.json
+++ b/examples/geo-search/package.json
@@ -17,8 +17,7 @@
     "qs": "6.5.1",
     "react": "16.7.0",
     "react-dom": "16.7.0",
-    "react-instantsearch": "5.4.0-beta.1",
-    "react-instantsearch-dom": "5.4.0-beta.0",
-    "react-instantsearch-dom-maps": "5.4.0-beta.0"
+    "react-instantsearch-dom": "5.4.0-beta.1",
+    "react-instantsearch-dom-maps": "5.4.0-beta.1"
   }
 }

--- a/examples/geo-search/yarn.lock
+++ b/examples/geo-search/yarn.lock
@@ -6568,15 +6568,6 @@ react-error-overlay@^4.0.0:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
   integrity sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw==
 
-react-instantsearch-core@^5.4.0-beta.0:
-  version "5.4.0-beta.0"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-core/-/react-instantsearch-core-5.4.0-beta.0.tgz#8009cfd347bacbf93dde29c8689484ec9265ec71"
-  integrity sha512-5F5oVjOHvobmrxXqYCUSRErCMYvMWu88+RuqZ46DeafVOLlZLwMEGx2e4sG5kUzKVVyIpwX2aPa1e3R+F5y/aw==
-  dependencies:
-    algoliasearch-helper "^2.26.0"
-    lodash "^4.17.4"
-    prop-types "^15.5.10"
-
 react-instantsearch-core@^5.4.0-beta.1:
   version "5.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/react-instantsearch-core/-/react-instantsearch-core-5.4.0-beta.1.tgz#3e4798c6b43b9f9b1a3b09776674f54242d3b154"
@@ -6586,29 +6577,17 @@ react-instantsearch-core@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
-react-instantsearch-dom-maps@5.4.0-beta.0:
-  version "5.4.0-beta.0"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-dom-maps/-/react-instantsearch-dom-maps-5.4.0-beta.0.tgz#c32bf24beaab7c65c2bf701902cd74f322913beb"
-  integrity sha512-oO0XmUpGfaT+CNCuMXkKAa2ymIcg2VdvXWHrMOF2GNDxgNNLLWBj6eMmZBl95Rh34cYvcDRV3jaYSc0nThBhpg==
+react-instantsearch-dom-maps@5.4.0-beta.1:
+  version "5.4.0-beta.1"
+  resolved "https://registry.yarnpkg.com/react-instantsearch-dom-maps/-/react-instantsearch-dom-maps-5.4.0-beta.1.tgz#ca1b102f84c9837c58500207eaf3b239e61e5c38"
+  integrity sha512-UbSKF5D98BDNsy+kOhas1WgUWzOhXiKARAVaAkgZqAn5G6Qe35B4N0NAowbPC80bKUI0C2EUV4zAdjbhtZ9kzQ==
   dependencies:
     lodash "^4.17.4"
     prop-types "^15.5.10"
     react-lifecycles-compat "^3.0.4"
     scriptjs "^2.5.8"
 
-react-instantsearch-dom@5.4.0-beta.0:
-  version "5.4.0-beta.0"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-dom/-/react-instantsearch-dom-5.4.0-beta.0.tgz#7b30bde3004ce04e188d1ce0eda35b8368814534"
-  integrity sha512-XcImNalMPaEJ+SDAy945Q2X1L2xuLh4Kx8IJBF3+iJ+tyaLOlaKzVwppArYO36bG1k81n78kswL5fJhM9pem8A==
-  dependencies:
-    algoliasearch "^3.27.1"
-    algoliasearch-helper "^2.26.0"
-    classnames "^2.2.5"
-    lodash "^4.17.4"
-    prop-types "^15.5.10"
-    react-instantsearch-core "^5.4.0-beta.0"
-
-react-instantsearch-dom@^5.4.0-beta.1:
+react-instantsearch-dom@5.4.0-beta.1:
   version "5.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/react-instantsearch-dom/-/react-instantsearch-dom-5.4.0-beta.1.tgz#75f466a215887a0c2ee1a649239a57602658e49d"
   integrity sha512-v+rlVD8YRE+rMUhVJvvI5tJ7OzuZcLy5DPf6342BnSXIAEfaDMuwo9L0jXkChwJh1k+Hi7JWX9dz5ZqboON3Kw==
@@ -6619,23 +6598,6 @@ react-instantsearch-dom@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
     react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch-native@^5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-native/-/react-instantsearch-native-5.4.0-beta.1.tgz#629eeda8cca93b1c52b19fa467768827e69b346a"
-  integrity sha512-FbZPEQD0csE+dff+y5Ng7fplQsojOmEmBzS2HG2HRe8knNU4ln+0IKyRae4vvvqOXI1MryrSNkb/lKMK57lFgQ==
-  dependencies:
-    algoliasearch "^3.27.1"
-    react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch@5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-5.4.0-beta.1.tgz#632bb5ca90695cb7223c36f645ef176280affced"
-  integrity sha512-cIqT7dfF3FyHQX8hW/K0a4jTztqeg0AZyBF1iJQiTRy9hviBMI6h2LkcxxqdRYblQ4ESQF5Ko7QMtqOD2kFhCg==
-  dependencies:
-    react-instantsearch-core "^5.4.0-beta.1"
-    react-instantsearch-dom "^5.4.0-beta.1"
-    react-instantsearch-native "^5.4.0-beta.1"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"

--- a/examples/multi-index/package.json
+++ b/examples/multi-index/package.json
@@ -17,6 +17,6 @@
     "prop-types": "15.6.0",
     "react": "16.7.0",
     "react-dom": "16.7.0",
-    "react-instantsearch": "5.4.0-beta.1"
+    "react-instantsearch-dom": "5.4.0-beta.1"
   }
 }

--- a/examples/multi-index/src/App.js
+++ b/examples/multi-index/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InstantSearch, Hits, SearchBox, Index } from 'react-instantsearch/dom';
+import { InstantSearch, Hits, SearchBox, Index } from 'react-instantsearch-dom';
 
 const App = () => (
   <InstantSearch

--- a/examples/multi-index/yarn.lock
+++ b/examples/multi-index/yarn.lock
@@ -6118,7 +6118,7 @@ react-instantsearch-core@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
-react-instantsearch-dom@^5.4.0-beta.1:
+react-instantsearch-dom@5.4.0-beta.1:
   version "5.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/react-instantsearch-dom/-/react-instantsearch-dom-5.4.0-beta.1.tgz#75f466a215887a0c2ee1a649239a57602658e49d"
   integrity sha512-v+rlVD8YRE+rMUhVJvvI5tJ7OzuZcLy5DPf6342BnSXIAEfaDMuwo9L0jXkChwJh1k+Hi7JWX9dz5ZqboON3Kw==
@@ -6129,23 +6129,6 @@ react-instantsearch-dom@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
     react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch-native@^5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-native/-/react-instantsearch-native-5.4.0-beta.1.tgz#629eeda8cca93b1c52b19fa467768827e69b346a"
-  integrity sha512-FbZPEQD0csE+dff+y5Ng7fplQsojOmEmBzS2HG2HRe8knNU4ln+0IKyRae4vvvqOXI1MryrSNkb/lKMK57lFgQ==
-  dependencies:
-    algoliasearch "^3.27.1"
-    react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch@5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-5.4.0-beta.1.tgz#632bb5ca90695cb7223c36f645ef176280affced"
-  integrity sha512-cIqT7dfF3FyHQX8hW/K0a4jTztqeg0AZyBF1iJQiTRy9hviBMI6h2LkcxxqdRYblQ4ESQF5Ko7QMtqOD2kFhCg==
-  dependencies:
-    react-instantsearch-core "^5.4.0-beta.1"
-    react-instantsearch-dom "^5.4.0-beta.1"
-    react-instantsearch-native "^5.4.0-beta.1"
 
 react-scripts@1.1.1:
   version "1.1.1"

--- a/examples/next/components/app.js
+++ b/examples/next/components/app.js
@@ -7,7 +7,7 @@ import {
   Configure,
   Highlight,
   Pagination,
-} from 'react-instantsearch/dom';
+} from 'react-instantsearch-dom';
 import { InstantSearch } from './instantsearch';
 
 const HitComponent = ({ hit }) => (

--- a/examples/next/components/instantsearch.js
+++ b/examples/next/components/instantsearch.js
@@ -1,5 +1,3 @@
-import { createInstantSearch } from 'react-instantsearch/server';
+import { createInstantSearch } from 'react-instantsearch-dom/server';
 
-const { InstantSearch, findResultsState } = createInstantSearch();
-
-export { InstantSearch, findResultsState };
+export const { InstantSearch, findResultsState } = createInstantSearch();

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -23,6 +23,6 @@
     "qs": "6.6.0",
     "react": "16.7.0",
     "react-dom": "16.7.0",
-    "react-instantsearch": "5.4.0-beta.1"
+    "react-instantsearch-dom": "5.4.0-beta.1"
   }
 }

--- a/examples/next/yarn.lock
+++ b/examples/next/yarn.lock
@@ -4901,7 +4901,7 @@ react-instantsearch-core@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
-react-instantsearch-dom@^5.4.0-beta.1:
+react-instantsearch-dom@5.4.0-beta.1:
   version "5.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/react-instantsearch-dom/-/react-instantsearch-dom-5.4.0-beta.1.tgz#75f466a215887a0c2ee1a649239a57602658e49d"
   integrity sha512-v+rlVD8YRE+rMUhVJvvI5tJ7OzuZcLy5DPf6342BnSXIAEfaDMuwo9L0jXkChwJh1k+Hi7JWX9dz5ZqboON3Kw==
@@ -4912,23 +4912,6 @@ react-instantsearch-dom@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
     react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch-native@^5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-native/-/react-instantsearch-native-5.4.0-beta.1.tgz#629eeda8cca93b1c52b19fa467768827e69b346a"
-  integrity sha512-FbZPEQD0csE+dff+y5Ng7fplQsojOmEmBzS2HG2HRe8knNU4ln+0IKyRae4vvvqOXI1MryrSNkb/lKMK57lFgQ==
-  dependencies:
-    algoliasearch "^3.27.1"
-    react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch@5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-5.4.0-beta.1.tgz#632bb5ca90695cb7223c36f645ef176280affced"
-  integrity sha512-cIqT7dfF3FyHQX8hW/K0a4jTztqeg0AZyBF1iJQiTRy9hviBMI6h2LkcxxqdRYblQ4ESQF5Ko7QMtqOD2kFhCg==
-  dependencies:
-    react-instantsearch-core "^5.4.0-beta.1"
-    react-instantsearch-dom "^5.4.0-beta.1"
-    react-instantsearch-native "^5.4.0-beta.1"
 
 react-is@^16.6.3:
   version "16.6.3"

--- a/examples/react-router-v3/package.json
+++ b/examples/react-router-v3/package.json
@@ -19,7 +19,7 @@
     "qs": "6.5.1",
     "react": "16.7.0",
     "react-dom": "16.7.0",
-    "react-instantsearch": "5.4.0-beta.1",
+    "react-instantsearch-dom": "5.4.0-beta.1",
     "react-router": "3.0.5"
   },
   "renovate": {

--- a/examples/react-router-v3/src/App.js
+++ b/examples/react-router-v3/src/App.js
@@ -1,5 +1,8 @@
-import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+import qs from 'qs';
 import {
   InstantSearch,
   HierarchicalMenu,
@@ -11,10 +14,7 @@ import {
   RefinementList,
   SearchBox,
   ClearRefinements,
-} from 'react-instantsearch/dom';
-import { withRouter } from 'react-router';
-import qs from 'qs';
-import { isEqual } from 'lodash';
+} from 'react-instantsearch-dom';
 
 class App extends Component {
   constructor(props) {

--- a/examples/react-router-v3/yarn.lock
+++ b/examples/react-router-v3/yarn.lock
@@ -6130,7 +6130,7 @@ react-instantsearch-core@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
-react-instantsearch-dom@^5.4.0-beta.1:
+react-instantsearch-dom@5.4.0-beta.1:
   version "5.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/react-instantsearch-dom/-/react-instantsearch-dom-5.4.0-beta.1.tgz#75f466a215887a0c2ee1a649239a57602658e49d"
   integrity sha512-v+rlVD8YRE+rMUhVJvvI5tJ7OzuZcLy5DPf6342BnSXIAEfaDMuwo9L0jXkChwJh1k+Hi7JWX9dz5ZqboON3Kw==
@@ -6141,23 +6141,6 @@ react-instantsearch-dom@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
     react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch-native@^5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-native/-/react-instantsearch-native-5.4.0-beta.1.tgz#629eeda8cca93b1c52b19fa467768827e69b346a"
-  integrity sha512-FbZPEQD0csE+dff+y5Ng7fplQsojOmEmBzS2HG2HRe8knNU4ln+0IKyRae4vvvqOXI1MryrSNkb/lKMK57lFgQ==
-  dependencies:
-    algoliasearch "^3.27.1"
-    react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch@5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-5.4.0-beta.1.tgz#632bb5ca90695cb7223c36f645ef176280affced"
-  integrity sha512-cIqT7dfF3FyHQX8hW/K0a4jTztqeg0AZyBF1iJQiTRy9hviBMI6h2LkcxxqdRYblQ4ESQF5Ko7QMtqOD2kFhCg==
-  dependencies:
-    react-instantsearch-core "^5.4.0-beta.1"
-    react-instantsearch-dom "^5.4.0-beta.1"
-    react-instantsearch-native "^5.4.0-beta.1"
 
 react-router@3.0.5:
   version "3.0.5"

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -20,7 +20,7 @@
     "qs": "6.5.1",
     "react": "16.7.0",
     "react-dom": "16.7.0",
-    "react-instantsearch": "5.4.0-beta.1",
+    "react-instantsearch-dom": "5.4.0-beta.1",
     "react-router-dom": "4.2.2"
   }
 }

--- a/examples/react-router/src/App.js
+++ b/examples/react-router/src/App.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import qs from 'qs';
 import {
   InstantSearch,
   HierarchicalMenu,
@@ -10,9 +12,7 @@ import {
   RefinementList,
   SearchBox,
   ClearRefinements,
-} from 'react-instantsearch/dom';
-import PropTypes from 'prop-types';
-import qs from 'qs';
+} from 'react-instantsearch-dom';
 
 const updateAfter = 700;
 

--- a/examples/react-router/yarn.lock
+++ b/examples/react-router/yarn.lock
@@ -6109,7 +6109,7 @@ react-instantsearch-core@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
-react-instantsearch-dom@^5.4.0-beta.1:
+react-instantsearch-dom@5.4.0-beta.1:
   version "5.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/react-instantsearch-dom/-/react-instantsearch-dom-5.4.0-beta.1.tgz#75f466a215887a0c2ee1a649239a57602658e49d"
   integrity sha512-v+rlVD8YRE+rMUhVJvvI5tJ7OzuZcLy5DPf6342BnSXIAEfaDMuwo9L0jXkChwJh1k+Hi7JWX9dz5ZqboON3Kw==
@@ -6120,23 +6120,6 @@ react-instantsearch-dom@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
     react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch-native@^5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-native/-/react-instantsearch-native-5.4.0-beta.1.tgz#629eeda8cca93b1c52b19fa467768827e69b346a"
-  integrity sha512-FbZPEQD0csE+dff+y5Ng7fplQsojOmEmBzS2HG2HRe8knNU4ln+0IKyRae4vvvqOXI1MryrSNkb/lKMK57lFgQ==
-  dependencies:
-    algoliasearch "^3.27.1"
-    react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch@5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-5.4.0-beta.1.tgz#632bb5ca90695cb7223c36f645ef176280affced"
-  integrity sha512-cIqT7dfF3FyHQX8hW/K0a4jTztqeg0AZyBF1iJQiTRy9hviBMI6h2LkcxxqdRYblQ4ESQF5Ko7QMtqOD2kFhCg==
-  dependencies:
-    react-instantsearch-core "^5.4.0-beta.1"
-    react-instantsearch-dom "^5.4.0-beta.1"
-    react-instantsearch-native "^5.4.0-beta.1"
 
 react-router-dom@4.2.2:
   version "4.2.2"

--- a/examples/server-side-rendering/package.json
+++ b/examples/server-side-rendering/package.json
@@ -26,6 +26,6 @@
     "prop-types": "15.6.0",
     "react": "16.7.0",
     "react-dom": "16.7.0",
-    "react-instantsearch": "5.4.0-beta.1"
+    "react-instantsearch-dom": "5.4.0-beta.1"
   }
 }

--- a/examples/server-side-rendering/src/app/index.js
+++ b/examples/server-side-rendering/src/app/index.js
@@ -1,14 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { createInstantSearch } from 'react-instantsearch-dom/server';
 import {
   RefinementList,
   SearchBox,
   Hits,
   Configure,
-} from 'react-instantsearch/dom';
-import { createInstantSearch } from 'react-instantsearch/server';
+} from 'react-instantsearch-dom';
 
 const { InstantSearch, findResultsState } = createInstantSearch();
+
 class App extends Component {
   render() {
     const { resultsState } = this.props;

--- a/examples/server-side-rendering/yarn.lock
+++ b/examples/server-side-rendering/yarn.lock
@@ -4158,7 +4158,7 @@ react-instantsearch-core@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
-react-instantsearch-dom@^5.4.0-beta.1:
+react-instantsearch-dom@5.4.0-beta.1:
   version "5.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/react-instantsearch-dom/-/react-instantsearch-dom-5.4.0-beta.1.tgz#75f466a215887a0c2ee1a649239a57602658e49d"
   integrity sha512-v+rlVD8YRE+rMUhVJvvI5tJ7OzuZcLy5DPf6342BnSXIAEfaDMuwo9L0jXkChwJh1k+Hi7JWX9dz5ZqboON3Kw==
@@ -4169,23 +4169,6 @@ react-instantsearch-dom@^5.4.0-beta.1:
     lodash "^4.17.4"
     prop-types "^15.5.10"
     react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch-native@^5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-native/-/react-instantsearch-native-5.4.0-beta.1.tgz#629eeda8cca93b1c52b19fa467768827e69b346a"
-  integrity sha512-FbZPEQD0csE+dff+y5Ng7fplQsojOmEmBzS2HG2HRe8knNU4ln+0IKyRae4vvvqOXI1MryrSNkb/lKMK57lFgQ==
-  dependencies:
-    algoliasearch "^3.27.1"
-    react-instantsearch-core "^5.4.0-beta.1"
-
-react-instantsearch@5.4.0-beta.1:
-  version "5.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-5.4.0-beta.1.tgz#632bb5ca90695cb7223c36f645ef176280affced"
-  integrity sha512-cIqT7dfF3FyHQX8hW/K0a4jTztqeg0AZyBF1iJQiTRy9hviBMI6h2LkcxxqdRYblQ4ESQF5Ko7QMtqOD2kFhCg==
-  dependencies:
-    react-instantsearch-core "^5.4.0-beta.1"
-    react-instantsearch-dom "^5.4.0-beta.1"
-    react-instantsearch-native "^5.4.0-beta.1"
 
 react-test-renderer@16.2.0:
   version "16.2.0"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -134,12 +134,7 @@ yarn
 yarn upgrade react-instantsearch-dom@$newVersion -D
 yarn upgrade react-instantsearch-dom-maps@$newVersion -D
 
-for example in examples/* ; do
-  (
-    cd $example
-    yarn upgrade react-instantsearch@$newVersion
-  )
-done
+node scripts/update-examples.js $newVersion
 
 commitMessage="chore(deps): update examples to react-instantsearch v$newVersion"
 git add examples package.json yarn.lock

--- a/scripts/update-examples.js
+++ b/scripts/update-examples.js
@@ -1,0 +1,40 @@
+const glob = require('glob');
+const execSync = require('child_process').execSync;
+const [version] = process.argv.slice(2);
+
+{
+  // Update React InstantSearch DOM
+  const packages = glob.sync('examples/!(react-native*)');
+
+  packages.forEach(path => {
+    execSync(`cd ${path} && yarn upgrade react-instantsearch-dom@${version}`, {
+      stdio: 'inherit',
+    });
+  });
+}
+
+{
+  // Update React InstantSearch Native
+  const packages = glob.sync('examples/+(react-native*)');
+
+  packages.forEach(path => {
+    // @TODO: update to react-instantsearch-native
+    execSync(`cd ${path} && yarn upgrade react-instantsearch@${version}`, {
+      stdio: 'inherit',
+    });
+  });
+}
+
+{
+  // Update React InstantSearch DOM Maps
+  const packages = glob.sync('examples/geo-search');
+
+  packages.forEach(path => {
+    execSync(
+      `cd ${path} && yarn upgrade react-instantsearch-dom-maps@${version}`,
+      {
+        stdio: 'inherit',
+      }
+    );
+  });
+}


### PR DESCRIPTION
**Summary**

This PR move the example on the DOM package. The React Native one haven't been updated yet 
because they does not run anymore. I'll update them separately to a newer version of Expo. 

Now that the packages used in the examples differ we have to update them independently at release time. I've create a basic script to support that. Note that once the example are on the workspaces the script can be removed ~~because Renovate will be in charge of the update~~ because Lerna will take of them.