### PR TITLE
feat(queryRules): add connectQueryRules connector [part 1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "type-check:watch": "yarn type-check --watch",
     "test": "yarn jest",
     "test:watch": "yarn jest --watch",
-    "test:e2e": "yarn test:regressions && yarn test:argos",
+    "test:e2e": "NODE_ENV=development yarn test:regressions && yarn test:argos",
     "test:examples": "node scripts/test-examples.js",
     "test:build": "yarn build && yarn test:size",
     "test:regressions": "webpack --config integration/webpack.config.js && node integration/runTest.js",
@@ -130,19 +130,19 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Connectors.min.js",
-      "maxSize": "40 kB"
+      "maxSize": "40.25 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "63 kB"
+      "maxSize": "63.75 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "41 kB"
+      "maxSize": "41.25 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "63 kB"
+      "maxSize": "63.50 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
@@ -1,8 +1,6 @@
-import connect from '../connectQueryRules';
+import connect, { QueryRulesProps } from '../connectQueryRules';
 
-jest.mock('../../core/createConnector', () => (component: React.Component) =>
-  component
-);
+jest.mock('../../core/createConnector', () => (connector: any) => connector);
 
 describe('connectQueryRules', () => {
   describe('single index', () => {
@@ -12,7 +10,9 @@ describe('connectQueryRules', () => {
 
     describe('without userData', () => {
       it('provides the correct props to the component', () => {
-        const props = {};
+        const props: QueryRulesProps = {
+          transformItems: items => items,
+        };
         const searchState = {};
         const searchResults = {
           results: { [indexName]: { userData: undefined } },
@@ -27,7 +27,9 @@ describe('connectQueryRules', () => {
 
     describe('with userData', () => {
       it('provides the correct props to the component', () => {
-        const props = {};
+        const props: QueryRulesProps = {
+          transformItems: items => items,
+        };
         const searchState = {};
         const searchResults = {
           results: {
@@ -42,8 +44,11 @@ describe('connectQueryRules', () => {
       });
 
       it('transforms items before passing the props to the component', () => {
-        const props = {
-          transformItems: () => [{ banner: 'image-transformed.png' }],
+        const transformItemsSpy = jest.fn(() => [
+          { banner: 'image-transformed.png' },
+        ]);
+        const props: QueryRulesProps = {
+          transformItems: transformItemsSpy,
         };
         const searchState = {};
         const searchResults = {
@@ -56,26 +61,33 @@ describe('connectQueryRules', () => {
           items: [{ banner: 'image-transformed.png' }],
           canRefine: true,
         });
+        expect(transformItemsSpy).toHaveBeenCalledTimes(1);
+        expect(transformItemsSpy).toHaveBeenCalledWith([
+          { banner: 'image.png' },
+        ]);
       });
     });
   });
 
   describe('multi index', () => {
-    const indexName = 'index';
+    const firstIndexName = 'firstIndex';
+    const secondIndexName = 'secondIndex';
     const context = {
       context: {
-        ais: { mainTargetedIndex: indexName },
-        multiIndexContext: { targetedIndex: indexName },
+        ais: { mainTargetedIndex: firstIndexName },
+        multiIndexContext: { targetedIndex: secondIndexName },
       },
     };
     const getProvidedProps = connect.getProvidedProps.bind(context);
 
     describe('without userData', () => {
       it('provides the correct props to the component', () => {
-        const props = {};
+        const props: QueryRulesProps = {
+          transformItems: items => items,
+        };
         const searchState = {};
         const searchResults = {
-          results: { [indexName]: { userData: undefined } },
+          results: { [secondIndexName]: { userData: undefined } },
         };
 
         expect(getProvidedProps(props, searchState, searchResults)).toEqual({
@@ -87,11 +99,13 @@ describe('connectQueryRules', () => {
 
     describe('with userData', () => {
       it('provides the correct props to the component', () => {
-        const props = {};
+        const props: QueryRulesProps = {
+          transformItems: items => items,
+        };
         const searchState = {};
         const searchResults = {
           results: {
-            [indexName]: { userData: [{ banner: 'image.png' }] },
+            [secondIndexName]: { userData: [{ banner: 'image.png' }] },
           },
         };
 
@@ -102,20 +116,26 @@ describe('connectQueryRules', () => {
       });
 
       it('transforms items before passing the props to the component', () => {
-        const props = {
-          transformItems: () => [{ banner: 'image-transformed.png' }],
+        const transformItemsSpy = jest.fn(() => [
+          { banner: 'image-transformed.png' },
+        ]);
+        const props: QueryRulesProps = {
+          transformItems: transformItemsSpy,
         };
         const searchState = {};
         const searchResults = {
           results: {
-            [indexName]: { userData: [{ banner: 'image.png' }] },
+            [secondIndexName]: { userData: [{ banner: 'image.png' }] },
           },
         };
-
         expect(getProvidedProps(props, searchState, searchResults)).toEqual({
           items: [{ banner: 'image-transformed.png' }],
           canRefine: true,
         });
+        expect(transformItemsSpy).toHaveBeenCalledTimes(1);
+        expect(transformItemsSpy).toHaveBeenCalledWith([
+          { banner: 'image.png' },
+        ]);
       });
     });
   });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
@@ -1,0 +1,122 @@
+import connect from '../connectQueryRules';
+
+jest.mock('../../core/createConnector', () => (component: React.Component) =>
+  component
+);
+
+describe('connectQueryRules', () => {
+  describe('single index', () => {
+    const indexName = 'index';
+    const context = { context: { ais: { mainTargetedIndex: indexName } } };
+    const getProvidedProps = connect.getProvidedProps.bind(context);
+
+    describe('without userData', () => {
+      it('provides the correct props to the component', () => {
+        const props = {};
+        const searchState = {};
+        const searchResults = {
+          results: { [indexName]: { userData: undefined } },
+        };
+
+        expect(getProvidedProps(props, searchState, searchResults)).toEqual({
+          items: [],
+          canRefine: false,
+        });
+      });
+    });
+
+    describe('with userData', () => {
+      it('provides the correct props to the component', () => {
+        const props = {};
+        const searchState = {};
+        const searchResults = {
+          results: {
+            [indexName]: { userData: [{ banner: 'image.png' }] },
+          },
+        };
+
+        expect(getProvidedProps(props, searchState, searchResults)).toEqual({
+          items: [{ banner: 'image.png' }],
+          canRefine: true,
+        });
+      });
+
+      it('transforms items before passing the props to the component', () => {
+        const props = {
+          transformItems: () => [{ banner: 'image-transformed.png' }],
+        };
+        const searchState = {};
+        const searchResults = {
+          results: {
+            [indexName]: { userData: [{ banner: 'image.png' }] },
+          },
+        };
+
+        expect(getProvidedProps(props, searchState, searchResults)).toEqual({
+          items: [{ banner: 'image-transformed.png' }],
+          canRefine: true,
+        });
+      });
+    });
+  });
+
+  describe('multi index', () => {
+    const indexName = 'index';
+    const context = {
+      context: {
+        ais: { mainTargetedIndex: indexName },
+        multiIndexContext: { targetedIndex: indexName },
+      },
+    };
+    const getProvidedProps = connect.getProvidedProps.bind(context);
+
+    describe('without userData', () => {
+      it('provides the correct props to the component', () => {
+        const props = {};
+        const searchState = {};
+        const searchResults = {
+          results: { [indexName]: { userData: undefined } },
+        };
+
+        expect(getProvidedProps(props, searchState, searchResults)).toEqual({
+          items: [],
+          canRefine: false,
+        });
+      });
+    });
+
+    describe('with userData', () => {
+      it('provides the correct props to the component', () => {
+        const props = {};
+        const searchState = {};
+        const searchResults = {
+          results: {
+            [indexName]: { userData: [{ banner: 'image.png' }] },
+          },
+        };
+
+        expect(getProvidedProps(props, searchState, searchResults)).toEqual({
+          items: [{ banner: 'image.png' }],
+          canRefine: true,
+        });
+      });
+
+      it('transforms items before passing the props to the component', () => {
+        const props = {
+          transformItems: () => [{ banner: 'image-transformed.png' }],
+        };
+        const searchState = {};
+        const searchResults = {
+          results: {
+            [indexName]: { userData: [{ banner: 'image.png' }] },
+          },
+        };
+
+        expect(getProvidedProps(props, searchState, searchResults)).toEqual({
+          items: [{ banner: 'image-transformed.png' }],
+          canRefine: true,
+        });
+      });
+    });
+  });
+});

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
@@ -1,17 +1,25 @@
+import { SearchParameters } from 'algoliasearch-helper';
 import connect, { QueryRulesProps } from '../connectQueryRules';
 
 jest.mock('../../core/createConnector', () => (connector: any) => connector);
 
 describe('connectQueryRules', () => {
+  const defaultProps: QueryRulesProps = {
+    transformItems: items => items,
+    trackedFilters: {},
+    transformRuleContexts: ruleContexts => ruleContexts,
+  };
+
   describe('single index', () => {
     const indexName = 'index';
     const context = { context: { ais: { mainTargetedIndex: indexName } } };
     const getProvidedProps = connect.getProvidedProps.bind(context);
+    const getSearchParameters = connect.getSearchParameters.bind(context);
 
-    describe('without userData', () => {
-      it('provides the correct props to the component', () => {
+    describe('default', () => {
+      it('without userData provides the correct props to the component', () => {
         const props: QueryRulesProps = {
-          transformItems: items => items,
+          ...defaultProps,
         };
         const searchState = {};
         const searchResults = {
@@ -23,12 +31,10 @@ describe('connectQueryRules', () => {
           canRefine: false,
         });
       });
-    });
 
-    describe('with userData', () => {
-      it('provides the correct props to the component', () => {
+      it('with userData provides the correct props to the component', () => {
         const props: QueryRulesProps = {
-          transformItems: items => items,
+          ...defaultProps,
         };
         const searchState = {};
         const searchResults = {
@@ -42,12 +48,15 @@ describe('connectQueryRules', () => {
           canRefine: true,
         });
       });
+    });
 
+    describe('transformItems', () => {
       it('transforms items before passing the props to the component', () => {
         const transformItemsSpy = jest.fn(() => [
           { banner: 'image-transformed.png' },
         ]);
         const props: QueryRulesProps = {
+          ...defaultProps,
           transformItems: transformItemsSpy,
         };
         const searchState = {};
@@ -64,6 +73,368 @@ describe('connectQueryRules', () => {
         expect(transformItemsSpy).toHaveBeenCalledTimes(1);
         expect(transformItemsSpy).toHaveBeenCalledWith([
           { banner: 'image.png' },
+        ]);
+      });
+    });
+
+    describe('trackedFilters', () => {
+      it('does not set ruleContexts without search state and trackedFilters', () => {
+        const props: QueryRulesProps = {
+          ...defaultProps,
+        };
+        const searchState = {};
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(searchParameters.ruleContexts).toEqual(undefined);
+      });
+
+      it('does not set ruleContexts with search state but without tracked filters', () => {
+        const props: QueryRulesProps = {
+          ...defaultProps,
+        };
+        const searchState = {
+          range: {
+            price: {
+              min: 20,
+              max: 3000,
+            },
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(searchParameters.ruleContexts).toEqual(undefined);
+      });
+
+      it('does not reset initial ruleContexts with trackedFilters', () => {
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            price: values => values,
+          },
+        };
+        const searchState = {};
+        const searchParameters = getSearchParameters(
+          SearchParameters.make({
+            ruleContexts: ['initial-rule'],
+          }),
+          props,
+          searchState
+        );
+
+        expect(searchParameters.ruleContexts).toEqual(['initial-rule']);
+      });
+
+      it('sets ruleContexts based on range', () => {
+        const priceSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            price: priceSpy,
+          },
+        };
+        const searchState = {
+          range: {
+            price: {
+              min: 20,
+              max: 3000,
+            },
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(priceSpy).toHaveBeenCalledTimes(1);
+        expect(priceSpy).toHaveBeenCalledWith([20, 3000]);
+        expect(searchParameters.ruleContexts).toEqual([
+          'ais-price-20',
+          'ais-price-3000',
+        ]);
+      });
+
+      it('sets ruleContexts based on refinementList', () => {
+        const fruitSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            fruit: fruitSpy,
+          },
+        };
+        const searchState = {
+          refinementList: {
+            fruit: ['lemon', 'orange'],
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(fruitSpy).toHaveBeenCalledTimes(1);
+        expect(fruitSpy).toHaveBeenCalledWith(['lemon', 'orange']);
+        expect(searchParameters.ruleContexts).toEqual([
+          'ais-fruit-lemon',
+          'ais-fruit-orange',
+        ]);
+      });
+
+      it('sets ruleContexts based on hierarchicalMenu', () => {
+        const productsSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            products: productsSpy,
+          },
+        };
+        const searchState = {
+          hierarchicalMenu: {
+            products: 'Laptops > Surface',
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(productsSpy).toHaveBeenCalledTimes(1);
+        expect(productsSpy).toHaveBeenCalledWith(['Laptops > Surface']);
+        expect(searchParameters.ruleContexts).toEqual([
+          'ais-products-Laptops_Surface',
+        ]);
+      });
+
+      it('sets ruleContexts based on menu', () => {
+        const brandsSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            brands: brandsSpy,
+          },
+        };
+        const searchState = {
+          menu: {
+            brands: 'Sony',
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(brandsSpy).toHaveBeenCalledTimes(1);
+        expect(brandsSpy).toHaveBeenCalledWith(['Sony']);
+        expect(searchParameters.ruleContexts).toEqual(['ais-brands-Sony']);
+      });
+
+      it('sets ruleContexts based on multiRange', () => {
+        const rankSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            rank: rankSpy,
+          },
+        };
+        const searchState = {
+          multiRange: {
+            rank: '2:5',
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(rankSpy).toHaveBeenCalledTimes(1);
+        expect(rankSpy).toHaveBeenCalledWith(['2', '5']);
+        expect(searchParameters.ruleContexts).toEqual([
+          'ais-rank-2',
+          'ais-rank-5',
+        ]);
+      });
+
+      it('sets ruleContexts based on toggle', () => {
+        const freeShippingSpy = jest.fn(values => values);
+        const availableInStockSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            freeShipping: freeShippingSpy,
+            availableInStock: availableInStockSpy,
+          },
+        };
+        const searchState = {
+          toggle: {
+            freeShipping: true,
+            availableInStock: false,
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(freeShippingSpy).toHaveBeenCalledTimes(1);
+        expect(freeShippingSpy).toHaveBeenCalledWith([true]);
+        expect(availableInStockSpy).toHaveBeenCalledTimes(1);
+        expect(availableInStockSpy).toHaveBeenCalledWith([false]);
+        expect(searchParameters.ruleContexts).toEqual([
+          'ais-freeShipping-true',
+          'ais-availableInStock-false',
+        ]);
+      });
+
+      it('escapes all rule contexts before passing them to search parameters', () => {
+        const brandSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            brand: brandSpy,
+          },
+        };
+        const searchState = {
+          refinementList: {
+            brand: ['Insignia™', '© Apple'],
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(brandSpy).toHaveBeenCalledTimes(1);
+        expect(brandSpy).toHaveBeenCalledWith(['Insignia™', '© Apple']);
+        expect(searchParameters.ruleContexts).toEqual([
+          'ais-brand-Insignia_',
+          'ais-brand-_Apple',
+        ]);
+      });
+
+      it('slices and warns in development when more than 10 rule contexts are applied', () => {
+        // We need to simulate being in development mode and to mock the global console object
+        // in this test to assert that development warnings are displayed correctly.
+        const originalNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'development';
+        const warnSpy = jest
+          .spyOn(console, 'warn')
+          .mockImplementation(() => {});
+
+        const brandFacetRefinements = [
+          'Insignia',
+          'Canon',
+          'Dynex',
+          'LG',
+          'Metra',
+          'Sony',
+          'HP',
+          'Apple',
+          'Samsung',
+          'Speck',
+          'PNY',
+        ];
+
+        expect(brandFacetRefinements).toHaveLength(11);
+
+        const brandSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            brand: brandSpy,
+          },
+        };
+        const searchState = {
+          refinementList: {
+            brand: brandFacetRefinements,
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy)
+          .toHaveBeenCalledWith(`The maximum number of \`ruleContexts\` is 10. They have been sliced to that limit.
+Consider using \`transformRuleContexts\` to minimize the number of rules sent to Algolia.`);
+
+        expect(brandSpy).toHaveBeenCalledTimes(1);
+        expect(brandSpy).toHaveBeenCalledWith([
+          'Insignia',
+          'Canon',
+          'Dynex',
+          'LG',
+          'Metra',
+          'Sony',
+          'HP',
+          'Apple',
+          'Samsung',
+          'Speck',
+          'PNY',
+        ]);
+        expect(searchParameters.ruleContexts).toEqual([
+          'ais-brand-Insignia',
+          'ais-brand-Canon',
+          'ais-brand-Dynex',
+          'ais-brand-LG',
+          'ais-brand-Metra',
+          'ais-brand-Sony',
+          'ais-brand-HP',
+          'ais-brand-Apple',
+          'ais-brand-Samsung',
+          'ais-brand-Speck',
+        ]);
+
+        process.env.NODE_ENV = originalNodeEnv;
+        warnSpy.mockRestore();
+      });
+    });
+
+    describe('transformRuleContexts', () => {
+      it('transform rule contexts before adding them to search parameters', () => {
+        const priceSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            price: priceSpy,
+          },
+          transformRuleContexts: rules =>
+            rules.map(rule => rule.replace('ais-', 'transformed-')),
+        };
+        const searchState = {
+          range: {
+            price: {
+              min: 20,
+              max: 3000,
+            },
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(priceSpy).toHaveBeenCalledTimes(1);
+        expect(priceSpy).toHaveBeenCalledWith([20, 3000]);
+        expect(searchParameters.ruleContexts).toEqual([
+          'transformed-price-20',
+          'transformed-price-3000',
         ]);
       });
     });
@@ -79,47 +450,47 @@ describe('connectQueryRules', () => {
       },
     };
     const getProvidedProps = connect.getProvidedProps.bind(context);
+    const getSearchParameters = connect.getSearchParameters.bind(context);
 
-    describe('without userData', () => {
-      it('provides the correct props to the component', () => {
-        const props: QueryRulesProps = {
-          transformItems: items => items,
-        };
-        const searchState = {};
-        const searchResults = {
-          results: { [secondIndexName]: { userData: undefined } },
-        };
+    it('without userData provides the correct props to the component', () => {
+      const props: QueryRulesProps = {
+        ...defaultProps,
+      };
+      const searchState = {};
+      const searchResults = {
+        results: { [secondIndexName]: { userData: undefined } },
+      };
 
-        expect(getProvidedProps(props, searchState, searchResults)).toEqual({
-          items: [],
-          canRefine: false,
-        });
+      expect(getProvidedProps(props, searchState, searchResults)).toEqual({
+        items: [],
+        canRefine: false,
       });
     });
 
-    describe('with userData', () => {
-      it('provides the correct props to the component', () => {
-        const props: QueryRulesProps = {
-          transformItems: items => items,
-        };
-        const searchState = {};
-        const searchResults = {
-          results: {
-            [secondIndexName]: { userData: [{ banner: 'image.png' }] },
-          },
-        };
+    it('with userData provides the correct props to the component', () => {
+      const props: QueryRulesProps = {
+        ...defaultProps,
+      };
+      const searchState = {};
+      const searchResults = {
+        results: {
+          [secondIndexName]: { userData: [{ banner: 'image.png' }] },
+        },
+      };
 
-        expect(getProvidedProps(props, searchState, searchResults)).toEqual({
-          items: [{ banner: 'image.png' }],
-          canRefine: true,
-        });
+      expect(getProvidedProps(props, searchState, searchResults)).toEqual({
+        items: [{ banner: 'image.png' }],
+        canRefine: true,
       });
+    });
 
+    describe('transformItems', () => {
       it('transforms items before passing the props to the component', () => {
         const transformItemsSpy = jest.fn(() => [
           { banner: 'image-transformed.png' },
         ]);
         const props: QueryRulesProps = {
+          ...defaultProps,
           transformItems: transformItemsSpy,
         };
         const searchState = {};
@@ -135,6 +506,119 @@ describe('connectQueryRules', () => {
         expect(transformItemsSpy).toHaveBeenCalledTimes(1);
         expect(transformItemsSpy).toHaveBeenCalledWith([
           { banner: 'image.png' },
+        ]);
+      });
+    });
+
+    describe('trackedFilters', () => {
+      it('does not set ruleContexts without search state and trackedFilters', () => {
+        const props: QueryRulesProps = {
+          ...defaultProps,
+        };
+        const searchState = {};
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(searchParameters.ruleContexts).toEqual(undefined);
+      });
+
+      it('does not set ruleContexts with search state but without tracked filters', () => {
+        const props: QueryRulesProps = {
+          ...defaultProps,
+        };
+        const searchState = {
+          indices: {
+            [secondIndexName]: {
+              range: {
+                price: {
+                  min: 20,
+                  max: 3000,
+                },
+              },
+            },
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(searchParameters.ruleContexts).toEqual(undefined);
+      });
+
+      it('sets ruleContexts based on range', () => {
+        const priceSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            price: priceSpy,
+          },
+        };
+        const searchState = {
+          indices: {
+            [secondIndexName]: {
+              range: {
+                price: {
+                  min: 20,
+                  max: 3000,
+                },
+              },
+            },
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(priceSpy).toHaveBeenCalledTimes(1);
+        expect(priceSpy).toHaveBeenCalledWith([20, 3000]);
+        expect(searchParameters.ruleContexts).toEqual([
+          'ais-price-20',
+          'ais-price-3000',
+        ]);
+      });
+    });
+
+    describe('transformRuleContexts', () => {
+      it('transform rule contexts before adding them to search parameters', () => {
+        const priceSpy = jest.fn(values => values);
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            price: priceSpy,
+          },
+          transformRuleContexts: rules =>
+            rules.map(rule => rule.replace('ais-', 'transformed-')),
+        };
+        const searchState = {
+          indices: {
+            [secondIndexName]: {
+              range: {
+                price: {
+                  min: 20,
+                  max: 3000,
+                },
+              },
+            },
+          },
+        };
+        const searchParameters = getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(priceSpy).toHaveBeenCalledTimes(1);
+        expect(priceSpy).toHaveBeenCalledWith([20, 3000]);
+        expect(searchParameters.ruleContexts).toEqual([
+          'transformed-price-20',
+          'transformed-price-3000',
         ]);
       });
     });

--- a/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
@@ -1,0 +1,44 @@
+import createConnector from '../core/createConnector';
+import { getResults } from '../core/indexUtils';
+
+export type CustomUserData = {
+  [key: string]: any;
+};
+
+type QueryRulesProps<TItem = CustomUserData> = {
+  transformItems: (items: TItem[]) => TItem[];
+};
+
+export default createConnector({
+  displayName: 'AlgoliaQueryRules',
+
+  defaultProps: {
+    transformItems: items => items,
+  } as QueryRulesProps,
+
+  getProvidedProps(
+    props: QueryRulesProps,
+    _searchState: any,
+    searchResults: any
+  ) {
+    const results = getResults(searchResults, this.context);
+
+    if (results === null) {
+      return {
+        items: [],
+        canRefine: false,
+      };
+    }
+
+    const { userData = [] } = results;
+    const { transformItems } = props;
+    const transformedItems = transformItems
+      ? transformItems(userData)
+      : userData;
+
+    return {
+      items: transformedItems,
+      canRefine: transformedItems.length > 0,
+    };
+  },
+});

--- a/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
@@ -5,7 +5,7 @@ export type CustomUserData = {
   [key: string]: any;
 };
 
-type QueryRulesProps<TItem = CustomUserData> = {
+export type QueryRulesProps<TItem = CustomUserData> = {
   transformItems: (items: TItem[]) => TItem[];
 };
 
@@ -28,9 +28,7 @@ export default createConnector({
 
     const { userData = [] } = results;
     const { transformItems } = props;
-    const transformedItems = transformItems
-      ? transformItems(userData)
-      : userData;
+    const transformedItems = transformItems(userData);
 
     return {
       items: transformedItems,

--- a/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
@@ -1,19 +1,120 @@
 import createConnector from '../core/createConnector';
-import { getResults } from '../core/indexUtils';
+import { getResults, getIndexId, hasMultipleIndices } from '../core/indexUtils';
+
+type SearchState = any;
+
+type SearchParameters = any;
 
 export type CustomUserData = {
   [key: string]: any;
 };
 
+type TrackedFilterRefinement = string | number | boolean;
+
 export type QueryRulesProps<TItem = CustomUserData> = {
+  trackedFilters: {
+    [facetName: string]: (
+      facetValues: TrackedFilterRefinement[]
+    ) => TrackedFilterRefinement[];
+  };
+  transformRuleContexts: (ruleContexts: string[]) => string[];
   transformItems: (items: TItem[]) => TItem[];
 };
+
+// A context rule must consist only of alphanumeric characters, hyphens, and underscores.
+// See https://www.algolia.com/doc/guides/managing-results/refine-results/merchandising-and-promoting/in-depth/implementing-query-rules/#context
+function escapeRuleContext(ruleName: string): string {
+  return ruleName.replace(/[^a-z0-9-_]+/gi, '_');
+}
+
+function getWidgetRefinements(
+  attribute: string,
+  widgetKey: string,
+  searchState: SearchState
+): TrackedFilterRefinement[] {
+  const widgetState = searchState[widgetKey];
+
+  switch (widgetKey) {
+    case 'range':
+      return Object.keys(widgetState[attribute]).map(
+        rangeKey => widgetState[attribute][rangeKey]
+      );
+
+    case 'refinementList':
+      return widgetState[attribute];
+
+    case 'hierarchicalMenu':
+      return [widgetState[attribute]];
+
+    case 'menu':
+      return [widgetState[attribute]];
+
+    case 'multiRange':
+      return widgetState[attribute].split(':');
+
+    case 'toggle':
+      return [widgetState[attribute]];
+
+    default:
+      return [];
+  }
+}
+
+function getRefinements(
+  attribute: string,
+  searchState: SearchState = {}
+): TrackedFilterRefinement[] {
+  const refinements = Object.keys(searchState)
+    .filter(
+      widgetKey => typeof searchState[widgetKey][attribute] !== 'undefined'
+    )
+    .map(widgetKey => getWidgetRefinements(attribute, widgetKey, searchState))
+    .reduce((acc, current) => acc.concat(current), []); // flatten the refinements
+
+  return refinements;
+}
+
+function getRuleContextsFromTrackedFilters({
+  searchState,
+  trackedFilters,
+}: {
+  searchState: SearchState;
+  trackedFilters: QueryRulesProps['trackedFilters'];
+}) {
+  const ruleContexts = Object.keys(trackedFilters).reduce<string[]>(
+    (facets, facetName) => {
+      const facetRefinements: TrackedFilterRefinement[] = getRefinements(
+        facetName,
+        searchState
+      );
+
+      const getTrackedFacetValues = trackedFilters[facetName];
+      const trackedFacetValues = getTrackedFacetValues(facetRefinements);
+
+      return [
+        ...facets,
+        ...facetRefinements
+          .filter(facetRefinement =>
+            trackedFacetValues.includes(facetRefinement)
+          )
+          .map(facetValue =>
+            escapeRuleContext(`ais-${facetName}-${facetValue}`)
+          ),
+      ];
+    },
+    []
+  );
+
+  return ruleContexts;
+}
 
 export default createConnector({
   displayName: 'AlgoliaQueryRules',
 
   defaultProps: {
     transformItems: items => items,
+    transformRuleContexts: ruleContexts => ruleContexts,
+    trackedFilters: {},
   } as QueryRulesProps,
 
   getProvidedProps(props: QueryRulesProps, _1: any, searchResults: any) {
@@ -34,5 +135,43 @@ export default createConnector({
       items: transformedItems,
       canRefine: transformedItems.length > 0,
     };
+  },
+
+  getSearchParameters(
+    searchParameters: SearchParameters,
+    props: QueryRulesProps,
+    searchState: SearchState
+  ) {
+    if (Object.keys(props.trackedFilters).length === 0) {
+      return searchParameters;
+    }
+
+    const indexSearchState = hasMultipleIndices(this.context)
+      ? searchState.indices[getIndexId(this.context)]
+      : searchState;
+
+    const newRuleContexts = getRuleContextsFromTrackedFilters({
+      searchState: indexSearchState,
+      trackedFilters: props.trackedFilters,
+    });
+
+    const initialRuleContexts = searchParameters.ruleContexts || [];
+    const nextRuleContexts = [...initialRuleContexts, ...newRuleContexts];
+
+    if (process.env.NODE_ENV === 'development') {
+      if (nextRuleContexts.length > 10) {
+        // tslint:disable-next-line:no-console
+        console.warn(
+          `The maximum number of \`ruleContexts\` is 10. They have been sliced to that limit.
+Consider using \`transformRuleContexts\` to minimize the number of rules sent to Algolia.`
+        );
+      }
+    }
+
+    const ruleContexts = props
+      .transformRuleContexts(nextRuleContexts)
+      .slice(0, 10);
+
+    return searchParameters.setQueryParameter('ruleContexts', ruleContexts);
   },
 });

--- a/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
@@ -16,11 +16,7 @@ export default createConnector({
     transformItems: items => items,
   } as QueryRulesProps,
 
-  getProvidedProps(
-    props: QueryRulesProps,
-    _searchState: any,
-    searchResults: any
-  ) {
+  getProvidedProps(props: QueryRulesProps, _1: any, searchResults: any) {
     const results = getResults(searchResults, this.context);
 
     if (results === null) {

--- a/packages/react-instantsearch-core/src/index.js
+++ b/packages/react-instantsearch-core/src/index.js
@@ -48,3 +48,4 @@ export { default as connectStats } from './connectors/connectStats';
 export {
   default as connectToggleRefinement,
 } from './connectors/connectToggleRefinement';
+export { default as connectQueryRules } from './connectors/connectQueryRules';

--- a/packages/react-instantsearch-core/src/index.js
+++ b/packages/react-instantsearch-core/src/index.js
@@ -34,6 +34,7 @@ export { default as connectMenu } from './connectors/connectMenu';
 export { default as connectNumericMenu } from './connectors/connectNumericMenu';
 export { default as connectPagination } from './connectors/connectPagination';
 export { default as connectPoweredBy } from './connectors/connectPoweredBy';
+export { default as connectQueryRules } from './connectors/connectQueryRules';
 export { default as connectRange } from './connectors/connectRange';
 export {
   default as connectRefinementList,
@@ -48,4 +49,3 @@ export { default as connectStats } from './connectors/connectStats';
 export {
   default as connectToggleRefinement,
 } from './connectors/connectToggleRefinement';
-export { default as connectQueryRules } from './connectors/connectQueryRules';

--- a/packages/react-instantsearch-core/src/index.js
+++ b/packages/react-instantsearch-core/src/index.js
@@ -10,6 +10,7 @@ export { default as translatable } from './core/translatable';
 
 // Widgets
 export { default as Configure } from './widgets/Configure';
+export { default as QueryRuleContext } from './widgets/QueryRuleContext';
 
 // Connectors
 export {

--- a/packages/react-instantsearch-core/src/widgets/QueryRuleContext.ts
+++ b/packages/react-instantsearch-core/src/widgets/QueryRuleContext.ts
@@ -1,0 +1,5 @@
+import connectQueryRules from '../connectors/connectQueryRules';
+
+export default connectQueryRules(function QueryRuleContext() {
+  return null;
+});

--- a/packages/react-instantsearch-dom/src/components/QueryRuleCustomData.tsx
+++ b/packages/react-instantsearch-dom/src/components/QueryRuleCustomData.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { CustomUserData } from 'react-instantsearch-core';
+import { createClassNames } from '../core/utils';
+
+const cx = createClassNames('QueryRuleCustomData');
+
+type QueryRuleCustomDataRenderProps<TItem> = {
+  items: TItem[];
+};
+
+export type QueryRuleCustomDataProps<TItem> = {
+  items: TItem[];
+  className?: string;
+  children: (options: QueryRuleCustomDataRenderProps<TItem>) => React.ReactNode;
+};
+
+const QueryRuleCustomData: React.FC<
+  QueryRuleCustomDataProps<CustomUserData>
+> = ({ items, className, children }) => (
+  <div className={classNames(cx(''), className)}>{children({ items })}</div>
+);
+
+QueryRuleCustomData.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  className: PropTypes.string,
+  children: PropTypes.func.isRequired,
+};
+
+export default QueryRuleCustomData;

--- a/packages/react-instantsearch-dom/src/components/__tests__/QueryRuleCustomData.tsx
+++ b/packages/react-instantsearch-dom/src/components/__tests__/QueryRuleCustomData.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import QueryRuleCustomData, {
+  QueryRuleCustomDataProps,
+} from '../QueryRuleCustomData';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+type CustomDataItem = {
+  title: string;
+  banner: string;
+};
+
+type CustomDataProps = QueryRuleCustomDataProps<CustomDataItem>;
+
+describe('QueryRuleCustomData', () => {
+  it('expects to render the empty container with empty items', () => {
+    const props: CustomDataProps = {
+      items: [],
+      children: jest.fn(({ items }) =>
+        items.map(item => (
+          <section key={item.title}>
+            <img src={item.banner} alt={item.title} />
+          </section>
+        ))
+      ),
+    };
+
+    const wrapper = shallow(<QueryRuleCustomData {...props} />);
+
+    expect(props.children).toHaveBeenCalledTimes(1);
+    expect(props.children).toHaveBeenCalledWith({ items: props.items });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expects to render multiple items', () => {
+    const props: CustomDataProps = {
+      items: [
+        { title: 'Image 1', banner: 'image-1.png' },
+        { title: 'Image 2', banner: 'image-2.png' },
+      ],
+      children: jest.fn(({ items }) =>
+        items.map(item => (
+          <section key={item.title}>
+            <img src={item.banner} alt={item.title} />
+          </section>
+        ))
+      ),
+    };
+
+    const wrapper = shallow(<QueryRuleCustomData {...props} />);
+
+    expect(props.children).toHaveBeenCalledTimes(1);
+    expect(props.children).toHaveBeenCalledWith({ items: props.items });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('expects to render with custom className', () => {
+    const props: CustomDataProps = {
+      items: [],
+      className: 'CustomClassName',
+      children: jest.fn(() => null),
+    };
+
+    const wrapper = shallow(<QueryRuleCustomData {...props} />);
+
+    expect(wrapper.props().className).toContain('CustomClassName');
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/QueryRuleCustomData.tsx.snap
+++ b/packages/react-instantsearch-dom/src/components/__tests__/__snapshots__/QueryRuleCustomData.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QueryRuleCustomData expects to render multiple items 1`] = `
+<div
+  className="ais-QueryRuleCustomData"
+>
+  <section
+    key="Image 1"
+  >
+    <img
+      alt="Image 1"
+      src="image-1.png"
+    />
+  </section>
+  <section
+    key="Image 2"
+  >
+    <img
+      alt="Image 2"
+      src="image-2.png"
+    />
+  </section>
+</div>
+`;
+
+exports[`QueryRuleCustomData expects to render the empty container with empty items 1`] = `
+<div
+  className="ais-QueryRuleCustomData"
+/>
+`;
+
+exports[`QueryRuleCustomData expects to render with custom className 1`] = `
+<div
+  className="ais-QueryRuleCustomData CustomClassName"
+/>
+`;

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -29,6 +29,7 @@ export { connectSortBy } from 'react-instantsearch-core';
 export { connectStateResults } from 'react-instantsearch-core';
 export { connectStats } from 'react-instantsearch-core';
 export { connectToggleRefinement } from 'react-instantsearch-core';
+export { connectQueryRules } from 'react-instantsearch-core';
 
 // DOM
 export { default as InstantSearch } from './widgets/InstantSearch';

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -5,6 +5,7 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
+export { QueryRuleContext } from 'react-instantsearch-core';
 
 // Connectors
 export { connectAutoComplete } from 'react-instantsearch-core';
@@ -58,6 +59,7 @@ export { default as Snippet } from './widgets/Snippet';
 export { default as SortBy } from './widgets/SortBy';
 export { default as Stats } from './widgets/Stats';
 export { default as ToggleRefinement } from './widgets/ToggleRefinement';
+export { default as QueryRuleCustomData } from './widgets/QueryRuleCustomData';
 
 // Utils
 export { createClassNames } from './core/utils';

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -21,6 +21,7 @@ export { connectMenu } from 'react-instantsearch-core';
 export { connectNumericMenu } from 'react-instantsearch-core';
 export { connectPagination } from 'react-instantsearch-core';
 export { connectPoweredBy } from 'react-instantsearch-core';
+export { connectQueryRules } from 'react-instantsearch-core';
 export { connectRange } from 'react-instantsearch-core';
 export { connectRefinementList } from 'react-instantsearch-core';
 export { connectScrollTo } from 'react-instantsearch-core';
@@ -29,7 +30,6 @@ export { connectSortBy } from 'react-instantsearch-core';
 export { connectStateResults } from 'react-instantsearch-core';
 export { connectStats } from 'react-instantsearch-core';
 export { connectToggleRefinement } from 'react-instantsearch-core';
-export { connectQueryRules } from 'react-instantsearch-core';
 
 // DOM
 export { default as InstantSearch } from './widgets/InstantSearch';

--- a/packages/react-instantsearch-dom/src/widgets/QueryRuleCustomData.tsx
+++ b/packages/react-instantsearch-dom/src/widgets/QueryRuleCustomData.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { connectQueryRules, CustomUserData } from 'react-instantsearch-core';
+import PanelCallbackHandler from '../components/PanelCallbackHandler';
+import QueryRuleCustomData, {
+  QueryRuleCustomDataProps,
+} from '../components/QueryRuleCustomData';
+
+const QueryRuleCustomDataWidget: React.FC<
+  QueryRuleCustomDataProps<CustomUserData>
+> = props => (
+  <PanelCallbackHandler {...props}>
+    <QueryRuleCustomData {...props} />
+  </PanelCallbackHandler>
+);
+
+export default connectQueryRules(QueryRuleCustomDataWidget);

--- a/packages/react-instantsearch-native/src/index.js
+++ b/packages/react-instantsearch-native/src/index.js
@@ -21,6 +21,7 @@ export { connectMenu } from 'react-instantsearch-core';
 export { connectNumericMenu } from 'react-instantsearch-core';
 export { connectPagination } from 'react-instantsearch-core';
 export { connectPoweredBy } from 'react-instantsearch-core';
+export { connectQueryRules } from 'react-instantsearch-core';
 export { connectRange } from 'react-instantsearch-core';
 export { connectRefinementList } from 'react-instantsearch-core';
 export { connectScrollTo } from 'react-instantsearch-core';
@@ -29,7 +30,6 @@ export { connectSortBy } from 'react-instantsearch-core';
 export { connectStateResults } from 'react-instantsearch-core';
 export { connectStats } from 'react-instantsearch-core';
 export { connectToggleRefinement } from 'react-instantsearch-core';
-export { connectQueryRules } from 'react-instantsearch-core';
 
 // Native
 export { default as InstantSearch } from './widgets/InstantSearch';

--- a/packages/react-instantsearch-native/src/index.js
+++ b/packages/react-instantsearch-native/src/index.js
@@ -5,6 +5,7 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
+export { QueryRuleContext } from 'react-instantsearch-core';
 
 // Connectors
 export { connectAutoComplete } from 'react-instantsearch-core';

--- a/packages/react-instantsearch-native/src/index.js
+++ b/packages/react-instantsearch-native/src/index.js
@@ -29,6 +29,7 @@ export { connectSortBy } from 'react-instantsearch-core';
 export { connectStateResults } from 'react-instantsearch-core';
 export { connectStats } from 'react-instantsearch-core';
 export { connectToggleRefinement } from 'react-instantsearch-core';
+export { connectQueryRules } from 'react-instantsearch-core';
 
 // Native
 export { default as InstantSearch } from './widgets/InstantSearch';

--- a/stories/QueryRuleContext.stories.tsx
+++ b/stories/QueryRuleContext.stories.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { connectHits } from 'react-instantsearch-core';
+import {
+  QueryRuleCustomData,
+  QueryRuleContext,
+  Highlight,
+  RefinementList,
+} from 'react-instantsearch-dom';
+import { WrapWithHits } from './util';
+
+type CustomDataItem = {
+  title: string;
+  banner: string;
+  link: string;
+};
+
+type MovieHit = {
+  actors: string[];
+  color: string;
+  genre: string[];
+  image: string;
+  objectID: string;
+  score: number;
+  title: string;
+};
+
+const stories = storiesOf('QueryRuleContext', module);
+
+const StoryHits = connectHits(({ hits }: { hits: MovieHit[] }) => (
+  <div className="hits">
+    {hits.map(hit => (
+      <div key={hit.objectID} className="hit">
+        <div className="hit-picture">
+          <img src={hit.image} />
+        </div>
+
+        <div className="hit-content">
+          <div>
+            <Highlight attribute="title" hit={hit} />
+          </div>
+        </div>
+      </div>
+    ))}
+  </div>
+));
+
+const storyProps = {
+  appId: 'latency',
+  apiKey: 'af044fb0788d6bb15f807e4420592bc5',
+  indexName: 'instant_search_movies',
+  linkedStoryGroup: 'QueryRuleCustomData',
+  hitsElement: <StoryHits />,
+};
+
+stories
+  .add('default', () => (
+    <WrapWithHits {...storyProps}>
+      <ul>
+        <li>
+          On empty query, select the "Drama" category and The Shawshank
+          Redemption appears
+        </li>
+        <li>
+          On empty query, select the "Thriller" category and Pulp Fiction
+          appears
+        </li>
+        <li>
+          Type <q>music</q> and a banner will appear
+        </li>
+      </ul>
+
+      <div style={{ display: 'flex' }}>
+        <aside style={{ flex: 1 }}>
+          <RefinementList attribute="genre" />
+        </aside>
+
+        <main style={{ flex: 2 }}>
+          <QueryRuleContext
+            trackedFilters={{
+              genre: () => ['Drama', 'Thriller'],
+            }}
+          />
+
+          <QueryRuleCustomData>
+            {({ items }: { items: CustomDataItem[] }) =>
+              items.map(({ banner, title, link }) => {
+                if (!banner) {
+                  return null;
+                }
+
+                return (
+                  <section key={title}>
+                    <h2>{title}</h2>
+
+                    <a href={link}>
+                      <img src={banner} alt={title} />
+                    </a>
+                  </section>
+                );
+              })
+            }
+          </QueryRuleCustomData>
+        </main>
+      </div>
+    </WrapWithHits>
+  ))
+  .add('with default rule context', () => (
+    <WrapWithHits {...storyProps}>
+      <ul>
+        <li>The rule context `ais-genre-Drama` is applied by default</li>
+        <li>
+          Select the "Drama" category and The Shawshank Redemption appears
+        </li>
+        <li>Select the "Thriller" category and Pulp Fiction appears</li>
+        <li>
+          Type <q>music</q> and a banner will appear
+        </li>
+      </ul>
+
+      <div style={{ display: 'flex' }}>
+        <aside style={{ flex: 1 }}>
+          <RefinementList attribute="genre" />
+        </aside>
+
+        <main style={{ flex: 2 }}>
+          <QueryRuleContext
+            trackedFilters={{
+              genre: () => ['Drama', 'Thriller'],
+            }}
+            transformRuleContexts={(ruleContexts: string[]) => {
+              if (ruleContexts.length === 0) {
+                return ['ais-genre-Drama'];
+              }
+
+              return ruleContexts;
+            }}
+          />
+
+          <QueryRuleCustomData>
+            {({ items }: { items: CustomDataItem[] }) =>
+              items.map(({ banner, title, link }) => {
+                if (!banner) {
+                  return null;
+                }
+
+                return (
+                  <section key={title}>
+                    <h2>{title}</h2>
+
+                    <a href={link}>
+                      <img src={banner} alt={title} />
+                    </a>
+                  </section>
+                );
+              })
+            }
+          </QueryRuleCustomData>
+        </main>
+      </div>
+    </WrapWithHits>
+  ));

--- a/stories/QueryRuleCustomData.stories.tsx
+++ b/stories/QueryRuleCustomData.stories.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { connectHits } from 'react-instantsearch-core';
+import { QueryRuleCustomData, Panel, Highlight } from 'react-instantsearch-dom';
+import { WrapWithHits } from './util';
+
+type CustomDataItem = {
+  title: string;
+  banner: string;
+  link: string;
+};
+
+type MovieHit = {
+  actors: string[];
+  color: string;
+  genre: string[];
+  image: string;
+  objectID: string;
+  score: number;
+  title: string;
+};
+
+const stories = storiesOf('QueryRuleCustomData', module);
+
+const StoryHits = connectHits(({ hits }: { hits: MovieHit[] }) => (
+  <div className="hits">
+    {hits.map(hit => (
+      <div key={hit.objectID} className="hit">
+        <div className="hit-picture">
+          <img src={hit.image} />
+        </div>
+
+        <div className="hit-content">
+          <div>
+            <Highlight attribute="title" hit={hit} />
+          </div>
+        </div>
+      </div>
+    ))}
+  </div>
+));
+
+const storyProps = {
+  appId: 'latency',
+  apiKey: 'af044fb0788d6bb15f807e4420592bc5',
+  indexName: 'instant_search_movies',
+  linkedStoryGroup: 'QueryRuleCustomData',
+  hitsElement: <StoryHits />,
+};
+
+stories
+  .add('default', () => (
+    <WrapWithHits {...storyProps}>
+      <p>
+        Type <q>music</q> and a banner will appear.
+      </p>
+
+      <QueryRuleCustomData>
+        {({ items }: { items: CustomDataItem[] }) =>
+          items.map(({ banner, title, link }) => {
+            if (!banner) {
+              return null;
+            }
+
+            return (
+              <section key={title}>
+                <h2>{title}</h2>
+
+                <a href={link}>
+                  <img src={banner} alt={title} />
+                </a>
+              </section>
+            );
+          })
+        }
+      </QueryRuleCustomData>
+    </WrapWithHits>
+  ))
+  .add('with default banner', () => (
+    <WrapWithHits {...storyProps}>
+      <p>
+        Kill Bill appears whenever no other results are promoted. Type{' '}
+        <q>music</q> to see another movie promoted.
+      </p>
+
+      <QueryRuleCustomData
+        transformItems={(items: CustomDataItem[]) => {
+          if (items.length > 0) {
+            return items;
+          }
+
+          return [
+            {
+              title: 'Kill Bill',
+              banner: 'http://static.bobatv.net/IMovie/mv_2352/poster_2352.jpg',
+              link: 'https://www.netflix.com/title/60031236',
+            },
+          ];
+        }}
+      >
+        {({ items }: { items: CustomDataItem[] }) =>
+          items.map(({ banner, title, link }) => {
+            if (!banner) {
+              return null;
+            }
+
+            return (
+              <section key={title}>
+                <h2>{title}</h2>
+
+                <a href={link}>
+                  <img src={banner} alt={title} />
+                </a>
+              </section>
+            );
+          })
+        }
+      </QueryRuleCustomData>
+    </WrapWithHits>
+  ))
+  .add('with Panel', () => (
+    <WrapWithHits {...storyProps}>
+      <p>
+        Type <q>music</q> and a banner will appear.
+      </p>
+
+      <Panel header="QueryRuleCustomData" footer="footer">
+        <QueryRuleCustomData>
+          {({ items }: { items: CustomDataItem[] }) =>
+            items.map(({ banner, title, link }) => {
+              if (!banner) {
+                return null;
+              }
+
+              return (
+                <section key={title}>
+                  <h2>{title}</h2>
+
+                  <a href={link}>
+                    <img src={banner} alt={title} />
+                  </a>
+                </section>
+              );
+            })
+          }
+        </QueryRuleCustomData>
+      </Panel>
+    </WrapWithHits>
+  ));

--- a/storybook/public/default.css
+++ b/storybook/public/default.css
@@ -8,3 +8,7 @@ a {
   color: #3e82f7;
   text-decoration: none;
 }
+
+#root img {
+  max-width: 100%;
+}

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
             loader: 'babel-loader',
             options: {
               rootMode: 'upward',
+              presets: [['react-app', { typescript: true }]],
             },
           },
         ],

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,8 @@
     "no-parameter-reassignment": false,
     "object-literal-sort-keys": false,
     "ordered-imports": false,
-    "prettier": true
+    "prettier": true,
+    "jsx-no-lambda": false,
+    "no-empty": false
   }
 }


### PR DESCRIPTION
_This is the 1st PR in the series "Merchandized Query Rules"._

## Summary

This creates the `connectQueryRules` connector, responsible for handling Algolia Query Rules features.

## Motivation

[Read RFC →](https://github.com/algolia/instantsearch-rfcs/blob/master/accepted/merchandized-query-rules.md)

## Implementation

The connector passes `userData` array to the widget via a prop named `items`.

For this React implementation, I decided not to keep the name `userData` because at second thought, it makes more sense to apply `transformItems` to something called `items`. I will rename this data in the InstantSearch.js implementation.

## Connector usage

Two widgets will be based on this connector:

- `QueryRuleCustomData`
- `QueryRuleContext`

## Related

- InstantSearch.js
  - [`connectQueryRules`](https://github.com/algolia/instantsearch.js/pull/3597)
  - [`queryRuleCustomData`](https://github.com/algolia/instantsearch.js/pull/3600)
  - [`queryRuleContext`](https://github.com/algolia/instantsearch.js/pull/3602)
- [Merchandized Query Rules RFC](https://github.com/algolia/instantsearch-rfcs/blob/master/accepted/merchandized-query-rules.md)