### PR TITLE
feat(insights): compute insights data in connectHits [PART-1] 

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Connectors.min.js",
-      "maxSize": "40 kB"
+      "maxSize": "40.25 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
@@ -142,7 +142,7 @@
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "63 kB"
+      "maxSize": "63.25 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHitInsights.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHitInsights.ts
@@ -1,0 +1,106 @@
+import connect from '../connectHitInsights';
+
+jest.mock('../../core/createConnector', () => x => x);
+
+function setup() {
+  const insightsClient = jest.fn();
+
+  const createMultiIndexContext = () => ({
+    context: {
+      ais: {
+        mainTargetedIndex: 'theFirstIndex',
+      },
+      multiIndexContext: {
+        targetedIndex: 'theIndex',
+      },
+    },
+  });
+
+  const context = createMultiIndexContext();
+  const getProvidedProps = connect(insightsClient).getProvidedProps.bind(
+    context
+  );
+
+  const hit = {
+    objectID: 'objectID_42',
+    __position: 42,
+    __queryID: 'theQueryID',
+  };
+  const searchResults = { results: { theIndex: { index: 'theIndex' } } };
+  const props = getProvidedProps({ hit }, null, searchResults);
+  return { insightsClient, props };
+}
+
+describe('connectHitInsights', () => {
+  it('should expose an `insights` property', () => {
+    const { props } = setup();
+    expect(props).toHaveProperty('insights');
+  });
+
+  it('exposed `insights` should be a function', () => {
+    const { props } = setup();
+    expect(typeof props.insights).toBe('function');
+  });
+
+  describe('when called with `clickedObjectIDsAfterSearch`', () => {
+    let insightsClient;
+    beforeEach(() => {
+      const { insightsClient: aa, props } = setup();
+      insightsClient = aa;
+      props.insights('clickedObjectIDsAfterSearch', {
+        eventName: 'Add to cart',
+      });
+    });
+
+    it('should forward call to insightsClient with the correct payload', () => {
+      expect(insightsClient).toHaveBeenCalledTimes(1);
+      const [method, payload] = insightsClient.mock.calls[0];
+      expect(method).toEqual('clickedObjectIDsAfterSearch');
+      expect(payload).toEqual({
+        eventName: 'Add to cart',
+        objectIDs: ['objectID_42'],
+        positions: [42],
+        queryID: 'theQueryID',
+        index: 'theIndex',
+      });
+    });
+  });
+
+  describe('when called with `convertedObjectIDsAfterSearch`', () => {
+    let insightsClient;
+    beforeEach(() => {
+      const { insightsClient: aa, props } = setup();
+      insightsClient = aa;
+      props.insights('convertedObjectIDsAfterSearch', {
+        eventName: 'Add to cart',
+      });
+    });
+
+    it('should forward call to insightsClient with the correct payload', () => {
+      expect(insightsClient).toHaveBeenCalledTimes(1);
+
+      const [method, payload] = insightsClient.mock.calls[0];
+      expect(method).toEqual('convertedObjectIDsAfterSearch');
+      expect(payload).toEqual({
+        eventName: 'Add to cart',
+        objectIDs: ['objectID_42'],
+        queryID: 'theQueryID',
+        index: 'theIndex',
+      });
+    });
+  });
+
+  describe('when called with an unsupported method', () => {
+    it('should reject the call', () => {
+      expect(() => {
+        const { props } = setup();
+        // @ts-ignore
+        props.insights('wrong-method-name', {
+          eventName: 'Add to cart',
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"Unsupported method \\"wrong-method-name\\" passed to the insights function. The supported methods are: \\"clickedObjectIDsAfterSearch\\", \\"convertedObjectIDsAfterSearch\\"."`
+      );
+    });
+  });
+});

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHits.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHits.js
@@ -11,9 +11,31 @@ describe('connectHits', () => {
     it('provides the current hits to the component', () => {
       const hits = [{}];
       const props = getProvidedProps(null, null, {
-        results: { hits },
+        results: { hits, hitsPerPage: 2, page: 2 },
       });
-      expect(props).toEqual({ hits });
+      expect(props).toEqual({
+        hits: hits.map(hit => expect.objectContaining(hit)),
+      });
+    });
+
+    it('adds positions to the hits provided to the component', () => {
+      const hits = [{}];
+      const props = getProvidedProps(null, null, {
+        results: { hits, hitsPerPage: 2, page: 2 },
+      });
+      expect(props).toEqual({
+        hits: [{ __position: 5 }],
+      });
+    });
+
+    it('adds queryID to the hits provided to the component', () => {
+      const hits = [{}];
+      const props = getProvidedProps(null, null, {
+        results: { hits, hitsPerPage: 2, page: 2, queryID: 'theQueryID' },
+      });
+      expect(props).toEqual({
+        hits: [expect.objectContaining({ __queryID: 'theQueryID' })],
+      });
     });
 
     it("doesn't render when no hits are available", () => {
@@ -37,9 +59,33 @@ describe('connectHits', () => {
     it('provides the current hits to the component', () => {
       const hits = [{}];
       const props = getProvidedProps(null, null, {
-        results: { second: { hits } },
+        results: { second: { hits, hitsPerPage: 2, page: 2 } },
       });
-      expect(props).toEqual({ hits });
+      expect(props).toEqual({
+        hits: hits.map(hit => expect.objectContaining(hit)),
+      });
+    });
+
+    it('adds positions to the hits provided to the component', () => {
+      const hits = [{}];
+      const props = getProvidedProps(null, null, {
+        results: { second: { hits, hitsPerPage: 2, page: 2 } },
+      });
+      expect(props).toEqual({
+        hits: [{ __position: 5 }],
+      });
+    });
+
+    it('adds queryID to the hits provided to the component', () => {
+      const hits = [{}];
+      const props = getProvidedProps(null, null, {
+        results: {
+          second: { hits, hitsPerPage: 2, page: 2, queryID: 'theQueryID' },
+        },
+      });
+      expect(props).toEqual({
+        hits: [expect.objectContaining({ __queryID: 'theQueryID' })],
+      });
     });
 
     it("doesn't render when no hits are available", () => {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectInfiniteHits.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectInfiniteHits.js
@@ -160,6 +160,7 @@ describe('connectInfiniteHits', () => {
         10,
         11,
         12,
+        // hitsPerPage changed from 6 to 8, elements 13-16 are skipped
         // page: 2, hitsPerPage: 8
         17,
         18,
@@ -226,6 +227,7 @@ describe('connectInfiniteHits', () => {
         10,
         11,
         12,
+        // hitsPerPage changed from 6 to 8, elements 13-16 are skipped
         // page: 2, hitsPerPage: 8
         17,
         18,

--- a/packages/react-instantsearch-core/src/connectors/connectHitInsights.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectHitInsights.ts
@@ -1,0 +1,77 @@
+import createConnector from '../core/createConnector';
+import { getResults } from '../core/indexUtils';
+
+type Without<T, K> = Pick<T, Exclude<keyof T, K>>;
+type Results = { index: string };
+type Hit = { objectID: string; __position: number; __queryID: string };
+
+type InsightsClient = (
+  method: InsightsClientMethod,
+  payload: InsightsClientPayload
+) => void;
+
+type InsightsClientMethod =
+  | 'clickedObjectIDsAfterSearch'
+  | 'convertedObjectIDsAfterSearch';
+
+type InsightsClientPayload = {
+  index: string;
+  queryID: string;
+  eventName: string;
+  objectIDs: string[];
+  positions?: number[];
+};
+
+function inferPayload({
+  method,
+  results,
+  currentHit,
+}: {
+  method: InsightsClientMethod;
+  results: Results;
+  currentHit: Hit;
+}): Without<InsightsClientPayload, 'eventName'> {
+  const { index } = results;
+  const queryID = currentHit.__queryID;
+  const objectIDs = [currentHit.objectID];
+  switch (method) {
+    case 'clickedObjectIDsAfterSearch': {
+      const positions = [currentHit.__position];
+      return { index, queryID, objectIDs, positions };
+    }
+
+    case 'convertedObjectIDsAfterSearch':
+      return { index, queryID, objectIDs };
+
+    default:
+      throw new Error(
+        `Unsupported method "${method}" passed to the insights function. The supported methods are: "clickedObjectIDsAfterSearch", "convertedObjectIDsAfterSearch".`
+      );
+  }
+}
+
+const wrapInsightsClient = (
+  aa: InsightsClient,
+  results: Results,
+  currentHit: Hit
+) => (
+  method: InsightsClientMethod,
+  payload: Partial<InsightsClientPayload>
+) => {
+  if (typeof aa !== 'function') {
+    throw new TypeError(`Expected insightsClient to be a Function`);
+  }
+  const inferredPayload = inferPayload({ method, results, currentHit });
+  aa(method, { ...inferredPayload, ...payload } as any);
+};
+
+export default (insightsClient: InsightsClient) =>
+  createConnector({
+    displayName: 'AlgoliaInsights',
+
+    getProvidedProps(props, _, searchResults) {
+      const results: Results = getResults(searchResults, this.context);
+      const insights = wrapInsightsClient(insightsClient, results, props.hit);
+      return { insights };
+    },
+  });

--- a/packages/react-instantsearch-core/src/connectors/connectHits.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHits.js
@@ -1,5 +1,9 @@
 import createConnector from '../core/createConnector';
-import { getResults } from '../core/indexUtils';
+import {
+  addAbsolutePositions,
+  addQueryID,
+  getResults,
+} from '../core/indexUtils';
 
 /**
  * connectHits connector provides the logic to create connected
@@ -45,8 +49,16 @@ export default createConnector({
 
   getProvidedProps(props, searchState, searchResults) {
     const results = getResults(searchResults, this.context);
-    const hits = results ? results.hits : [];
+    let hits = [];
+    if (results) {
+      hits = addAbsolutePositions(
+        results.hits,
+        results.hitsPerPage,
+        results.page
+      );
 
+      hits = addQueryID(hits, results.queryID);
+    }
     return { hits };
   },
 

--- a/packages/react-instantsearch-core/src/connectors/connectHits.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHits.js
@@ -46,17 +46,19 @@ export default createConnector({
 
   getProvidedProps(props, searchState, searchResults) {
     const results = getResults(searchResults, this.context);
-    let hits = [];
-    if (results) {
-      hits = addAbsolutePositions(
-        results.hits,
-        results.hitsPerPage,
-        results.page
-      );
-
-      hits = addQueryID(hits, results.queryID);
+    if (!results) {
+      return { hits: [] };
     }
-    return { hits };
+    const hitsWithPositions = addAbsolutePositions(
+      results.hits,
+      results.hitsPerPage,
+      results.page
+    );
+    const hitsWithPositionsAndQueryID = addQueryID(
+      hitsWithPositions,
+      results.queryID
+    );
+    return { hits: hitsWithPositionsAndQueryID };
   },
 
   /* Hits needs to be considered as a widget to trigger a search if no others widgets are used.

--- a/packages/react-instantsearch-core/src/connectors/connectHits.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHits.js
@@ -1,9 +1,6 @@
 import createConnector from '../core/createConnector';
-import {
-  addAbsolutePositions,
-  addQueryID,
-  getResults,
-} from '../core/indexUtils';
+import { getResults } from '../core/indexUtils';
+import { addAbsolutePositions, addQueryID } from '../core/utils';
 
 /**
  * connectHits connector provides the logic to create connected

--- a/packages/react-instantsearch-core/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch-core/src/connectors/connectInfiniteHits.js
@@ -54,13 +54,9 @@ export default createConnector({
       };
     }
 
-    const { page, nbPages } = results;
+    const { hits, hitsPerPage, page, nbPages } = results;
 
-    const hitsWithPositions = addAbsolutePositions(
-      results.hits,
-      results.hitsPerPage,
-      page
-    );
+    const hitsWithPositions = addAbsolutePositions(hits, hitsPerPage, page);
     const hitsWithPositionsAndQueryID = addQueryID(
       hitsWithPositions,
       results.queryID

--- a/packages/react-instantsearch-core/src/index.js
+++ b/packages/react-instantsearch-core/src/index.js
@@ -48,3 +48,4 @@ export { default as connectStats } from './connectors/connectStats';
 export {
   default as connectToggleRefinement,
 } from './connectors/connectToggleRefinement';
+export { default as connectHitInsights } from './connectors/connectHitInsights';

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -14,6 +14,7 @@ export { connectCurrentRefinements } from 'react-instantsearch-core';
 export { connectGeoSearch } from 'react-instantsearch-core';
 export { connectHierarchicalMenu } from 'react-instantsearch-core';
 export { connectHighlight } from 'react-instantsearch-core';
+export { connectHitInsights } from 'react-instantsearch-core';
 export { connectHits } from 'react-instantsearch-core';
 export { connectHitsPerPage } from 'react-instantsearch-core';
 export { connectInfiniteHits } from 'react-instantsearch-core';

--- a/packages/react-instantsearch-native/src/index.js
+++ b/packages/react-instantsearch-native/src/index.js
@@ -14,6 +14,7 @@ export { connectCurrentRefinements } from 'react-instantsearch-core';
 export { connectGeoSearch } from 'react-instantsearch-core';
 export { connectHierarchicalMenu } from 'react-instantsearch-core';
 export { connectHighlight } from 'react-instantsearch-core';
+export { connectHitInsights } from 'react-instantsearch-core';
 export { connectHits } from 'react-instantsearch-core';
 export { connectHitsPerPage } from 'react-instantsearch-core';
 export { connectInfiniteHits } from 'react-instantsearch-core';

--- a/packages/react-instantsearch/connectors.js
+++ b/packages/react-instantsearch/connectors.js
@@ -5,6 +5,7 @@ export { connectCurrentRefinements } from 'react-instantsearch-core';
 export { connectGeoSearch } from 'react-instantsearch-core';
 export { connectHierarchicalMenu } from 'react-instantsearch-core';
 export { connectHighlight } from 'react-instantsearch-core';
+export { connectHitInsights } from 'react-instantsearch-core';
 export { connectHits } from 'react-instantsearch-core';
 export { connectHitsPerPage } from 'react-instantsearch-core';
 export { connectInfiniteHits } from 'react-instantsearch-core';

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -6,8 +6,11 @@ import {
   Highlight,
   Panel,
   Snippet,
+  Configure,
 } from 'react-instantsearch-dom';
 import { WrapWithHits } from './util';
+import { action } from '@storybook/addon-actions';
+import { connectHitInsights } from 'react-instantsearch-core';
 
 const stories = storiesOf('InfiniteHits', module);
 
@@ -17,33 +20,67 @@ stories
       <InfiniteHits />
     </WrapWithHits>
   ))
-  .add('with custom rendering', () => (
-    <WrapWithHits linkedStoryGroup="InfiniteHits">
-      <InfiniteHits hitComponent={Product} />
-    </WrapWithHits>
-  ))
+  .add('with custom rendering', () => {
+    function Product({ hit }) {
+      return (
+        <div>
+          <Highlight attribute="name" hit={hit} />
+          <p>
+            <Highlight attribute="type" hit={hit} />
+          </p>
+          <p>
+            <Snippet attribute="description" hit={hit} />
+          </p>
+        </div>
+      );
+    }
+
+    Product.propTypes = {
+      hit: PropTypes.object.isRequired,
+    };
+
+    return (
+      <WrapWithHits linkedStoryGroup="InfiniteHits">
+        <InfiniteHits hitComponent={Product} />
+      </WrapWithHits>
+    );
+  })
   .add('with Panel', () => (
     <WrapWithHits linkedStoryGroup="InfiniteHits" pagination={false}>
       <Panel header="Infinite hits" footer="Footer">
         <InfiniteHits />
       </Panel>
     </WrapWithHits>
-  ));
+  ))
+  .add('with Insights', () => {
+    const insightsClient = (method, payload) =>
+      action(`[InsightsClient] sent ${method} with payload`)(payload);
+    const ProductWithInsights = connectHitInsights(insightsClient)(Product);
 
-function Product({ hit }) {
-  return (
-    <div>
-      <Highlight attribute="name" hit={hit} />
-      <p>
-        <Highlight attribute="type" hit={hit} />
-      </p>
-      <p>
-        <Snippet attribute="description" hit={hit} />
-      </p>
-    </div>
-  );
-}
-
-Product.propTypes = {
-  hit: PropTypes.object.isRequired,
-};
+    function Product({ hit, insights }) {
+      return (
+        <div>
+          <Highlight attribute="name" hit={hit} />
+          <button
+            onClick={() =>
+              insights('clickedObjectIDsAfterSearch', {
+                eventName: 'Add to cart',
+              })
+            }
+          >
+            Add to cart
+          </button>
+        </div>
+      );
+    }
+    Product.propTypes = {
+      hit: PropTypes.object.isRequired,
+      insights: PropTypes.func.isRequired,
+    };
+    return (
+      <WrapWithHits linkedStoryGroup="Hits">
+        <Configure clickAnalytics />
+        <InfiniteHits hitComponent={ProductWithInsights} />
+      </WrapWithHits>
+    );
+  });


### PR DESCRIPTION
**Summary**

This PR adds what's need to add **absolute position** and **queryID** to every hit of connectHits



**Result**

Not much to demonstrate yet but from now on every hit will look like this
```js
{
    objectID: "theObjectID",
    __position: 42,
    __queryID: "theQueryID"
}
```

**Global Outline** 
- [x] PART-0 add __positions and __query ID inside connectInfiniteHits https://github.com/algolia/react-instantsearch/pull/2215
- [x] PART-1 add __positions and __query ID inside connectHits [#current](https://github.com/algolia/react-instantsearch/pull/2216)
- [x] PART-2 create connectInsights https://github.com/algolia/react-instantsearch/pull/2217
