### PR TITLE
fix(compat): upgrade Tourism example lifecycles

### DIFF
--- a/website/examples/tourism/App.js
+++ b/website/examples/tourism/App.js
@@ -291,13 +291,16 @@ class Range extends Component {
 
   state = { currentValues: { min: this.props.min, max: this.props.max } };
 
-  componentWillReceiveProps(sliderState) {
-    // @TODO: derived state
-    if (sliderState.canRefine) {
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.canRefine &&
+      (prevProps.currentRefinement.min !== this.props.currentRefinement.min ||
+        prevProps.currentRefinement.max !== this.props.currentRefinement.max)
+    ) {
       this.setState({
         currentValues: {
-          min: sliderState.currentRefinement.min,
-          max: sliderState.currentRefinement.max,
+          min: this.props.currentRefinement.min,
+          max: this.props.currentRefinement.max,
         },
       });
     }


### PR DESCRIPTION
This migrates away the Tourism example from deprecated React lifecycles.

[See Tourism example →](https://deploy-preview-2305--react-instantsearch.netlify.com/examples/tourism)