### PR TITLE
Add an onChange prop to the Pagination widget

### DIFF
--- a/packages/react-instantsearch-dom/src/components/Pagination.js
+++ b/packages/react-instantsearch-dom/src/components/Pagination.js
@@ -62,6 +62,7 @@ class Pagination extends Component {
     padding: PropTypes.number,
     totalPages: PropTypes.number,
     className: PropTypes.string,
+    onChange: PropTypes.func,
   };
 
   static defaultProps = {
@@ -87,6 +88,14 @@ class Pagination extends Component {
     };
   }
 
+  onSelect = page => {
+    const { currentRefinement, onChange, refine } = this.props;
+    refine(page);
+    if (page !== currentRefinement && onChange) {
+      this.props.onChange(page);
+    }
+  };
+
   render() {
     const {
       listComponent: ListComponent,
@@ -98,7 +107,6 @@ class Pagination extends Component {
       showPrevious,
       showNext,
       showLast,
-      refine,
       createURL,
       canRefine,
       translate,
@@ -170,7 +178,7 @@ class Pagination extends Component {
           {...otherProps}
           cx={cx}
           items={items}
-          onSelect={refine}
+          onSelect={this.onSelect}
           createURL={createURL}
           canRefine={canRefine}
         />

--- a/packages/react-instantsearch-dom/src/widgets/Pagination.js
+++ b/packages/react-instantsearch-dom/src/widgets/Pagination.js
@@ -14,6 +14,7 @@ import Pagination from '../components/Pagination';
  * @propType {boolean} [showNext=true] - Display the next page link.
  * @propType {number} [padding=3] - How many page links to display around the current page.
  * @propType {number} [totalPages=Infinity] - Maximum number of pages to display.
+ * @propType {function} [onChange] - Function called with the page when the user changes a page.
  * @themeKey ais-Pagination - the root div of the widget
  * @themeKey ais-Pagination--noRefinement - the root div of the widget when there is no refinement
  * @themeKey ais-Pagination-list - the list of all pagination items

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, number } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { Panel, Pagination, SearchBox } from 'react-instantsearch-dom';
 import { WrapWithHits } from './util';
 
@@ -33,6 +34,7 @@ stories
         showNext={boolean('show Next', true)}
         padding={number('pages Padding', 2)}
         totalPages={number('max Pages', 3)}
+        onChange={action('onChange')}
       />
     </WrapWithHits>
   ))


### PR DESCRIPTION
**Summary**

Because of #164, I'd like to manage the scroll to top logic manually. Also, Thanks to this, I'll be able to animate the scroll to top when the page change.

**Result**

This adds a `onChange(page)` prop to the `<Pagination>` widget so the developer can implements custom logic when the user changes the page.