### PR TITLE
fix(compat): upgrade React Router example lifecycles

### DIFF
--- a/examples/react-router/src/App.js
+++ b/examples/react-router/src/App.js
@@ -23,13 +23,9 @@ const searchStateToUrl = (props, searchState) =>
 const urlToSearchState = location => qs.parse(location.search.slice(1));
 
 class App extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      searchState: urlToSearchState(props.location),
-    };
-  }
+  state = {
+    searchState: urlToSearchState(this.props.location),
+  };
 
   componentDidUpdate(prevProps) {
     if (prevProps.location !== this.props.location) {
@@ -39,12 +35,14 @@ class App extends Component {
 
   onSearchStateChange = searchState => {
     clearTimeout(this.debouncedSetState);
+
     this.debouncedSetState = setTimeout(() => {
       this.props.history.push(
         searchStateToUrl(this.props, searchState),
         searchState
       );
     }, updateAfter);
+
     this.setState({ searchState });
   };
 
@@ -71,6 +69,7 @@ class App extends Component {
             <SearchBox />
             <PoweredBy />
           </div>
+
           <div style={{ display: 'flex' }}>
             <div style={{ padding: '0px 20px' }}>
               <p>Hierarchical Menu</p>
@@ -89,6 +88,7 @@ class App extends Component {
               <p>Range Ratings</p>
               <RatingMenu attribute="rating" max={6} />
             </div>
+
             <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
               <div style={{ display: 'flex', justifyContent: 'space-around' }}>
                 <ClearRefinements />

--- a/examples/react-router/src/App.js
+++ b/examples/react-router/src/App.js
@@ -31,10 +31,9 @@ class App extends Component {
     };
   }
 
-  componentWillReceiveProps(props) {
-    // @TODO: derived state
-    if (props.location !== this.props.location) {
-      this.setState({ searchState: urlToSearchState(props.location) });
+  componentDidUpdate(prevProps) {
+    if (prevProps.location !== this.props.location) {
+      this.setState({ searchState: urlToSearchState(this.props.location) });
     }
   }
 

--- a/examples/react-router/yarn.lock
+++ b/examples/react-router/yarn.lock
@@ -8429,11 +8429,14 @@ react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
+<<<<<<< HEAD
 react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
+=======
+>>>>>>> fix(compat): upgrade React Router example lifecycles
 react-router-dom@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.0.tgz#542a9b86af269a37f0b87218c4c25ea8dcf0c073"


### PR DESCRIPTION
This migrates away the React Router example from deprecated React lifecycles.