### PR TITLE
Allow for custom input classes & disabling the control buttons

### DIFF
--- a/packages/react-instantsearch-dom/src/components/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/SearchBox.js
@@ -61,6 +61,7 @@ class SearchBox extends Component {
   static propTypes = {
     currentRefinement: PropTypes.string,
     className: PropTypes.string,
+    inputClassName: PropTypes.string,
     refine: PropTypes.func.isRequired,
     translate: PropTypes.func.isRequired,
 
@@ -81,6 +82,7 @@ class SearchBox extends Component {
 
     isSearchStalled: PropTypes.bool,
     showLoadingIndicator: PropTypes.bool,
+    showControls: PropTypes.bool
 
     // For testing purposes
     __inputRef: PropTypes.func,
@@ -220,11 +222,13 @@ class SearchBox extends Component {
   render() {
     const {
       className,
+      inputClassName,
       translate,
       autoFocus,
       loadingIndicator,
       submit,
       reset,
+      showControls
     } = this.props;
     const query = this.getQuery();
 
@@ -270,21 +274,25 @@ class SearchBox extends Component {
             {...searchInputEvents}
             className={cx('input')}
           />
-          <button
-            type="submit"
-            title={translate('submitTitle')}
-            className={cx('submit')}
-          >
-            {submit}
-          </button>
-          <button
-            type="reset"
-            title={translate('resetTitle')}
-            className={cx('reset')}
-            hidden={!query || isSearchStalled}
-          >
-            {reset}
-          </button>
+          {showControls &&
+             <>
+              <button
+                type="submit"
+                title={translate('submitTitle')}
+                className={`${cx('submit')} ${inputClassName}`}
+              >
+                {submit}
+              </button>
+              <button
+                type="reset"
+                title={translate('resetTitle')}
+                className={cx('reset')}
+                hidden={!query || isSearchStalled}
+              >
+                {reset}
+              </button>
+             </>
+          }
           {this.props.showLoadingIndicator && (
             <span hidden={!isSearchStalled} className={cx('loadingIndicator')}>
               {loadingIndicator}


### PR DESCRIPTION
**Purpose of this PR is to communicate some enhancements that could potentially be useful to many devs that use CSS frameworks or have specific design preferences. I unfortunately did not have time to review your contributing guides...**

When you use a framework like Bulma, you need a className of `input` for your `<input />` elements, or the styling would not show.

Also once you do add that class, the reset button for the input appears as well.

Let me know if you found this proposal useful.