### PR TITLE
docs: update link community -> algolia/doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@ This new version introduce a complete revamp of the naming and the HTML output o
 
 This release also introduces a new CSS naming convention which will be reused across all InstantSearch libraries. This will enable the possibility to develop cross-libraries CSS themes easily.
 
-You can find all the informations for the migration [in our documentation](https://community.algolia.com/react-instantsearch/guide/Migration_guide_v5.html).
+You can find all the informations for the migration [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/#upgrade-from-v4-to-v5).
 
 
 
@@ -254,7 +254,7 @@ This new version introduce a complete revamp of the naming and the HTML output o
 
 This release also introduces a new CSS naming convention which will be reused across all InstantSearch libraries. This will enable the possibility to develop cross-libraries CSS themes easily.
 
-You can find all the informations for the migration [in our documentation](https://community.algolia.com/react-instantsearch/guide/Migration_guide_v5.html).
+You can find all the informations for the migration [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/#upgrade-from-v4-to-v5).
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://community.algolia.com/react-instantsearch">
+  <a href="https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/">
     <img alt="React InstantSearch" src="./docgen/assets/img/InstantSearch-React-medal.svg" width="250">
   </a>
 </p>
@@ -13,15 +13,14 @@ To run this project, you will need:
 
 ## Development
 
-We use the [documentation website][website] as the main way to develop React InstantSearch.
+We use the [Storybook](https://storybook.js.org/) as the main way to develop React InstantSearch.
 
 ```sh
 yarn
 yarn start
 ```
 
-Go to <http://localhost:3000> for the documentation website.
-Go to <http://localhost:6006> for Storybook.
+Go to <http://localhost:6006>.
 
 The applications won't reload on code change. To enable the watch mode, run the following command in another tab.
 
@@ -84,7 +83,3 @@ yarn docs:deploy-preview
 ```
 
 This uses [netlify](https://www.netlify.com).
-
-<!-- Links -->
-
-[website]: https://community.algolia.com/react-instantsearch

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://community.algolia.com/react-instantsearch">
+  <a href="https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/">
     <img alt="React InstantSearch" src="./docgen/assets/img/InstantSearch-React-medal.svg" width="250">
   </a>
 
@@ -66,11 +66,11 @@ const App = () => (
   </a>
 </p>
 
-To learn more about the library, follow the [getting started guide](https://community.algolia.com/react-instantsearch/Getting_started.html).
+To learn more about the library, follow the [getting started guide][doc-getting-started].
 
 ## Documentation
 
-The documentation is available at [community.algolia.com/react-instantsearch][website].
+The documentation is available on [algolia.com/doc][doc].
 
 ## Demos
 
@@ -78,13 +78,13 @@ The documentation is available at [community.algolia.com/react-instantsearch][we
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <a href="https://community.algolia.com/react-instantsearch/examples/e-commerce/"><img src="./docgen/src/images/examples/e-commerce.png" width="250" alt="E-commerce demo preview"></a> | <a href="https://community.algolia.com/react-instantsearch/examples/media/"><img src="./docgen/src/images/examples/media.png" width="250" alt="Media demo preview"></a> | <a href="https://community.algolia.com/react-instantsearch/examples/tourism/"><img src="./docgen/src/images/examples/tourism.png" width="250" alt="Tourism demo preview"></a> |
 
-See more examples [on the website](https://community.algolia.com/react-instantsearch/examples/Demos.html).
+See more examples [on the website][doc-demos].
 
 ## Playground
 
-You can get to know React InstantSearch on [this playground](https://codesandbox.io/s/github/algolia/create-instantsearch-app/tree/templates/react-instantsearch).
+You can get to know React InstantSearch on [this playground][doc-playground].
 
-Start by [adding components](https://community.algolia.com/react-instantsearch/Getting_started.html#add-the-%3Cinstantsearch%3E-component) and tweaking the display. Once you get more familiar with the library, you can learn more advanced concepts in [our guides](https://community.algolia.com/react-instantsearch/guide/).
+Start by [adding components][doc-getting-started] and tweaking the display. Once you get more familiar with the library, you can learn more advanced concepts in [our guides][doc-guides].
 
 ## Contributing
 
@@ -96,7 +96,11 @@ React InstantSearch is [MIT licensed](LICENSE).
 
 <!-- Links -->
 
-[website]: https://community.algolia.com/react-instantsearch
+[doc]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/
+[doc-getting-started]: https://www.algolia.com/doc/guides/building-search-ui/getting-started/react/
+[doc-guides]: https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/react/
+[doc-demos]: https://www.algolia.com/doc/guides/building-search-ui/resources/demos/react/
+[doc-playground]: https://codesandbox.io/s/github/algolia/create-instantsearch-app/tree/templates/react-instantsearch
 [algolia-website]: https://www.algolia.com/
 [instantsearch.js-github]: https://github.com/algolia/instantsearch.js
 [instantsearch-android-github]: https://github.com/algolia/instantsearch-android

--- a/examples/autocomplete/README.md
+++ b/examples/autocomplete/README.md
@@ -20,4 +20,4 @@ yarn start
 ```
 
 
-Read more about `react-instantsearch` [in our documentation](https://community.algolia.com/react-instantsearch/).
+Read more about `react-instantsearch` [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/).

--- a/examples/geo-search/README.md
+++ b/examples/geo-search/README.md
@@ -13,4 +13,4 @@ yarn install --no-lockfile
 yarn start
 ```
 
-Read more about `react-instantsearch` [in our documentation](https://community.algolia.com/react-instantsearch/).
+Read more about `react-instantsearch` [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/).

--- a/examples/multi-index/README.md
+++ b/examples/multi-index/README.md
@@ -13,4 +13,4 @@ yarn install --no-lockfile
 yarn start
 ```
 
-Read more about `react-instantsearch` [in our documentation](https://community.algolia.com/react-instantsearch/).
+Read more about `react-instantsearch` [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/).

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -13,4 +13,4 @@ yarn install --no-lockfile
 yarn run dev
 ```
 
-Read more about `react-instantsearch` [in our documentation](https://community.algolia.com/react-instantsearch/).
+Read more about `react-instantsearch` [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/).

--- a/examples/react-native-query-suggestions/Readme.md
+++ b/examples/react-native-query-suggestions/Readme.md
@@ -23,6 +23,6 @@ yarn run ios //to see the app running on the ios simulator
 yarn run android //to see the app running on the android emulator
 ```
 
-Read more about `react-instantsearch` [in our documentation](https://community.algolia.com/react-instantsearch/).
+Read more about `react-instantsearch` [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/).
 
 Read more about `react-native` and how to run projects in [their documentation](https://facebook.github.io/react-native/docs/getting-started.html).

--- a/examples/react-native-query-suggestions/app.json
+++ b/examples/react-native-query-suggestions/app.json
@@ -1,11 +1,13 @@
 {
   "expo": {
     "name": "Algolia Query Suggestions with React InstantSearch",
-    "description":
-      "Showcase the Algolia Search Experience with Query Suggestions inside a React Native application. \n\n => Code can be found at https://github.com/algolia/react-instantsearch/tree/master/examples/react-native-query-suggestions \n\n => See React InstantSearch documentation website at https://community.algolia.com/react-instantsearch/ \n\n Setuping Query Suggestions on your Algolia Application, read https://www.algolia.com/doc/guides/analytics/query-suggestions/",
+    "description": "Showcase the Algolia Search Experience with Query Suggestions inside a React Native application. \n\n => Code can be found at https://github.com/algolia/react-instantsearch/tree/master/examples/react-native-query-suggestions \n\n => See React InstantSearch documentation website at https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/ \n\n Setuping Query Suggestions on your Algolia Application, read https://www.algolia.com/doc/guides/analytics/query-suggestions/",
     "slug": "algolia-query-suggestions-ris",
     "sdkVersion": "25.0.0",
-    "platforms": ["ios", "android"],
+    "platforms": [
+      "ios",
+      "android"
+    ],
     "privacy": "public",
     "version": "1.0.0",
     "orientation": "portrait",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -20,6 +20,6 @@ yarn run ios //to see the app running on the ios simulator
 yarn run android //to see the app running on the android emulator
 ```
 
-Read more about `react-instantsearch` [in our documentation](https://community.algolia.com/react-instantsearch/).
+Read more about `react-instantsearch` [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/).
 
 Read more about `react-native` and how to run projects in [their documentation](https://facebook.github.io/react-native/docs/getting-started.html).

--- a/examples/react-native/app.json
+++ b/examples/react-native/app.json
@@ -2,8 +2,7 @@
   "expo": {
     "sdkVersion": "25.0.0",
     "name": "React InstantSearch for React Native",
-    "description":
-      "Showcase the Algolia Search Experience inside a React Native application. \n\n => Code can be found at https://github.com/algolia/react-instantsearch/tree/master/examples/react-native \n\n => See React InstantSearch documentation website at https://community.algolia.com/react-instantsearch/",
+    "description": "Showcase the Algolia Search Experience inside a React Native application. \n\n => Code can be found at https://github.com/algolia/react-instantsearch/tree/master/examples/react-native \n\n => See React InstantSearch documentation website at https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/",
     "slug": "algolia-react-instantsearch",
     "orientation": "portrait",
     "privacy": "public",

--- a/examples/react-router-v3/README.md
+++ b/examples/react-router-v3/README.md
@@ -14,4 +14,4 @@ yarn install --no-lockfile
 yarn start
 ```
 
-Read more about react-instantsearch [in our documentation](https://community.algolia.com/react-instantsearch/).
+Read more about react-instantsearch [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/).

--- a/examples/react-router/README.md
+++ b/examples/react-router/README.md
@@ -14,4 +14,4 @@ yarn install --no-lockfile
 yarn start
 ```
 
-Read more about react-instantsearch [in our documentation](https://community.algolia.com/react-instantsearch/).
+Read more about react-instantsearch [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/).

--- a/examples/server-side-rendering/README.md
+++ b/examples/server-side-rendering/README.md
@@ -13,6 +13,6 @@ yarn install --no-lockfile
 yarn start
 ```
 
-Read more about react-instantsearch [in our documentation](https://community.algolia.com/react-instantsearch/).
+Read more about react-instantsearch [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/).
 
 This example was made possible thanks to https://github.com/Roilan/react-server-boilerplate.

--- a/packages/react-instantsearch-core/README.md
+++ b/packages/react-instantsearch-core/README.md
@@ -2,4 +2,4 @@
 
 This is the [React](https://facebook.github.io/react) version of Algolia's `instantsearch` library.
 
-Go to the [React InstantSearch website](https://community.algolia.com/react-instantsearch) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.
+Go to the [React InstantSearch website](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -6,7 +6,7 @@
   "module": "dist/es/index.js",
   "sideEffects": false,
   "license": "MIT",
-  "homepage": "https://community.algolia.com/react-instantsearch",
+  "homepage": "https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/",
   "repository": {
     "type": "git",
     "url": "https://github.com/algolia/react-instantsearch"

--- a/packages/react-instantsearch-core/rollup.config.js
+++ b/packages/react-instantsearch-core/rollup.config.js
@@ -10,8 +10,7 @@ const clear = x => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link =
-  'https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/';
+const link = 'https://github.com/algolia/react-instantsearch';
 const createLicence = name =>
   `/*! React InstantSearch${name} ${version} | ${algolia} | ${link} */`;
 

--- a/packages/react-instantsearch-core/rollup.config.js
+++ b/packages/react-instantsearch-core/rollup.config.js
@@ -10,7 +10,8 @@ const clear = x => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link = 'https://community.algolia.com/react-instantsearch';
+const link =
+  'https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/';
 const createLicence = name =>
   `/*! React InstantSearch${name} ${version} | ${algolia} | ${link} */`;
 

--- a/packages/react-instantsearch-core/src/core/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/createConnector.js
@@ -100,9 +100,9 @@ export default function createConnector(connectorDesc) {
                 ' the `connectStateResults` connector that you should use instead. The `createConnector` API will be ' +
                 'soon deprecated and will break in future next major versions.' +
                 '\n\n' +
-                'See more at https://community.algolia.com/react-instantsearch/connectors/connectStateResults.html' +
+                'See more at https://www.algolia.com/doc/api-reference/widgets/state-results/react/' +
                 '\n' +
-                'and https://community.algolia.com/react-instantsearch/guide/Conditional_display.html'
+                'and https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-display/react/'
             );
           }
         }

--- a/packages/react-instantsearch-dom-maps/README.md
+++ b/packages/react-instantsearch-dom-maps/README.md
@@ -2,4 +2,4 @@
 
 This is the geo search wiget for the [React](https://facebook.github.io/react) version of Algolia's `instantsearch` library.
 
-Go to the [React InstantSearch website](https://community.algolia.com/react-instantsearch) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.
+Go to the [React InstantSearch website](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.

--- a/packages/react-instantsearch-dom-maps/package.json
+++ b/packages/react-instantsearch-dom-maps/package.json
@@ -6,7 +6,7 @@
   "module": "dist/es/index.js",
   "sideEffects": false,
   "license": "MIT",
-  "homepage": "https://community.algolia.com/react-instantsearch",
+  "homepage": "https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/",
   "repository": {
     "type": "git",
     "url": "https://github.com/algolia/react-instantsearch"

--- a/packages/react-instantsearch-dom-maps/rollup.config.js
+++ b/packages/react-instantsearch-dom-maps/rollup.config.js
@@ -10,8 +10,7 @@ const clear = x => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link =
-  'https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/';
+const link = 'https://github.com/algolia/react-instantsearch';
 const createLicence = name =>
   `/*! React InstantSearch${name} ${version} | ${algolia} | ${link} */`;
 

--- a/packages/react-instantsearch-dom-maps/rollup.config.js
+++ b/packages/react-instantsearch-dom-maps/rollup.config.js
@@ -10,7 +10,8 @@ const clear = x => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link = 'https://community.algolia.com/react-instantsearch';
+const link =
+  'https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/';
 const createLicence = name =>
   `/*! React InstantSearch${name} ${version} | ${algolia} | ${link} */`;
 

--- a/packages/react-instantsearch-dom/README.md
+++ b/packages/react-instantsearch-dom/README.md
@@ -2,4 +2,4 @@
 
 This is the [React](https://facebook.github.io/react) version of Algolia's `instantsearch` library.
 
-Go to the [React InstantSearch website](https://community.algolia.com/react-instantsearch) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.
+Go to the [React InstantSearch website](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -6,7 +6,7 @@
   "module": "dist/es/index.js",
   "sideEffects": false,
   "license": "MIT",
-  "homepage": "https://community.algolia.com/react-instantsearch",
+  "homepage": "https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/",
   "repository": {
     "type": "git",
     "url": "https://github.com/algolia/react-instantsearch"

--- a/packages/react-instantsearch-dom/rollup.config.js
+++ b/packages/react-instantsearch-dom/rollup.config.js
@@ -10,8 +10,7 @@ const clear = x => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link =
-  'https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/';
+const link = 'https://github.com/algolia/react-instantsearch';
 const createLicence = name =>
   `/*! React InstantSearch${name} ${version} | ${algolia} | ${link} */`;
 

--- a/packages/react-instantsearch-dom/rollup.config.js
+++ b/packages/react-instantsearch-dom/rollup.config.js
@@ -10,7 +10,8 @@ const clear = x => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link = 'https://community.algolia.com/react-instantsearch';
+const link =
+  'https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/';
 const createLicence = name =>
   `/*! React InstantSearch${name} ${version} | ${algolia} | ${link} */`;
 

--- a/packages/react-instantsearch-dom/src/widgets/RangeSlider.js
+++ b/packages/react-instantsearch-dom/src/widgets/RangeSlider.js
@@ -90,9 +90,9 @@ export default () => (
     <a
       target="_blank"
       rel="noopener noreferrer"
-      href="https://community.algolia.com/react-instantsearch/widgets/RangeSlider.html"
+      href="https://www.algolia.com/doc/api-reference/widgets/range-slider/react/"
     >
-      https://community.algolia.com/react-instantsearch/widgets/RangeSlider.html
+      https://www.algolia.com/doc/api-reference/widgets/range-slider/react/
     </a>
   </div>
 );

--- a/packages/react-instantsearch-native/README.md
+++ b/packages/react-instantsearch-native/README.md
@@ -2,4 +2,4 @@
 
 This is the [React Native](https://facebook.github.io/react-native) version of Algolia's `instantsearch` library.
 
-Go to the [React InstantSearch website](https://community.algolia.com/react-instantsearch) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.
+Go to the [React InstantSearch website](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.

--- a/packages/react-instantsearch-native/package.json
+++ b/packages/react-instantsearch-native/package.json
@@ -6,7 +6,7 @@
   "module": "dist/es/index.js",
   "sideEffects": false,
   "license": "MIT",
-  "homepage": "https://community.algolia.com/react-instantsearch",
+  "homepage": "https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/",
   "repository": {
     "type": "git",
     "url": "https://github.com/algolia/react-instantsearch"

--- a/packages/react-instantsearch/README.md
+++ b/packages/react-instantsearch/README.md
@@ -2,4 +2,4 @@
 
 This is the [React](https://facebook.github.io/react) version of Algolia's `instantsearch` library.
 
-Go to the [React InstantSearch website](https://community.algolia.com/react-instantsearch) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.
+Go to the [React InstantSearch website](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/) or the [React InstantSearch GitHub repository](https://github.com/algolia/react-instantsearch) for more information.

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -6,7 +6,7 @@
   "module": "es/index.js",
   "sideEffects": false,
   "license": "MIT",
-  "homepage": "https://community.algolia.com/react-instantsearch",
+  "homepage": "https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/",
   "repository": {
     "type": "git",
     "url": "https://github.com/algolia/react-instantsearch"

--- a/packages/react-instantsearch/rollup.config.js
+++ b/packages/react-instantsearch/rollup.config.js
@@ -10,8 +10,7 @@ const clear = x => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link =
-  'https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/';
+const link = 'https://github.com/algolia/react-instantsearch';
 const createLicence = () =>
   `/*! React InstantSearch ${version} | ${algolia} | ${link} */`;
 

--- a/packages/react-instantsearch/rollup.config.js
+++ b/packages/react-instantsearch/rollup.config.js
@@ -10,7 +10,8 @@ const clear = x => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link = 'https://community.algolia.com/react-instantsearch';
+const link =
+  'https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/';
 const createLicence = () =>
   `/*! React InstantSearch ${version} | ${algolia} | ${link} */`;
 


### PR DESCRIPTION
**Summary**

This PR replaces the link to `community.algolia.com` to `algolia.com/doc`. The documentation source code is not updated because it will be removed and inaccessible soon.