### PR TITLE
chore: disable pinned dependencies for types

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,16 @@
     "config:js-lib",
     ":automergeMinor",
     ":automergePr"
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "^@types"
+      ],
+      "depTypeList": [
+        "devDependencies"
+      ],
+      "rangeStrategy": "replace"
+    }
   ]
 }


### PR DESCRIPTION
**Summary**

This PR (should) closes #1925. 

We use `:config:js-lib` preset that overrides the default options with [`:pinOnlyDevDependencies`](https://renovatebot.com/docs/presets-default/#pinonlydevdependencies). For `@types/xxx` dependencies it's easier to have range. It avoids issue with duplicate identifier.