### PR TITLE
feat(DOMMaps): expose withGoogleMaps HOC [PART-1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/classnames": "^2.2.7",
     "@types/enzyme": "^3.1.15",
     "@types/enzyme-adapter-react-16": "^1.0.3",
+    "@types/googlemaps": "^3.30.16",
     "@types/jest": "^24.0.0",
     "@types/prop-types": "^15.5.8",
     "@types/react": "^16.7.18",

--- a/packages/react-instantsearch-dom-maps/src/Control.js
+++ b/packages/react-instantsearch-dom-maps/src/Control.js
@@ -2,12 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { createClassNames, translatable } from 'react-instantsearch-dom';
 import { STATE_CONTEXT } from './Provider';
-import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+import withGoogleMaps from './withGoogleMaps';
 
 const cx = createClassNames('GeoSearch');
 
 export class Control extends Component {
   static propTypes = {
+    googleMapsInstance: PropTypes.object.isRequired,
     translate: PropTypes.func.isRequired,
   };
 
@@ -18,22 +19,14 @@ export class Control extends Component {
       hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
       refineWithInstance: PropTypes.func.isRequired,
     }).isRequired,
-    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
-      instance: PropTypes.object.isRequired,
-    }).isRequired,
   };
 
   getStateContext() {
     return this.context[STATE_CONTEXT];
   }
 
