### PR TITLE
fix(compat): upgrade SearchBox lifecycle

### DIFF
--- a/packages/react-instantsearch-dom/src/components/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/SearchBox.js
@@ -115,19 +115,13 @@ class SearchBox extends Component {
     document.removeEventListener('keydown', this.onKeyDown);
   }
 
-  componentWillReceiveProps(nextProps) {
-    // @TODO: should component maybe be controlled, otherwise Derived
-
-    // Reset query when the searchParameters query has changed.
-    // This is kind of an anti-pattern (props in state), but it works here
-    // since we know for sure that searchParameters having changed means a
-    // new search has been triggered.
+  componentDidUpdate(prevProps) {
     if (
-      !nextProps.searchAsYouType &&
-      nextProps.currentRefinement !== this.props.currentRefinement
+      !prevProps.searchAsYouType &&
+      prevProps.currentRefinement !== this.props.currentRefinement
     ) {
       this.setState({
-        query: nextProps.currentRefinement,
+        query: this.props.currentRefinement,
       });
     }
   }

--- a/packages/react-instantsearch-dom/src/components/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/SearchBox.js
@@ -117,7 +117,7 @@ class SearchBox extends Component {
 
   componentDidUpdate(prevProps) {
     if (
-      !prevProps.searchAsYouType &&
+      !this.props.searchAsYouType &&
       prevProps.currentRefinement !== this.props.currentRefinement
     ) {
       this.setState({


### PR DESCRIPTION
This migrates away from deprecated React lifecycles the `SearchBox` component.

I converted the `componentWillReceiveProps` to `componentDidMount`. This resolves in another render (from one to two) when hitting <kbd>Enter</kbd> in `{ searchAsYouType: false }` mode. As discussed IRL, this is a tradeoff that we're ready to accept until it's proven to be an issue.

[Try the stories →](https://deploy-preview-2288--react-instantsearch.netlify.com/storybook/?selectedKind=SearchBox&selectedStory=default)