### PR TITLE
chore(context): migrate Panel

### DIFF
--- a/packages/react-instantsearch-dom/src/components/Panel.js
+++ b/packages/react-instantsearch-dom/src/components/Panel.js
@@ -1,9 +1,14 @@
-import React, { Component } from 'react';
+import React, { Component, createContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { createClassNames } from '../core/utils';
 
 const cx = createClassNames('Panel');
+
+export const {
+  Consumer: PanelConsumer,
+  Provider: PanelProvider,
+} = createContext(function setCanRefine() {});
 
 class Panel extends Component {
   static propTypes = {
@@ -11,10 +16,6 @@ class Panel extends Component {
     className: PropTypes.string,
     header: PropTypes.node,
     footer: PropTypes.node,
-  };
-
-  static childContextTypes = {
-    setCanRefine: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -26,12 +27,6 @@ class Panel extends Component {
   state = {
     canRefine: true,
   };
-
-  getChildContext() {
-    return {
-      setCanRefine: this.setCanRefine,
-    };
-  }
 
   setCanRefine = nextCanRefine => {
     this.setState({ canRefine: nextCanRefine });
@@ -47,7 +42,9 @@ class Panel extends Component {
       >
         {header && <div className={cx('header')}>{header}</div>}
 
-        <div className={cx('body')}>{children}</div>
+        <div className={cx('body')}>
+          <PanelProvider value={this.setCanRefine}>{children}</PanelProvider>
+        </div>
 
         {footer && <div className={cx('footer')}>{footer}</div>}
       </div>

--- a/packages/react-instantsearch-dom/src/components/PanelCallbackHandler.js
+++ b/packages/react-instantsearch-dom/src/components/PanelCallbackHandler.js
@@ -1,28 +1,26 @@
-import { Component } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { PanelConsumer } from './Panel';
 
 class PanelCallbackHandler extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
     canRefine: PropTypes.bool.isRequired,
-  };
-
-  static contextTypes = {
-    setCanRefine: PropTypes.func,
+    setCanRefine: PropTypes.func.isRequired,
   };
 
   componentWillMount() {
-    if (this.context.setCanRefine) {
-      this.context.setCanRefine(this.props.canRefine);
+    if (this.props.setCanRefine) {
+      this.props.setCanRefine(this.props.canRefine);
     }
   }
 
   componentWillReceiveProps(nextProps) {
     if (
-      this.context.setCanRefine &&
+      this.props.setCanRefine &&
       this.props.canRefine !== nextProps.canRefine
     ) {
-      this.context.setCanRefine(nextProps.canRefine);
+      this.props.setCanRefine(nextProps.canRefine);
     }
   }
 
@@ -31,4 +29,19 @@ class PanelCallbackHandler extends Component {
   }
 }
 
-export default PanelCallbackHandler;
+const Wrapper = ({ canRefine, children }) => (
+  <PanelConsumer>
+    {setCanRefine => (
+      <PanelCallbackHandler setCanRefine={setCanRefine} canRefine={canRefine}>
+        {children}
+      </PanelCallbackHandler>
+    )}
+  </PanelConsumer>
+);
+
+Wrapper.propTypes = {
+  canRefine: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default Wrapper;

--- a/packages/react-instantsearch-dom/src/components/PanelCallbackHandler.js
+++ b/packages/react-instantsearch-dom/src/components/PanelCallbackHandler.js
@@ -9,18 +9,13 @@ class PanelCallbackHandler extends Component {
     setCanRefine: PropTypes.func.isRequired,
   };
 
-  componentWillMount() {
-    if (this.props.setCanRefine) {
-      this.props.setCanRefine(this.props.canRefine);
-    }
+  componentDidMount() {
+    this.props.setCanRefine(this.props.canRefine);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (
-      this.props.setCanRefine &&
-      this.props.canRefine !== nextProps.canRefine
-    ) {
-      this.props.setCanRefine(nextProps.canRefine);
+  componentDidUpdate(prevProps) {
+    if (prevProps.canRefine !== this.props.canRefine) {
+      this.props.setCanRefine(this.props.canRefine);
     }
   }
 
@@ -29,7 +24,7 @@ class PanelCallbackHandler extends Component {
   }
 }
 
-const Wrapper = ({ canRefine, children }) => (
+const PanelWrapper = ({ canRefine, children }) => (
   <PanelConsumer>
     {setCanRefine => (
       <PanelCallbackHandler setCanRefine={setCanRefine} canRefine={canRefine}>
@@ -39,9 +34,9 @@ const Wrapper = ({ canRefine, children }) => (
   </PanelConsumer>
 );
 
-Wrapper.propTypes = {
+PanelWrapper.propTypes = {
   canRefine: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
 };
 
-export default Wrapper;
+export default PanelWrapper;

--- a/packages/react-instantsearch-dom/src/components/__tests__/Panel.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/Panel.js
@@ -91,7 +91,9 @@ describe('Panel', () => {
       <Panel>
         <PanelConsumer>
           {setCanRefine => (
-            <button onClick={() => setCanRefine(false)}>call setCanRefine</button>
+            <button onClick={() => setCanRefine(false)}>
+              call setCanRefine
+            </button>
           )}
         </PanelConsumer>
       </Panel>

--- a/packages/react-instantsearch-dom/src/components/__tests__/Panel.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/Panel.js
@@ -103,9 +103,7 @@ describe('Panel', () => {
     // Simulate context call
     wrapper.find('button').simulate('click');
 
-    // wrapper.update();
-
     expect(wrapper.state('canRefine')).toBe(false);
     expect(wrapper).toMatchSnapshot();
   });
-}); // ok
+});

--- a/packages/react-instantsearch-dom/src/components/__tests__/Panel.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/Panel.js
@@ -91,7 +91,7 @@ describe('Panel', () => {
       <Panel>
         <PanelConsumer>
           {setCanRefine => (
-            <button onClick={() => setCanRefine(false)}>set to false</button>
+            <button onClick={() => setCanRefine(false)}>call setCanRefine</button>
           )}
         </PanelConsumer>
       </Panel>

--- a/packages/react-instantsearch-dom/src/components/__tests__/Panel.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/Panel.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import Enzyme, { shallow } from 'enzyme';
+import Enzyme, { shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import Panel from '../Panel';
+import Panel, { PanelConsumer } from '../Panel';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -70,22 +70,30 @@ describe('Panel', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('expect to expose context to his children', () => {
-    const wrapper = shallow(
+  it('expect to expose context to its children', () => {
+    let provided;
+    const wrapper = mount(
       <Panel>
-        <div>Hello content</div>
+        <PanelConsumer>
+          {setCanRefine => {
+            provided = setCanRefine;
+            return null;
+          }}
+        </PanelConsumer>
       </Panel>
     );
 
-    expect(wrapper.instance().getChildContext()).toEqual({
-      setCanRefine: wrapper.instance().setCanRefine,
-    });
+    expect(provided).toEqual(wrapper.instance().setCanRefine);
   });
 
   it('expect to render when setCanRefine is called', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <Panel>
-        <div>Hello content</div>
+        <PanelConsumer>
+          {setCanRefine => (
+            <button onClick={() => setCanRefine(false)}>set to false</button>
+          )}
+        </PanelConsumer>
       </Panel>
     );
 
@@ -93,14 +101,11 @@ describe('Panel', () => {
     expect(wrapper).toMatchSnapshot();
 
     // Simulate context call
-    wrapper
-      .instance()
-      .getChildContext()
-      .setCanRefine(false);
+    wrapper.find('button').simulate('click');
 
-    wrapper.update();
+    // wrapper.update();
 
     expect(wrapper.state('canRefine')).toBe(false);
     expect(wrapper).toMatchSnapshot();
   });
-});
+}); // ok

--- a/packages/react-instantsearch-dom/src/components/__tests__/PanelCallbackHandler.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/PanelCallbackHandler.js
@@ -1,18 +1,15 @@
 import React from 'react';
-import Enzyme, { shallow } from 'enzyme';
+import Enzyme, { shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import PanelCallbackHandler from '../PanelCallbackHandler';
+import { PanelProvider } from '../Panel';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('PanelCallbackHandler', () => {
   it('expect to render', () => {
-    const props = {
-      canRefine: true,
-    };
-
     const wrapper = shallow(
-      <PanelCallbackHandler {...props}>
+      <PanelCallbackHandler canRefine={true}>
         <div>Hello content</div>
       </PanelCallbackHandler>
     );
@@ -22,101 +19,87 @@ describe('PanelCallbackHandler', () => {
 
   describe('willMount', () => {
     it('expect to call setCanRefine when the context is given', () => {
-      const props = {
-        canRefine: true,
-      };
+      const setCanRefine = jest.fn();
 
-      const context = {
-        setCanRefine: jest.fn(),
-      };
-
-      shallow(
-        <PanelCallbackHandler {...props}>
-          <div>Hello content</div>
-        </PanelCallbackHandler>,
-        { context }
+      mount(
+        <PanelProvider value={setCanRefine}>
+          <PanelCallbackHandler canRefine={true}>
+            <div>Hello content</div>
+          </PanelCallbackHandler>
+        </PanelProvider>
       );
 
-      expect(context.setCanRefine).toHaveBeenCalledTimes(1);
-      expect(context.setCanRefine).toHaveBeenCalledWith(true);
+      expect(setCanRefine).toHaveBeenCalledTimes(1);
+      expect(setCanRefine).toHaveBeenCalledWith(true);
     });
 
     it('expect to not throw when the context is not given', () => {
-      const props = {
-        canRefine: true,
-      };
-
-      const trigger = () =>
+      expect(() =>
         shallow(
-          <PanelCallbackHandler {...props}>
+          <PanelCallbackHandler canRefine={true}>
             <div>Hello content</div>
           </PanelCallbackHandler>
-        );
-
-      expect(() => trigger()).not.toThrow();
+        )
+      ).not.toThrow();
     });
   });
 
   describe('willReceiveProps', () => {
     it('expect to call setCanRefine when the context is given', () => {
-      const props = {
-        canRefine: true,
-      };
+      const setCanRefine = jest.fn();
 
-      const context = {
-        setCanRefine: jest.fn(),
-      };
-
-      const wrapper = shallow(
-        <PanelCallbackHandler {...props}>
-          <div>Hello content</div>
-        </PanelCallbackHandler>,
-        { context }
+      const wrapper = mount(
+        <PanelProvider value={setCanRefine}>
+          <PanelCallbackHandler canRefine={true}>
+            <div>Hello content</div>
+          </PanelCallbackHandler>
+        </PanelProvider>
       );
 
-      wrapper.setProps({ canRefine: false });
+      wrapper.setProps({
+        children: (
+          <PanelCallbackHandler canRefine={false}>
+            <div>Hello content</div>
+          </PanelCallbackHandler>
+        ),
+      });
 
-      expect(context.setCanRefine).toHaveBeenCalledTimes(2);
-      expect(context.setCanRefine).toHaveBeenLastCalledWith(false);
+      expect(setCanRefine).toHaveBeenCalledTimes(2);
+      expect(setCanRefine).toHaveBeenLastCalledWith(false);
     });
 
     it('expect to not call setCanRefine when the nextProps is the same', () => {
-      const props = {
-        canRefine: true,
-      };
+      const setCanRefine = jest.fn();
 
-      const context = {
-        setCanRefine: jest.fn(),
-      };
-
-      const wrapper = shallow(
-        <PanelCallbackHandler {...props}>
-          <div>Hello content</div>
-        </PanelCallbackHandler>,
-        { context }
+      const wrapper = mount(
+        <PanelProvider value={setCanRefine}>
+          <PanelCallbackHandler canRefine={true}>
+            <div>Hello content</div>
+          </PanelCallbackHandler>
+        </PanelProvider>
       );
 
-      wrapper.setProps({ canRefine: true });
+      wrapper.setProps({
+        children: (
+          <PanelCallbackHandler canRefine={true}>
+            <div>Hello content</div>
+          </PanelCallbackHandler>
+        ),
+      });
 
-      expect(context.setCanRefine).toHaveBeenCalledTimes(1);
+      expect(setCanRefine).toHaveBeenCalledTimes(1);
     });
 
     it('expect to not throw when the context is not given', () => {
-      const props = {
-        canRefine: true,
-      };
-
-      const trigger = () => {
+      expect(() => {
         const wrapper = shallow(
-          <PanelCallbackHandler {...props}>
+          <PanelCallbackHandler canRefine={true}>
             <div>Hello content</div>
           </PanelCallbackHandler>
         );
 
         wrapper.setProps({ canRefine: false });
-      };
-
-      expect(() => trigger()).not.toThrow();
+      }).not.toThrow();
     });
   });
 });

--- a/packages/react-instantsearch-dom/src/components/__tests__/PanelCallbackHandler.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/PanelCallbackHandler.js
@@ -8,22 +8,35 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('PanelCallbackHandler', () => {
   it('expect to render', () => {
-    const wrapper = shallow(
-      <PanelCallbackHandler canRefine={true}>
+    const wrapper = mount(
+      <PanelCallbackHandler canRefine>
         <div>Hello content</div>
       </PanelCallbackHandler>
     );
 
-    expect(wrapper).toMatchSnapshot();
+    expect(wrapper).toMatchInlineSnapshot(`
+      <PanelWrapper
+        canRefine={true}
+      >
+        <PanelCallbackHandler
+          canRefine={true}
+          setCanRefine={[Function]}
+        >
+          <div>
+            Hello content
+          </div>
+        </PanelCallbackHandler>
+      </PanelWrapper>
+    `);
   });
 
-  describe('willMount', () => {
+  describe('didMount', () => {
     it('expect to call setCanRefine when the context is given', () => {
       const setCanRefine = jest.fn();
 
       mount(
         <PanelProvider value={setCanRefine}>
-          <PanelCallbackHandler canRefine={true}>
+          <PanelCallbackHandler canRefine>
             <div>Hello content</div>
           </PanelCallbackHandler>
         </PanelProvider>
@@ -36,7 +49,7 @@ describe('PanelCallbackHandler', () => {
     it('expect to not throw when the context is not given', () => {
       expect(() =>
         shallow(
-          <PanelCallbackHandler canRefine={true}>
+          <PanelCallbackHandler canRefine>
             <div>Hello content</div>
           </PanelCallbackHandler>
         )
@@ -44,13 +57,13 @@ describe('PanelCallbackHandler', () => {
     });
   });
 
-  describe('willReceiveProps', () => {
+  describe('didUpdate', () => {
     it('expect to call setCanRefine when the context is given', () => {
       const setCanRefine = jest.fn();
 
       const wrapper = mount(
         <PanelProvider value={setCanRefine}>
-          <PanelCallbackHandler canRefine={true}>
+          <PanelCallbackHandler canRefine>
             <div>Hello content</div>
           </PanelCallbackHandler>
         </PanelProvider>
@@ -73,7 +86,7 @@ describe('PanelCallbackHandler', () => {
 
       const wrapper = mount(
         <PanelProvider value={setCanRefine}>
-          <PanelCallbackHandler canRefine={true}>
+          <PanelCallbackHandler canRefine>
             <div>Hello content</div>
           </PanelCallbackHandler>
         </PanelProvider>
@@ -81,7 +94,7 @@ describe('PanelCallbackHandler', () => {
 
       wrapper.setProps({
         children: (
-          <PanelCallbackHandler canRefine={true}>
+          <PanelCallbackHandler canRefine>
             <div>Hello content</div>
           </PanelCallbackHandler>
         ),
@@ -93,7 +106,7 @@ describe('PanelCallbackHandler', () => {
     it('expect to not throw when the context is not given', () => {
       expect(() => {
         const wrapper = shallow(
-          <PanelCallbackHandler canRefine={true}>
+          <PanelCallbackHandler canRefine>
             <div>Hello content</div>
           </PanelCallbackHandler>
         );

--- a/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/Panel.js.snap
+++ b/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/Panel.js.snap
@@ -33,7 +33,7 @@ exports[`Panel expect to render when setCanRefine is called 1`] = `
       <button
         onClick={[Function]}
       >
-        set to false
+        call setCanRefine
       </button>
     </div>
   </div>
@@ -55,7 +55,7 @@ exports[`Panel expect to render when setCanRefine is called 2`] = `
       <button
         onClick={[Function]}
       >
-        set to false
+        call setCanRefine
       </button>
     </div>
   </div>

--- a/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/Panel.js.snap
+++ b/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/Panel.js.snap
@@ -7,39 +7,59 @@ exports[`Panel expect to render 1`] = `
   <div
     className="ais-Panel-body"
   >
-    <div>
-      Hello content
-    </div>
+    <ContextProvider
+      value={[Function]}
+    >
+      <div>
+        Hello content
+      </div>
+    </ContextProvider>
   </div>
 </div>
 `;
 
 exports[`Panel expect to render when setCanRefine is called 1`] = `
-<div
-  className="ais-Panel"
+<Panel
+  className=""
+  footer={null}
+  header={null}
 >
   <div
-    className="ais-Panel-body"
+    className="ais-Panel"
   >
-    <div>
-      Hello content
+    <div
+      className="ais-Panel-body"
+    >
+      <button
+        onClick={[Function]}
+      >
+        set to false
+      </button>
     </div>
   </div>
-</div>
+</Panel>
 `;
 
 exports[`Panel expect to render when setCanRefine is called 2`] = `
-<div
-  className="ais-Panel ais-Panel--noRefinement"
+<Panel
+  className=""
+  footer={null}
+  header={null}
 >
   <div
-    className="ais-Panel-body"
+    className="ais-Panel ais-Panel--noRefinement"
   >
-    <div>
-      Hello content
+    <div
+      className="ais-Panel-body"
+    >
+      <button
+        onClick={[Function]}
+      >
+        set to false
+      </button>
     </div>
   </div>
-</div>
+</Panel>
 `;
 
 exports[`Panel expect to render with custom className 1`] = `
@@ -49,9 +69,13 @@ exports[`Panel expect to render with custom className 1`] = `
   <div
     className="ais-Panel-body"
   >
-    <div>
-      Hello content
-    </div>
+    <ContextProvider
+      value={[Function]}
+    >
+      <div>
+        Hello content
+      </div>
+    </ContextProvider>
   </div>
 </div>
 `;
@@ -63,9 +87,13 @@ exports[`Panel expect to render with footer 1`] = `
   <div
     className="ais-Panel-body"
   >
-    <div>
-      Hello content
-    </div>
+    <ContextProvider
+      value={[Function]}
+    >
+      <div>
+        Hello content
+      </div>
+    </ContextProvider>
   </div>
   <div
     className="ais-Panel-footer"
@@ -91,9 +119,13 @@ exports[`Panel expect to render with header 1`] = `
   <div
     className="ais-Panel-body"
   >
-    <div>
-      Hello content
-    </div>
+    <ContextProvider
+      value={[Function]}
+    >
+      <div>
+        Hello content
+      </div>
+    </ContextProvider>
   </div>
 </div>
 `;
@@ -105,9 +137,13 @@ exports[`Panel expect to render without refinement 1`] = `
   <div
     className="ais-Panel-body"
   >
-    <div>
-      Hello content
-    </div>
+    <ContextProvider
+      value={[Function]}
+    >
+      <div>
+        Hello content
+      </div>
+    </ContextProvider>
   </div>
 </div>
 `;

--- a/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/PanelCallbackHandler.js.snap
+++ b/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/PanelCallbackHandler.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`PanelCallbackHandler expect to render 1`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
-`;

--- a/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/PanelCallbackHandler.js.snap
+++ b/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/PanelCallbackHandler.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PanelCallbackHandler expect to render 1`] = `
-<div>
-  Hello content
-</div>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;


### PR DESCRIPTION
This migration is fairly straightforward, and has no impact on how the PanelCallbackHandler is used, although it adds a new component in that tree so it can read the context

IFW-485

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

migrate Panel and PanelCallbackHandler to the new react createContext

**Result**

Nothing visual

**Test plan**

- none of the DOM tests change, except Panel & PanelCallbackHandler
- Storybook still has "noRefinement" class on relevant stories
