### PR TITLE
 feat(queryRules): add QueryRuleContext widget [part 4]

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "63.25 kB"
+      "maxSize": "63.50 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",

--- a/packages/react-instantsearch-core/src/index.js
+++ b/packages/react-instantsearch-core/src/index.js
@@ -10,6 +10,7 @@ export { default as translatable } from './core/translatable';
 
 // Widgets
 export { default as Configure } from './widgets/Configure';
+export { default as QueryRuleContext } from './widgets/QueryRuleContext';
 
 // Connectors
 export {

--- a/packages/react-instantsearch-core/src/widgets/QueryRuleContext.ts
+++ b/packages/react-instantsearch-core/src/widgets/QueryRuleContext.ts
@@ -1,0 +1,3 @@
+import connectQueryRules from '../connectors/connectQueryRules';
+
+export default connectQueryRules(() => null);

--- a/packages/react-instantsearch-core/src/widgets/QueryRuleContext.ts
+++ b/packages/react-instantsearch-core/src/widgets/QueryRuleContext.ts
@@ -1,3 +1,5 @@
 import connectQueryRules from '../connectors/connectQueryRules';
 
-export default connectQueryRules(() => null);
+export default connectQueryRules(function QueryRuleContext() {
+  return null;
+});

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -5,6 +5,7 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
+export { QueryRuleContext } from 'react-instantsearch-core';
 
 // Connectors
 export { connectAutoComplete } from 'react-instantsearch-core';

--- a/packages/react-instantsearch-native/src/index.js
+++ b/packages/react-instantsearch-native/src/index.js
@@ -5,6 +5,7 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
+export { QueryRuleContext } from 'react-instantsearch-core';
 
 // Connectors
 export { connectAutoComplete } from 'react-instantsearch-core';

--- a/stories/QueryRuleContext.stories.tsx
+++ b/stories/QueryRuleContext.stories.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { connectHits } from 'react-instantsearch-core';
+import {
+  QueryRuleCustomData,
+  QueryRuleContext,
+  Highlight,
+  RefinementList,
+} from 'react-instantsearch-dom';
+import { WrapWithHits } from './util';
+
+type CustomDataItem = {
+  title: string;
+  banner: string;
+  link: string;
+};
+
+type MovieHit = {
+  actors: string[];
+  color: string;
+  genre: string[];
+  image: string;
+  objectID: string;
+  score: number;
+  title: string;
+};
+
+const stories = storiesOf('QueryRuleContext', module);
+
+const StoryHits = connectHits(({ hits }: { hits: MovieHit[] }) => (
+  <div className="hits">
+    {hits.map(hit => (
+      <div key={hit.objectID} className="hit">
+        <div className="hit-picture">
+          <img src={hit.image} />
+        </div>
+
+        <div className="hit-content">
+          <div>
+            <Highlight attribute="title" hit={hit} />
+          </div>
+        </div>
+      </div>
+    ))}
+  </div>
+));
+
+const storyProps = {
+  appId: 'latency',
+  apiKey: 'af044fb0788d6bb15f807e4420592bc5',
+  indexName: 'instant_search_movies',
+  linkedStoryGroup: 'QueryRuleCustomData',
+  hitsElement: <StoryHits />,
+};
+
+stories
+  .add('default', () => (
+    <WrapWithHits {...storyProps}>
+      <ul>
+        <li>
+          On empty query, select the "Drama" category and The Shawshank
+          Redemption appears
+        </li>
+        <li>
+          On empty query, select the "Thriller" category and Pulp Fiction
+          appears
+        </li>
+        <li>
+          Type <q>music</q> and a banner will appear
+        </li>
+      </ul>
+
+      <div style={{ display: 'flex' }}>
+        <aside style={{ flex: 1 }}>
+          <RefinementList attribute="genre" />
+        </aside>
+
+        <main style={{ flex: 2 }}>
+          <QueryRuleContext
+            trackedFilters={{
+              genre: () => ['Drama', 'Thriller'],
+            }}
+          />
+
+          <QueryRuleCustomData>
+            {({ items }: { items: CustomDataItem[] }) => {
+              if (!items[0]) {
+                return null;
+              }
+
+              const { banner, title, link } = items[0];
+
+              if (!banner) {
+                return null;
+              }
+
+              return (
+                <section key={title}>
+                  <h2>{title}</h2>
+
+                  <a href={link}>
+                    <img src={banner} alt={title} />
+                  </a>
+                </section>
+              );
+            }}
+          </QueryRuleCustomData>
+        </main>
+      </div>
+    </WrapWithHits>
+  ))
+  .add('with default rule context', () => (
+    <WrapWithHits {...storyProps}>
+      <ul>
+        <li>The rule context `ais-genre-Drama` is applied by default</li>
+        <li>
+          Select the "Drama" category and The Shawshank Redemption appears
+        </li>
+        <li>Select the "Thriller" category and Pulp Fiction appears</li>
+        <li>
+          Type <q>music</q> and a banner will appear
+        </li>
+      </ul>
+
+      <div style={{ display: 'flex' }}>
+        <aside style={{ flex: 1 }}>
+          <RefinementList attribute="genre" />
+        </aside>
+
+        <main style={{ flex: 2 }}>
+          <QueryRuleContext
+            trackedFilters={{
+              genre: () => ['Drama', 'Thriller'],
+            }}
+            transformRuleContexts={(ruleContexts: string[]) => {
+              if (ruleContexts.length === 0) {
+                return ['ais-genre-Drama'];
+              }
+
+              return ruleContexts;
+            }}
+          />
+
+          <QueryRuleCustomData>
+            {({ items }: { items: CustomDataItem[] }) => {
+              if (!items[0]) {
+                return null;
+              }
+
+              const { banner, title, link } = items[0];
+
+              if (!banner) {
+                return null;
+              }
+
+              return (
+                <section key={title}>
+                  <h2>{title}</h2>
+
+                  <a href={link}>
+                    <img src={banner} alt={title} />
+                  </a>
+                </section>
+              );
+            }}
+          </QueryRuleCustomData>
+        </main>
+      </div>
+    </WrapWithHits>
+  ));

--- a/stories/QueryRuleContext.stories.tsx
+++ b/stories/QueryRuleContext.stories.tsx
@@ -83,27 +83,23 @@ stories
           />
 
           <QueryRuleCustomData>
-            {({ items }: { items: CustomDataItem[] }) => {
-              if (!items[0]) {
-                return null;
-              }
+            {({ items }: { items: CustomDataItem[] }) =>
+              items.map(({ banner, title, link }) => {
+                if (!banner) {
+                  return null;
+                }
 
-              const { banner, title, link } = items[0];
+                return (
+                  <section key={title}>
+                    <h2>{title}</h2>
 
-              if (!banner) {
-                return null;
-              }
-
-              return (
-                <section key={title}>
-                  <h2>{title}</h2>
-
-                  <a href={link}>
-                    <img src={banner} alt={title} />
-                  </a>
-                </section>
-              );
-            }}
+                    <a href={link}>
+                      <img src={banner} alt={title} />
+                    </a>
+                  </section>
+                );
+              })
+            }
           </QueryRuleCustomData>
         </main>
       </div>
@@ -142,27 +138,23 @@ stories
           />
 
           <QueryRuleCustomData>
-            {({ items }: { items: CustomDataItem[] }) => {
-              if (!items[0]) {
-                return null;
-              }
+            {({ items }: { items: CustomDataItem[] }) =>
+              items.map(({ banner, title, link }) => {
+                if (!banner) {
+                  return null;
+                }
 
-              const { banner, title, link } = items[0];
+                return (
+                  <section key={title}>
+                    <h2>{title}</h2>
 
-              if (!banner) {
-                return null;
-              }
-
-              return (
-                <section key={title}>
-                  <h2>{title}</h2>
-
-                  <a href={link}>
-                    <img src={banner} alt={title} />
-                  </a>
-                </section>
-              );
-            }}
+                    <a href={link}>
+                      <img src={banner} alt={title} />
+                    </a>
+                  </section>
+                );
+              })
+            }
           </QueryRuleCustomData>
         </main>
       </div>

--- a/storybook/public/default.css
+++ b/storybook/public/default.css
@@ -8,3 +8,7 @@ a {
   color: #3e82f7;
   text-decoration: none;
 }
+
+#root img {
+  max-width: 100%;
+}


### PR DESCRIPTION
## Summary

This **headless** widget sets the rule contexts (called [`ruleContexts`](https://www.algolia.com/doc/api-reference/api-parameters/ruleContexts/)) of the search parameters based on the search state.

## Usage

```jsx
<QueryRuleContext
  trackedFilters={{
    genre: () => ['Drama', 'Thriller'],
  }}
  transformRuleContexts={ruleContexts => {
    if (ruleContexts.length === 0) {
      return ['ais-genre-Drama'];
    }

    return ruleContexts;
  }}
/>
```

## Stories

- [Default](https://deploy-preview-2259--react-instantsearch.netlify.com/storybook/?selectedKind=QueryRuleContext&selectedStory=default&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs)

## Related

- Widget in InstantSearch.js: algolia/instantsearch.js#3602