### PR TITLE
fix(compat): upgrade React Router v3 example lifecycles

### DIFF
--- a/examples/react-router-v3/package.json
+++ b/examples/react-router-v3/package.json
@@ -20,7 +20,7 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-instantsearch-dom": "5.4.0",
-    "react-router": "3.0.5"
+    "react-router": "3.2.1"
   },
   "browserslist": [
     ">0.2%",

--- a/examples/react-router-v3/src/App.js
+++ b/examples/react-router-v3/src/App.js
@@ -16,41 +16,41 @@ import {
   ClearRefinements,
 } from 'react-instantsearch-dom';
 
+const THRESHOLD = 700;
+const createURL = state => `?${qs.stringify(state)}`;
+
 class App extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { searchState: { ...qs.parse(props.router.location.query) } };
-    this.onSearchStateChange = this.onSearchStateChange.bind(this);
-    this.createURL = this.createURL.bind(this);
-  }
+  state = {
+    searchState: qs.parse(this.props.router.location.query),
+  };
 
-  componentWillReceiveProps() {
-    // @TODO: derived state
-    this.setState({ searchState: qs.parse(this.props.router.location.query) });
-  }
+  static getDerivedStateFromProps(props, state) {
+    const newSearchState = qs.parse(props.router.location.query);
 
-  shouldComponentUpdate(nextProps, nextState) {
-    return !isEqual(this.state.searchState, nextState.searchState);
-  }
-
-  onSearchStateChange(nextSearchState) {
-    const THRESHOLD = 700;
-    const newPush = Date.now();
-    this.setState({ lastPush: newPush, searchState: nextSearchState });
-    if (this.state.lastPush && newPush - this.state.lastPush <= THRESHOLD) {
-      this.props.router.replace(
-        nextSearchState ? `?${qs.stringify(nextSearchState)}` : ''
-      );
-    } else {
-      this.props.router.push(
-        nextSearchState ? `?${qs.stringify(nextSearchState)}` : ''
-      );
+    if (!isEqual(newSearchState, state.searchState)) {
+      return {
+        searchState: newSearchState,
+      };
     }
+
+    return null;
   }
 
-  createURL(state) {
-    return `?${qs.stringify(state)}`;
-  }
+  onSearchStateChange = nextSearchState => {
+    const newPush = Date.now();
+
+    this.setState({ lastPush: newPush, searchState: nextSearchState }, () => {
+      if (this.state.lastPush && newPush - this.state.lastPush <= THRESHOLD) {
+        this.props.router.replace(
+          nextSearchState ? `?${qs.stringify(nextSearchState)}` : ''
+        );
+      } else {
+        this.props.router.push(
+          nextSearchState ? `?${qs.stringify(nextSearchState)}` : ''
+        );
+      }
+    });
+  };
 
   render() {
     return (
@@ -60,7 +60,7 @@ class App extends Component {
         indexName="instant_search"
         searchState={this.state.searchState}
         onSearchStateChange={this.onSearchStateChange}
-        createURL={this.createURL}
+        createURL={createURL}
       >
         <div>
           <div
@@ -75,6 +75,7 @@ class App extends Component {
             <SearchBox />
             <PoweredBy />
           </div>
+
           <div style={{ display: 'flex' }}>
             <div style={{ padding: '0px 20px' }}>
               <p>Hierarchical Menu</p>
@@ -93,6 +94,7 @@ class App extends Component {
               <p>Range Ratings</p>
               <RatingMenu attribute="rating" max={6} />
             </div>
+
             <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
               <div style={{ display: 'flex', justifyContent: 'space-around' }}>
                 <ClearRefinements />

--- a/examples/react-router-v3/yarn.lock
+++ b/examples/react-router-v3/yarn.lock
@@ -4662,10 +4662,10 @@ hoek@4.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
   integrity sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==
 
-hoist-non-react-statics@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
-  integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
+hoist-non-react-statics@^2.3.1:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -8435,14 +8435,14 @@ react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-router@3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.0.5.tgz#c3b7873758045a8bbc9562aef4ff4bc8cce7c136"
-  integrity sha1-w7eHN1gEWou8lWKu9P9LyMznwTY=
+react-router@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.1.tgz#b9a3279962bdfbe684c8bd0482b81ef288f0f244"
+  integrity sha512-SXkhC0nr3G0ltzVU07IN8jYl0bB6FsrDIqlLC9dK3SITXqyTJyM7yhXlUqs89w3Nqi5OkXsfRUeHX+P874HQrg==
   dependencies:
     create-react-class "^15.5.1"
     history "^3.0.0"
-    hoist-non-react-statics "^1.2.0"
+    hoist-non-react-statics "^2.3.1"
     invariant "^2.2.1"
     loose-envify "^1.2.0"
     prop-types "^15.5.6"


### PR DESCRIPTION
This migrates away the React Router v3 example from deprecated React lifecycles.