### PR TITLE
fix(createConnector): new life cycles

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -686,7 +686,7 @@ describe('createConnector', () => {
       expect(update).toHaveBeenCalledTimes(0);
     });
 
-    it('triggers an onSearchStateChange on props change with transitationState', () => {
+    it('triggers an onSearchStateChange on props change with transitionState', () => {
       const transitionState = jest.fn(function() {
         return this.props;
       });
@@ -723,7 +723,7 @@ describe('createConnector', () => {
 
       expect(onSearchStateChange).toHaveBeenCalledTimes(1);
       expect(onSearchStateChange).toHaveBeenCalledWith({
-        hello: 'there', // the instance didn't have the next props yet
+        hello: 'again', // the instance didn't have the next props yet
         contextValue: context,
       });
 
@@ -735,7 +735,7 @@ describe('createConnector', () => {
       );
     });
 
-    it('does not trigger an onSearchStateChange on props change wihtout transitionState', () => {
+    it('does not trigger an onSearchStateChange on props change without transitionState', () => {
       const Connected = createConnectorWithoutContext({
         displayName: 'Connector',
         getProvidedProps: () => {},

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -148,9 +148,7 @@ describe('createConnector', () => {
 
       const context = createFakeContext();
 
-      const wrapper = shallow(<Connected {...props} contextValue={context} />, {
-        disableLifecycleMethods: true,
-      });
+      const wrapper = shallow(<Connected {...props} contextValue={context} />);
 
       // Simulate props change before mount
       wrapper.setProps({ hello: 'again' });
@@ -337,16 +335,39 @@ describe('createConnector', () => {
 
       const props = { hello: 'there' };
       const context = createFakeContext();
-      const wrapper = shallow(<Connected {...props} contextValue={context} />);
+      const wrapper = mount(<Connected {...props} contextValue={context} />);
 
       expect(shouldComponentUpdate).toHaveBeenCalledTimes(0);
 
       wrapper.setProps({ hello: 'here' });
 
-      expect(shouldComponentUpdate).toHaveBeenCalledTimes(1);
+      expect(shouldComponentUpdate).toHaveBeenCalledTimes(2);
       expect(shouldComponentUpdate).toHaveBeenCalledWith(
         {
           hello: 'there',
+          contextValue: context,
+        },
+        {
+          hello: 'here',
+          contextValue: context,
+        },
+        {
+          providedProps: {
+            hello: 'there',
+            contextValue: context,
+          },
+        },
+        {
+          providedProps: {
+            hello: 'there',
+            contextValue: context,
+          },
+        }
+      );
+
+      expect(shouldComponentUpdate).toHaveBeenCalledWith(
+        {
+          hello: 'here',
           contextValue: context,
         },
         {

--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -723,7 +723,7 @@ describe('createConnector', () => {
 
       expect(onSearchStateChange).toHaveBeenCalledTimes(1);
       expect(onSearchStateChange).toHaveBeenCalledWith({
-        hello: 'again', // the instance didn't have the next props yet
+        hello: 'again',
         contextValue: context,
       });
 

--- a/packages/react-instantsearch-core/src/core/createConnector.tsx
+++ b/packages/react-instantsearch-core/src/core/createConnector.tsx
@@ -100,7 +100,9 @@ export function createConnectorWithoutContext(
         providedProps: this.getProvidedProps(this.props),
       };
 
-      componentWillMount() {
+      constructor(props: ConnectorProps) {
+        super(props);
+
         if (connectorDesc.getSearchParameters) {
           this.props.contextValue.onSearchParameters(
             connectorDesc.getSearchParameters.bind(this),
@@ -126,29 +128,6 @@ export function createConnectorWithoutContext(
           this.unregisterWidget = this.props.contextValue.widgetsManager.registerWidget(
             this
           );
-        }
-      }
-
-      componentWillReceiveProps(nextProps) {
-        if (!isEqual(this.props, nextProps)) {
-          this.setState({
-            providedProps: this.getProvidedProps(nextProps),
-          });
-
-          if (isWidget) {
-            this.props.contextValue.widgetsManager.update();
-
-            if (typeof connectorDesc.transitionState === 'function') {
-              this.props.contextValue.onSearchStateChange(
-                connectorDesc.transitionState.call(
-                  this,
-                  nextProps,
-                  this.props.contextValue.store.getState().widgets,
-                  this.props.contextValue.store.getState().widgets
-                )
-              );
-            }
-          }
         }
       }
 
@@ -179,6 +158,29 @@ export function createConnectorWithoutContext(
           !propsEqual ||
           !shallowEqual(this.state.providedProps, nextState.providedProps)
         );
+      }
+
+      componentDidUpdate(prevProps) {
+        if (!isEqual(prevProps, this.props)) {
+          this.setState({
+            providedProps: this.getProvidedProps(this.props),
+          });
+
+          if (isWidget) {
+            this.props.contextValue.widgetsManager.update();
+
+            if (typeof connectorDesc.transitionState === 'function') {
+              this.props.contextValue.onSearchStateChange(
+                connectorDesc.transitionState.call(
+                  this,
+                  this.props,
+                  this.props.contextValue.store.getState().widgets,
+                  this.props.contextValue.store.getState().widgets
+                )
+              );
+            }
+          }
+        }
       }
 
       componentWillUnmount() {


### PR DESCRIPTION
IFW-671

**Summary**


- move willMount -> constructor
- move willReceiveProps -> didUpdate

This didn't have an impact on more requests, but did cause one more render if you update a prop

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

there's no more old life cycles!