-  getGoogleMapsContext() {
-    return this.context[GOOGLE_MAPS_CONTEXT];
-  }
-
   render() {
-    const { translate } = this.props;
-    const { instance } = this.getGoogleMapsContext();
+    const { googleMapsInstance, translate } = this.props;
     const {
       isRefineOnMapMove,
       hasMapMoveSinceLastRefine,
@@ -56,7 +49,7 @@ export class Control extends Component {
         ) : (
           <button
             className={cx('redo')}
-            onClick={() => refineWithInstance(instance)}
+            onClick={() => refineWithInstance(googleMapsInstance)}
           >
             {translate('redo')}
           </button>
@@ -69,4 +62,4 @@ export class Control extends Component {
 export default translatable({
   control: 'Search as I move the map',
   redo: 'Redo search here',
-})(Control);
+})(withGoogleMaps(Control));

--- a/packages/react-instantsearch-dom-maps/src/CustomMarker.js
+++ b/packages/react-instantsearch-dom-maps/src/CustomMarker.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import createHTMLMarker from './elements/createHTMLMarker';
 import { registerEvents, createListenersPropTypes } from './utils';
 import { GeolocHitPropType } from './propTypes';
-import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+import withGoogleMaps from './withGoogleMaps';
 
 const eventTypes = {
   onClick: 'click',
@@ -18,22 +18,17 @@ const eventTypes = {
   onMouseUp: 'mouseup',
 };
 
-class CustomMarker extends Component {
+export class CustomMarker extends Component {
   static propTypes = {
     ...createListenersPropTypes(eventTypes),
     hit: GeolocHitPropType.isRequired,
     children: PropTypes.node.isRequired,
+    google: PropTypes.object.isRequired,
+    googleMapsInstance: PropTypes.object.isRequired,
     className: PropTypes.string,
     anchor: PropTypes.shape({
       x: PropTypes.number.isRequired,
       y: PropTypes.number.isRequired,
-    }),
-  };
-
-  static contextTypes = {
-    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
-      google: PropTypes.object,
-      instance: PropTypes.object,
     }),
   };
 
@@ -54,15 +49,14 @@ class CustomMarker extends Component {
   };
 
   componentDidMount() {
-    const { hit, className, anchor } = this.props;
-    const { google, instance } = this.context[GOOGLE_MAPS_CONTEXT];
+    const { hit, google, googleMapsInstance, className, anchor } = this.props;
     // Not the best way to create the reference of the CustomMarker
     // but since the Google object is required didn't find another
     // solution. Ideas?
     const Marker = createHTMLMarker(google);
 
     const marker = new Marker({
-      map: instance,
+      map: googleMapsInstance,
       position: hit._geoloc,
       className,
       anchor,
@@ -114,4 +108,4 @@ class CustomMarker extends Component {
   }
 }
 
-export default CustomMarker;
+export default withGoogleMaps(CustomMarker);

--- a/packages/react-instantsearch-dom-maps/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-maps/src/GoogleMaps.js
@@ -5,8 +5,6 @@ import { LatLngPropType, BoundingBoxPropType } from './propTypes';
 
 const cx = createClassNames('GeoSearch');
 
-export const GOOGLE_MAPS_CONTEXT = '__ais_geo_search__google_maps__';
-
 class GoogleMaps extends Component {
   static propTypes = {
     google: PropTypes.object.isRequired,
@@ -22,7 +20,8 @@ class GoogleMaps extends Component {
   };
 
   static childContextTypes = {
-    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+    // eslint-disable-next-line camelcase
+    __ais_geo_search__google_maps__: PropTypes.shape({
       google: PropTypes.object,
       instance: PropTypes.object,
     }),
@@ -40,7 +39,8 @@ class GoogleMaps extends Component {
     const { google } = this.props;
 
     return {
-      [GOOGLE_MAPS_CONTEXT]: {
+      // eslint-disable-next-line camelcase
+      __ais_geo_search__google_maps__: {
         instance: this.instance,
         google,
       },

--- a/packages/react-instantsearch-dom-maps/src/Marker.js
+++ b/packages/react-instantsearch-dom-maps/src/Marker.js
@@ -6,7 +6,7 @@ import {
   createFilterProps,
 } from './utils';
 import { GeolocHitPropType } from './propTypes';
-import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+import withGoogleMaps from './withGoogleMaps';
 
 const eventTypes = {
   onClick: 'click',
@@ -20,26 +20,20 @@ const eventTypes = {
 const excludes = ['children'].concat(Object.keys(eventTypes));
 const filterProps = createFilterProps(excludes);
 
-class Marker extends Component {
+export class Marker extends Component {
   static propTypes = {
     ...createListenersPropTypes(eventTypes),
+    google: PropTypes.object.isRequired,
+    googleMapsInstance: PropTypes.object.isRequired,
     hit: GeolocHitPropType.isRequired,
   };
 
-  static contextTypes = {
-    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
-      google: PropTypes.object,
-      instance: PropTypes.object,
-    }),
-  };
-
   componentDidMount() {
-    const { hit, ...props } = this.props;
-    const { google, instance } = this.context[GOOGLE_MAPS_CONTEXT];
+    const { google, googleMapsInstance, hit, ...props } = this.props;
 
     this.instance = new google.maps.Marker({
       ...filterProps(props),
-      map: instance,
+      map: googleMapsInstance,
       position: hit._geoloc,
     });
 
@@ -69,4 +63,4 @@ class Marker extends Component {
   }
 }
 
-export default Marker;
+export default withGoogleMaps(Marker);

--- a/packages/react-instantsearch-dom-maps/src/Redo.js
+++ b/packages/react-instantsearch-dom-maps/src/Redo.js
@@ -2,12 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { createClassNames, translatable } from 'react-instantsearch-dom';
 import { STATE_CONTEXT } from './Provider';
-import { GOOGLE_MAPS_CONTEXT } from './GoogleMaps';
+import withGoogleMaps from './withGoogleMaps';
 
 const cx = createClassNames('GeoSearch');
 
 export class Redo extends Component {
   static propTypes = {
+    googleMapsInstance: PropTypes.object.isRequired,
     translate: PropTypes.func.isRequired,
   };
 
@@ -16,22 +17,14 @@ export class Redo extends Component {
       hasMapMoveSinceLastRefine: PropTypes.bool.isRequired,
       refineWithInstance: PropTypes.func.isRequired,
     }).isRequired,
-    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
-      instance: PropTypes.object.isRequired,
-    }).isRequired,
   };
 
   getStateContext() {
     return this.context[STATE_CONTEXT];
   }
 
-  getGoogleMapsContext() {
-    return this.context[GOOGLE_MAPS_CONTEXT];
-  }
-
   render() {
-    const { translate } = this.props;
-    const { instance } = this.getGoogleMapsContext();
+    const { googleMapsInstance, translate } = this.props;
     const {
       hasMapMoveSinceLastRefine,
       refineWithInstance,
@@ -42,7 +35,7 @@ export class Redo extends Component {
         <button
           className={cx('redo', !hasMapMoveSinceLastRefine && 'redo--disabled')}
           disabled={!hasMapMoveSinceLastRefine}
-          onClick={() => refineWithInstance(instance)}
+          onClick={() => refineWithInstance(googleMapsInstance)}
         >
           {translate('redo')}
         </button>
@@ -53,4 +46,4 @@ export class Redo extends Component {
 
 export default translatable({
   redo: 'Redo search here',
-})(Redo);
+})(withGoogleMaps(Redo));

--- a/packages/react-instantsearch-dom-maps/src/__tests__/Control.js
+++ b/packages/react-instantsearch-dom-maps/src/__tests__/Control.js
@@ -3,13 +3,13 @@ import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createFakeMapInstance } from '../../test/mockGoogleMaps';
 import { STATE_CONTEXT } from '../Provider';
-import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
 import { Control } from '../Control';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('Control', () => {
   const defaultProps = {
+    googleMapsInstance: createFakeMapInstance(),
     translate: x => x,
   };
 
@@ -20,13 +20,9 @@ describe('Control', () => {
       toggleRefineOnMapMove: () => {},
       refineWithInstance: () => {},
     },
-    [GOOGLE_MAPS_CONTEXT]: {
-      instance: createFakeMapInstance(),
-    },
   };
 
   const getStateContext = context => context[STATE_CONTEXT];
-  const getGoogleMapsContext = context => context[GOOGLE_MAPS_CONTEXT];
 
   it('expect to render correctly with refine on map move', () => {
     const props = {
@@ -116,10 +112,11 @@ describe('Control', () => {
   });
 
   it('expect to call refineWithInstance on button click', () => {
-    const instance = createFakeMapInstance();
+    const mapInstance = createFakeMapInstance();
 
     const props = {
       ...defaultProps,
+      googleMapsInstance: mapInstance,
     };
 
     const context = {
@@ -129,10 +126,6 @@ describe('Control', () => {
         isRefineOnMapMove: false,
         hasMapMoveSinceLastRefine: true,
         refineWithInstance: jest.fn(),
-      },
-      [GOOGLE_MAPS_CONTEXT]: {
-        ...getGoogleMapsContext(defaultContext),
-        instance,
       },
     };
 
@@ -147,6 +140,6 @@ describe('Control', () => {
     wrapper.find('button').simulate('click');
 
     expect(refineWithInstance).toHaveBeenCalledTimes(1);
-    expect(refineWithInstance).toHaveBeenCalledWith(instance);
+    expect(refineWithInstance).toHaveBeenCalledWith(mapInstance);
   });
 });

--- a/packages/react-instantsearch-dom-maps/src/__tests__/CustomMarker.js
+++ b/packages/react-instantsearch-dom-maps/src/__tests__/CustomMarker.js
@@ -9,8 +9,7 @@ import {
 } from '../../test/mockGoogleMaps';
 import createHTMLMarker from '../elements/createHTMLMarker';
 import * as utils from '../utils';
-import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
-import CustomMarker from '../CustomMarker';
+import Connected, { CustomMarker } from '../CustomMarker';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -49,20 +48,14 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       const wrapper = shallow(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       expect(createHTMLMarker).toHaveBeenCalledWith(google);
@@ -93,24 +86,18 @@ describe('CustomMarker', () => {
       const props = {
         ...defaultProps,
         className: 'my-marker',
+        googleMapsInstance: mapInstance,
         anchor: {
           x: 10,
           y: 10,
         },
+        google,
       };
 
       shallow(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       expect(factory).toHaveBeenCalledWith(
@@ -136,20 +123,14 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       shallow(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       expect(utils.registerEvents).toHaveBeenCalledTimes(2); // cDM + cDU
@@ -177,20 +158,14 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       shallow(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       expect(removeEventListeners).toHaveBeenCalledTimes(1);
@@ -208,20 +183,14 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       shallow(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       expect(utils.registerEvents).toHaveBeenCalledTimes(2); // cDM + cDU
@@ -246,20 +215,14 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       const wrapper = shallow(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       wrapper.unmount();
@@ -289,6 +252,8 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       // Use `mount` instead of `shallow` to trigger the render
@@ -296,15 +261,7 @@ describe('CustomMarker', () => {
       const wrapper = mount(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       expect(wrapper).toMatchSnapshot();
@@ -323,6 +280,8 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       const wrapper = shallow(
@@ -331,12 +290,6 @@ describe('CustomMarker', () => {
         </CustomMarker>,
         {
           disableLifecycleMethods: true,
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
         }
       );
 
@@ -362,21 +315,15 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       // Use `mount` instead of `shallow` to trigger didUpdate
       const wrapper = mount(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       expect(unstableRenderSubtreeIntoContainer).not.toHaveBeenCalled();
@@ -406,20 +353,14 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       const wrapper = shallow(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       wrapper.unmount();
@@ -455,20 +396,14 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       const wrapper = mount(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       expect(wrapper).toMatchSnapshot();
@@ -499,6 +434,8 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       const wrapper = shallow(
@@ -507,12 +444,6 @@ describe('CustomMarker', () => {
         </CustomMarker>,
         {
           disableLifecycleMethods: true,
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
         }
       );
 
@@ -545,21 +476,15 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       // Use `mount` instead of `shallow` to avoid issue with `unstable_renderSubtreeIntoContainer`
       const wrapper = mount(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       expect(unstableRenderSubtreeIntoContainer).toHaveBeenCalledTimes(1);
@@ -606,21 +531,15 @@ describe('CustomMarker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       // Use `mount` instead of `shallow` to avoid issue with `unstable_renderSubtreeIntoContainer`
       const wrapper = mount(
         <CustomMarker {...props}>
           <span>This is the children.</span>
-        </CustomMarker>,
-        {
-          context: {
-            [GOOGLE_MAPS_CONTEXT]: {
-              instance: mapInstance,
-              google,
-            },
-          },
-        }
+        </CustomMarker>
       );
 
       wrapper.unmount();
@@ -632,6 +551,46 @@ describe('CustomMarker', () => {
 
       isReact16.mockReset();
       isReact16.mockRestore();
+    });
+  });
+
+  describe('Connected', () => {
+    it('expect to have access to Google Maps', () => {
+      const marker = createFakeHTMLMarkerInstance();
+      const factory = jest.fn(() => marker);
+      const mapInstance = createFakeMapInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+      });
+
+      createHTMLMarker.mockImplementationOnce(() => factory);
+
+      const props = {
+        ...defaultProps,
+      };
+
+      mount(
+        <Connected {...props}>
+          <span>This is the children.</span>
+        </Connected>,
+        {
+          context: {
+            // eslint-disable-next-line camelcase
+            __ais_geo_search__google_maps__: {
+              instance: mapInstance,
+              google,
+            },
+          },
+        }
+      );
+
+      expect(createHTMLMarker).toHaveBeenCalledWith(google);
+
+      expect(factory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          map: mapInstance,
+        })
+      );
     });
   });
 });

--- a/packages/react-instantsearch-dom-maps/src/__tests__/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-maps/src/__tests__/GoogleMaps.js
@@ -5,7 +5,7 @@ import {
   createFakeGoogleReference,
   createFakeMapInstance,
 } from '../../test/mockGoogleMaps';
-import GoogleMaps, { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+import GoogleMaps from '../GoogleMaps';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -320,7 +320,8 @@ describe('GoogleMaps', () => {
       });
 
       expect(wrapper.instance().getChildContext()).toEqual({
-        [GOOGLE_MAPS_CONTEXT]: expect.objectContaining({
+        // eslint-disable-next-line camelcase
+        __ais_geo_search__google_maps__: expect.objectContaining({
           google,
         }),
       });
@@ -342,7 +343,8 @@ describe('GoogleMaps', () => {
       });
 
       expect(wrapper.instance().getChildContext()).toEqual({
-        [GOOGLE_MAPS_CONTEXT]: expect.objectContaining({
+        // eslint-disable-next-line camelcase
+        __ais_geo_search__google_maps__: expect.objectContaining({
           instance: undefined,
         }),
       });
@@ -351,7 +353,8 @@ describe('GoogleMaps', () => {
       wrapper.instance().componentDidMount();
 
       expect(wrapper.instance().getChildContext()).toEqual({
-        [GOOGLE_MAPS_CONTEXT]: expect.objectContaining({
+        // eslint-disable-next-line camelcase
+        __ais_geo_search__google_maps__: expect.objectContaining({
           instance: mapInstance,
         }),
       });

--- a/packages/react-instantsearch-dom-maps/src/__tests__/Marker.js
+++ b/packages/react-instantsearch-dom-maps/src/__tests__/Marker.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Enzyme, { shallow } from 'enzyme';
+import Enzyme, { shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import {
   createFakeGoogleReference,
@@ -7,8 +7,7 @@ import {
   createFakeMarkerInstance,
 } from '../../test/mockGoogleMaps';
 import * as utils from '../utils';
-import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
-import Marker from '../Marker';
+import Connected, { Marker } from '../Marker';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -45,16 +44,11 @@ describe('Marker', () => {
 
     const props = {
       ...defaultProps,
+      googleMapsInstance: mapInstance,
+      google,
     };
 
-    const wrapper = shallow(<Marker {...props} />, {
-      context: {
-        [GOOGLE_MAPS_CONTEXT]: {
-          instance: mapInstance,
-          google,
-        },
-      },
-    });
+    const wrapper = shallow(<Marker {...props} />);
 
     expect(wrapper.type()).toBe(null);
   });
@@ -68,16 +62,12 @@ describe('Marker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       const wrapper = shallow(<Marker {...props} />, {
         disableLifecycleMethods: true,
-        context: {
-          [GOOGLE_MAPS_CONTEXT]: {
-            instance: mapInstance,
-            google,
-          },
-        },
       });
 
       expect(google.maps.Marker).not.toHaveBeenCalled();
@@ -103,20 +93,16 @@ describe('Marker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
         title: 'My Marker',
         visible: false,
         children: <span />,
         onClick: () => {},
+        google,
       };
 
       const wrapper = shallow(<Marker {...props} />, {
         disableLifecycleMethods: true,
-        context: {
-          [GOOGLE_MAPS_CONTEXT]: {
-            instance: mapInstance,
-            google,
-          },
-        },
       });
 
       expect(google.maps.Marker).not.toHaveBeenCalled();
@@ -146,16 +132,12 @@ describe('Marker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       const wrapper = shallow(<Marker {...props} />, {
         disableLifecycleMethods: true,
-        context: {
-          [GOOGLE_MAPS_CONTEXT]: {
-            instance: mapInstance,
-            google,
-          },
-        },
       });
 
       expect(utils.registerEvents).toHaveBeenCalledTimes(0);
@@ -186,16 +168,11 @@ describe('Marker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
-      const wrapper = shallow(<Marker {...props} />, {
-        context: {
-          [GOOGLE_MAPS_CONTEXT]: {
-            instance: mapInstance,
-            google,
-          },
-        },
-      });
+      const wrapper = shallow(<Marker {...props} />);
 
       expect(removeEventListeners).toHaveBeenCalledTimes(0);
 
@@ -215,18 +192,13 @@ describe('Marker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
       utils.registerEvents.mockImplementationOnce(() => () => {});
 
-      const wrapper = shallow(<Marker {...props} />, {
-        context: {
-          [GOOGLE_MAPS_CONTEXT]: {
-            instance: mapInstance,
-            google,
-          },
-        },
-      });
+      const wrapper = shallow(<Marker {...props} />);
 
       expect(utils.registerEvents).toHaveBeenCalledTimes(1);
 
@@ -253,21 +225,49 @@ describe('Marker', () => {
 
       const props = {
         ...defaultProps,
+        googleMapsInstance: mapInstance,
+        google,
       };
 
-      const wrapper = shallow(<Marker {...props} />, {
+      const wrapper = shallow(<Marker {...props} />);
+
+      wrapper.unmount();
+
+      expect(markerInstance.setMap).toHaveBeenCalledTimes(1);
+      expect(markerInstance.setMap).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('Connected', () => {
+    it('expect to have access to Google Maps', () => {
+      const mapInstance = createFakeMapInstance();
+      const markerInstance = createFakeMarkerInstance();
+      const google = createFakeGoogleReference({
+        mapInstance,
+        markerInstance,
+      });
+
+      const props = {
+        ...defaultProps,
+      };
+
+      mount(<Connected {...props} />, {
         context: {
-          [GOOGLE_MAPS_CONTEXT]: {
+          // eslint-disable-next-line camelcase
+          __ais_geo_search__google_maps__: {
             instance: mapInstance,
             google,
           },
         },
       });
 
-      wrapper.unmount();
-
-      expect(markerInstance.setMap).toHaveBeenCalledTimes(1);
-      expect(markerInstance.setMap).toHaveBeenCalledWith(null);
+      expect(google.maps.Marker).toHaveBeenCalledWith({
+        map: mapInstance,
+        position: {
+          lat: 10,
+          lng: 12,
+        },
+      });
     });
   });
 });

--- a/packages/react-instantsearch-dom-maps/src/__tests__/Redo.js
+++ b/packages/react-instantsearch-dom-maps/src/__tests__/Redo.js
@@ -3,13 +3,13 @@ import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createFakeMapInstance } from '../../test/mockGoogleMaps';
 import { STATE_CONTEXT } from '../Provider';
-import { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
 import { Redo } from '../Redo';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('Redo', () => {
   const defaultProps = {
+    googleMapsInstance: createFakeMapInstance(),
     translate: x => x,
   };
 
@@ -18,13 +18,9 @@ describe('Redo', () => {
       hasMapMoveSinceLastRefine: false,
       refineWithInstance: () => {},
     },
-    [GOOGLE_MAPS_CONTEXT]: {
-      instance: createFakeMapInstance(),
-    },
   };
 
   const getStateContext = context => context[STATE_CONTEXT];
-  const getGoogleMapsContext = context => context[GOOGLE_MAPS_CONTEXT];
 
   it('expect to render correctly', () => {
     const props = {
@@ -65,10 +61,11 @@ describe('Redo', () => {
   });
 
   it('expect to call refineWithInstance on button click', () => {
-    const instance = createFakeMapInstance();
+    const mapInstance = createFakeMapInstance();
 
     const props = {
       ...defaultProps,
+      googleMapsInstance: mapInstance,
     };
 
     const context = {
@@ -76,10 +73,6 @@ describe('Redo', () => {
       [STATE_CONTEXT]: {
         ...getStateContext(defaultContext),
         refineWithInstance: jest.fn(),
-      },
-      [GOOGLE_MAPS_CONTEXT]: {
-        ...getGoogleMapsContext(defaultContext),
-        instance,
       },
     };
 
@@ -94,6 +87,6 @@ describe('Redo', () => {
     wrapper.find('button').simulate('click');
 
     expect(refineWithInstance).toHaveBeenCalledTimes(1);
-    expect(refineWithInstance).toHaveBeenCalledWith(instance);
+    expect(refineWithInstance).toHaveBeenCalledWith(mapInstance);
   });
 });

--- a/packages/react-instantsearch-dom-maps/src/__tests__/__snapshots__/CustomMarker.js.snap
+++ b/packages/react-instantsearch-dom-maps/src/__tests__/__snapshots__/CustomMarker.js.snap
@@ -9,6 +9,35 @@ exports[`CustomMarker with portal expect to render correctly 1`] = `
     }
   }
   className=""
+  google={
+    Object {
+      "maps": Object {
+        "ControlPosition": Object {
+          "LEFT_TOP": "left:top",
+        },
+        "LatLng": [MockFunction],
+        "LatLngBounds": [MockFunction],
+        "Map": [MockFunction],
+        "Marker": [MockFunction],
+        "OverlayView": [Function],
+        "event": Object {
+          "addListenerOnce": [MockFunction],
+        },
+      },
+    }
+  }
+  googleMapsInstance={
+    Object {
+      "addListener": [MockFunction],
+      "fitBounds": [MockFunction],
+      "getBounds": [MockFunction],
+      "getCenter": [MockFunction],
+      "getProjection": [MockFunction],
+      "getZoom": [MockFunction],
+      "setCenter": [MockFunction],
+      "setZoom": [MockFunction],
+    }
+  }
   hit={
     Object {
       "_geoloc": Object {
@@ -43,6 +72,35 @@ exports[`CustomMarker with unstable_renderSubtreeIntoContainer expect to render 
     }
   }
   className=""
+  google={
+    Object {
+      "maps": Object {
+        "ControlPosition": Object {
+          "LEFT_TOP": "left:top",
+        },
+        "LatLng": [MockFunction],
+        "LatLngBounds": [MockFunction],
+        "Map": [MockFunction],
+        "Marker": [MockFunction],
+        "OverlayView": [Function],
+        "event": Object {
+          "addListenerOnce": [MockFunction],
+        },
+      },
+    }
+  }
+  googleMapsInstance={
+    Object {
+      "addListener": [MockFunction],
+      "fitBounds": [MockFunction],
+      "getBounds": [MockFunction],
+      "getCenter": [MockFunction],
+      "getProjection": [MockFunction],
+      "getZoom": [MockFunction],
+      "setCenter": [MockFunction],
+      "setZoom": [MockFunction],
+    }
+  }
   hit={
     Object {
       "_geoloc": Object {

--- a/packages/react-instantsearch-dom-maps/src/__tests__/withGoogleMaps.tsx
+++ b/packages/react-instantsearch-dom-maps/src/__tests__/withGoogleMaps.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import Enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import withGoogleMaps, {
+  GoogleMapsContext,
+  WithGoogleMapsProps,
+} from '../withGoogleMaps';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('withGoogleMaps', () => {
+  interface Props extends WithGoogleMapsProps {
+    value: number;
+  }
+
+  const createFakeContext = ({
+    google = {} as any,
+    googleMapsInstance = {} as any,
+  }): GoogleMapsContext => ({
+    __ais_geo_search__google_maps__: {
+      instance: googleMapsInstance,
+      google,
+    },
+  });
+
+  it('expect to inject `google` prop', () => {
+    const fakeGoogle: any = {
+      maps: {
+        visualization: {
+          HeatmapLayer: jest.fn(() => ({
+            getMap() {
+              return null;
+            },
+          })),
+        },
+      },
+    };
+
+    const Fake = withGoogleMaps(({ google }: Props) => {
+      const heatmap = new google.maps.visualization.HeatmapLayer({
+        data: [10, 20, 30],
+        radius: 50,
+      });
+
+      heatmap.getMap();
+
+      return null;
+    });
+
+    mount(<Fake value={10} />, {
+      context: createFakeContext({
+        google: fakeGoogle,
+      }),
+    });
+
+    expect(fakeGoogle.maps.visualization.HeatmapLayer).toHaveBeenCalledWith({
+      data: [10, 20, 30],
+      radius: 50,
+    });
+  });
+
+  it('expect to inject `googleMapsInstance` prop', () => {
+    const fakeGoogleMapsInstance: any = {
+      fitBounds: jest.fn(),
+    };
+
+    const Fake = withGoogleMaps(({ googleMapsInstance }: Props) => {
+      googleMapsInstance.fitBounds({
+        north: 10,
+        east: 12,
+        south: 14,
+        west: 16,
+      });
+
+      return null;
+    });
+
+    mount(<Fake value={10} />, {
+      context: createFakeContext({
+        googleMapsInstance: fakeGoogleMapsInstance,
+      }),
+    });
+
+    expect(fakeGoogleMapsInstance.fitBounds).toHaveBeenCalledWith({
+      north: 10,
+      east: 12,
+      south: 14,
+      west: 16,
+    });
+  });
+});

--- a/packages/react-instantsearch-dom-maps/src/index.js
+++ b/packages/react-instantsearch-dom-maps/src/index.js
@@ -4,3 +4,4 @@ export { default as Marker } from './Marker';
 export { default as CustomMarker } from './CustomMarker';
 export { default as Redo } from './Redo';
 export { default as Control } from './Control';
+export { default as withGoogleMaps } from './withGoogleMaps';

--- a/packages/react-instantsearch-dom-maps/src/withGoogleMaps.tsx
+++ b/packages/react-instantsearch-dom-maps/src/withGoogleMaps.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+type Subtract<T, K> = Omit<T, keyof K>;
+
+// @TODO: Move to GoogleMaps once it's migrated to TypeScript
+export interface GoogleMapsContext {
+  __ais_geo_search__google_maps__: {
+    google: typeof google;
+    instance: google.maps.Map;
+  };
+}
+
+export interface WithGoogleMapsProps {
+  google: typeof google;
+  googleMapsInstance: google.maps.Map;
+}
+
+const withGoogleMaps = <Props extends WithGoogleMapsProps>(
+  Wrapped: React.ComponentType<Props>
+) => {
+  const WithGoogleMaps: React.FC<Subtract<Props, WithGoogleMapsProps>> = (
+    props,
+    context: GoogleMapsContext
+  ) => {
+    const { google, instance } = context.__ais_geo_search__google_maps__;
+
+    return (
+      <Wrapped
+        // @TODO: remove the cast once TypeScript fixes the issue
+        // https://github.com/Microsoft/TypeScript/issues/28938
+        {...props as Props}
+        google={google}
+        googleMapsInstance={instance}
+      />
+    );
+  };
+
+  WithGoogleMaps.contextTypes = {
+    __ais_geo_search__google_maps__: PropTypes.shape({
+      google: PropTypes.object,
+      instance: PropTypes.object,
+    }),
+  };
+
+  return WithGoogleMaps;
+};
+
+export default withGoogleMaps;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,6 +3029,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/googlemaps@^3.30.16":
+  version "3.30.16"
+  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.30.16.tgz#3264d5ef7c3a92fab2a9f00e09e3247866ff3532"
+  integrity sha512-6OZ64ahLzYfzuSr71y4jAHZXiwxjvvEM2bfF2tzjIc9KUZVbO30SkYa8WewTsR8aM5BFz/uBiNlZ14eRLXYS0g==
+
 "@types/jest@^24.0.0":
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.0.tgz#848492026c327b3548d92be0352a545c36a21e8a"


### PR DESCRIPTION
**Summary**

This PR introduces a new HOC for the maps package. It's now part of the public API because we export this component. The HOC gives access to the `google` object and the `googleMapsInstance` which is the instance of the map. 

Users might want to leverage this to create their own layer on top of our geo search widget. It was already the case with the [heatmap](https://github.com/algolia/react-instantsearch/pull/1721) PR. Now it's possible to build it in user-land.

We choose the HOC over a render prop because it's easier to build a component with lifecycle hooks out of an HOC. With a render prop you have to create a layer to extract the value and provide it to the component that will use it. We can built an HOC out of render prop so if someone ask for it we can refactor the API to provide both.

**Usage**

```jsx
const Heatmap = withGoogleMaps({ google, googleMapsInstance }) => null;

const App = () => (
  <GeoSearch google={google}>
    {() => (
      <Fragment>
        <Heatmap />
      </Fragment>
    )}
  </GeoSearch>
);
```