### PR TITLE
chore(build): remove React propTypes from build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,6 +7,7 @@ const clean = x => x.filter(Boolean);
 
 module.exports = api => {
   const isTest = api.env('test');
+  const isStorybook = api.env('storybook');
   const targets = {};
 
   if (!isTest) {
@@ -26,7 +27,11 @@ module.exports = api => {
       ],
       '@babel/preset-react',
     ],
-    plugins: ['@babel/plugin-proposal-class-properties', 'babel-plugin-lodash'],
+    plugins: clean([
+      '@babel/plugin-proposal-class-properties',
+      'babel-plugin-lodash',
+      !isStorybook && 'babel-plugin-transform-react-remove-prop-types',
+    ]),
     overrides: [
       {
         test: 'packages/*',

--- a/babel.config.js
+++ b/babel.config.js
@@ -7,7 +7,6 @@ const clean = x => x.filter(Boolean);
 
 module.exports = api => {
   const isTest = api.env('test');
-  const isStorybook = api.env('storybook');
   const targets = {};
 
   if (!isTest) {
@@ -30,7 +29,7 @@ module.exports = api => {
     plugins: clean([
       '@babel/plugin-proposal-class-properties',
       'babel-plugin-lodash',
-      !isStorybook && 'babel-plugin-transform-react-remove-prop-types',
+      isRollup && 'babel-plugin-transform-react-remove-prop-types',
     ]),
     overrides: [
       {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   "bundlesize": [
     {
       "path": "packages/react-instantsearch/dist/umd/Core.min.js",
-      "maxSize": "7.75 kB"
+      "maxSize": "7.50 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Connectors.min.js",
@@ -134,7 +134,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "63.75 kB"
+      "maxSize": "63.00 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
@@ -142,11 +142,11 @@
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "63.75 kB"
+      "maxSize": "62.75 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",
-      "maxSize": "10.75 kB"
+      "maxSize": "10.50 kB"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "41.50 kB"
+      "maxSize": "41.25 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
@@ -146,7 +146,7 @@
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",
-      "maxSize": "10.50 kB"
+      "maxSize": "10.25 kB"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-loader": "8.0.5",
     "babel-plugin-dynamic-import-node": "2.2.0",
     "babel-plugin-lodash": "3.3.4",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "bundlesize": "0.17.1",
     "conventional-changelog-cli": "2.0.12",
     "copy-webpack-plugin": "5.0.2",

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -13,7 +13,6 @@ module.exports = ({ config }) => ({
             loader: 'babel-loader',
             options: {
               rootMode: 'upward',
-              envName: 'storybook',
               presets: [['react-app', { typescript: true }]],
             },
           },

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = ({ config }) => ({
             loader: 'babel-loader',
             options: {
               rootMode: 'upward',
+              envName: 'storybook',
               presets: [['react-app', { typescript: true }]],
             },
           },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
The propTypes were still present in the production build, making the UMD bundles a bit heavier than needed.

This change adds the [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) plugin to the Babel configuration to remove the propTypes at build time.

With this change we gain a few KB on the final bundles.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

No visible changes.
