### PR TITLE
fix(compat): upgrade RangeSlider lifecycle

### DIFF
--- a/packages/react-instantsearch-dom/src/widgets/RangeSlider.js
+++ b/packages/react-instantsearch-dom/src/widgets/RangeSlider.js
@@ -29,14 +29,17 @@ class Range extends React.Component {
 
   state = { currentValues: { min: this.props.min, max: this.props.max } };
 
-  componentWillReceiveProps(sliderState) {
-    // @TODO: Derived State, maybe render
-    if (sliderState.canRefine) {
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.canRefine &&
+      (prevProps.currentRefinement.min !== this.props.currentRefinement.min ||
+        prevProps.currentRefinement.max !== this.props.currentRefinement.max)
+    ) {
       this.setState({
         currentValues: {
-          min: sliderState.currentRefinement.min,
-          max: sliderState.currentRefinement.max
-        }
+          min: this.props.currentRefinement.min,
+          max: this.props.currentRefinement.max,
+        },
       });
     }
   }

--- a/stories/3rdPartyIntegrations.stories.js
+++ b/stories/3rdPartyIntegrations.stories.js
@@ -29,13 +29,16 @@ class Range extends Component {
 
   state = { currentValues: { min: this.props.min, max: this.props.max } };
 
-  componentWillReceiveProps(sliderState) {
-    // @TODO: Derived State, maybe render
-    if (sliderState.canRefine) {
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.canRefine &&
+      (prevProps.currentRefinement.min !== this.props.currentRefinement.min ||
+        prevProps.currentRefinement.max !== this.props.currentRefinement.max)
+    ) {
       this.setState({
         currentValues: {
-          min: sliderState.currentRefinement.min,
-          max: sliderState.currentRefinement.max,
+          min: this.props.currentRefinement.min,
+          max: this.props.currentRefinement.max,
         },
       });
     }


### PR DESCRIPTION
This migrates away from deprecated React lifecycles the `RangeSlider` component and its 3rd party integrations.

[See stories →](https://deploy-preview-2290--react-instantsearch.netlify.com/storybook/?selectedKind=Integration%20With%20Other%20Libraries&selectedStory=Airbnb%20Rheostat)