### PR TITLE
feat(DOMMaps): expose withGoogleMaps [PART-6]

### DIFF
--- a/packages/react-instantsearch-dom-maps/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-maps/src/GoogleMaps.js
@@ -5,8 +5,6 @@ import { LatLngPropType, BoundingBoxPropType } from './propTypes';
 
 const cx = createClassNames('GeoSearch');
 
-export const GOOGLE_MAPS_CONTEXT = '__ais_geo_search__google_maps__';
-
 class GoogleMaps extends Component {
   static propTypes = {
     google: PropTypes.object.isRequired,
@@ -22,7 +20,8 @@ class GoogleMaps extends Component {
   };
 
   static childContextTypes = {
-    [GOOGLE_MAPS_CONTEXT]: PropTypes.shape({
+    // eslint-disable-next-line camelcase
+    __ais_geo_search__google_maps__: PropTypes.shape({
       google: PropTypes.object,
       instance: PropTypes.object,
     }),
@@ -40,7 +39,8 @@ class GoogleMaps extends Component {
     const { google } = this.props;
 
     return {
-      [GOOGLE_MAPS_CONTEXT]: {
+      // eslint-disable-next-line camelcase
+      __ais_geo_search__google_maps__: {
         instance: this.instance,
         google,
       },

--- a/packages/react-instantsearch-dom-maps/src/__tests__/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-maps/src/__tests__/GoogleMaps.js
@@ -5,7 +5,7 @@ import {
   createFakeGoogleReference,
   createFakeMapInstance,
 } from '../../test/mockGoogleMaps';
-import GoogleMaps, { GOOGLE_MAPS_CONTEXT } from '../GoogleMaps';
+import GoogleMaps from '../GoogleMaps';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -320,7 +320,8 @@ describe('GoogleMaps', () => {
       });
 
       expect(wrapper.instance().getChildContext()).toEqual({
-        [GOOGLE_MAPS_CONTEXT]: expect.objectContaining({
+        // eslint-disable-next-line camelcase
+        __ais_geo_search__google_maps__: expect.objectContaining({
           google,
         }),
       });
@@ -342,7 +343,8 @@ describe('GoogleMaps', () => {
       });
 
       expect(wrapper.instance().getChildContext()).toEqual({
-        [GOOGLE_MAPS_CONTEXT]: expect.objectContaining({
+        // eslint-disable-next-line camelcase
+        __ais_geo_search__google_maps__: expect.objectContaining({
           instance: undefined,
         }),
       });
@@ -351,7 +353,8 @@ describe('GoogleMaps', () => {
       wrapper.instance().componentDidMount();
 
       expect(wrapper.instance().getChildContext()).toEqual({
-        [GOOGLE_MAPS_CONTEXT]: expect.objectContaining({
+        // eslint-disable-next-line camelcase
+        __ais_geo_search__google_maps__: expect.objectContaining({
           instance: mapInstance,
         }),
       });


### PR DESCRIPTION
**Summary**

This PR drop the usage of the token `GOOGLE_MAPS_CONTEXT`. Now its benefit is very limited because it's only use in two places in the source code. Plus with TypeScript its usage is useless since we have the type checking + autocompletion.
