### PR TITLE
refactor(lodash): has

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/translatable.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/translatable.js
@@ -25,9 +25,11 @@ describe('translatable', () => {
     const defaultTranslations = {
       sup: 'hey',
       thing: n => `${n} things`,
+      fallbackThing: 'hi',
     };
     const translations = {
       sup: 'hoy',
+      fallbackThing: undefined,
     };
     const Translated = translatable(defaultTranslations)(Dummy);
     const { translate } = shallow(<Translated translations={translations} />)
@@ -35,5 +37,6 @@ describe('translatable', () => {
       .props();
     expect(translate('sup')).toBe('hoy');
     expect(translate('thing', 20)).toBe('20 things');
+    expect(translate('fallbackThing')).toBe(undefined);
   });
 });

--- a/packages/react-instantsearch-core/src/core/translatable.js
+++ b/packages/react-instantsearch-core/src/core/translatable.js
@@ -22,7 +22,7 @@ export default function translatable(defaultTranslations) {
         const { translations } = this.props;
 
         const translation =
-          translations && translations[key] !== undefined
+          translations && translations.hasOwnProperty(key)
             ? translations[key]
             : defaultTranslations[key];
 

--- a/packages/react-instantsearch-core/src/core/translatable.js
+++ b/packages/react-instantsearch-core/src/core/translatable.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { has } from 'lodash';
 
 const withKeysPropType = keys => (props, propName, componentName) => {
   const prop = props[propName];

--- a/packages/react-instantsearch-core/src/core/translatable.js
+++ b/packages/react-instantsearch-core/src/core/translatable.js
@@ -23,7 +23,7 @@ export default function translatable(defaultTranslations) {
         const { translations } = this.props;
 
         const translation =
-          translations && has(translations, key)
+          translations && translations[key] !== undefined
             ? translations[key]
             : defaultTranslations[key];
 

--- a/packages/react-instantsearch-dom/src/components/LinkList.js
+++ b/packages/react-instantsearch-dom/src/components/LinkList.js
@@ -35,7 +35,7 @@ export default class LinkList extends Component {
       <ul className={cx('list', !canRefine && 'list--noRefinement')}>
         {items.map(item => (
           <li
-            key={has(item, 'key') ? item.key : item.value}
+            key={item.key === undefined ? item.value : item.key}
             className={cx(
               'item',
               item.selected && !item.disabled && 'item--selected',
@@ -45,7 +45,7 @@ export default class LinkList extends Component {
           >
             {item.disabled ? (
               <span className={cx('link')}>
-                {has(item, 'label') ? item.label : item.value}
+                {item.label === undefined ? item.value : item.label}
               </span>
             ) : (
               <Link
@@ -54,7 +54,7 @@ export default class LinkList extends Component {
                 href={createURL(item.value)}
                 onClick={() => onSelect(item.value)}
               >
-                {has(item, 'label') ? item.label : item.value}
+                {item.label === undefined ? item.value : item.label}
               </Link>
             )}
           </li>

--- a/packages/react-instantsearch-dom/src/components/LinkList.js
+++ b/packages/react-instantsearch-dom/src/components/LinkList.js
@@ -1,4 +1,3 @@
-import { has } from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Link from './Link';

--- a/packages/react-instantsearch-dom/src/components/Select.js
+++ b/packages/react-instantsearch-dom/src/components/Select.js
@@ -36,11 +36,11 @@ export default class Select extends Component {
         {items.map(item => (
           <option
             className={cx('option')}
-            key={has(item, 'key') ? item.key : item.value}
+            key={item.key === undefined ? item.value : item.key}
             disabled={item.disabled}
             value={item.value}
           >
-            {has(item, 'label') ? item.label : item.value}
+            {item.label === undefined ? item.value : item.label}
           </option>
         ))}
       </select>

--- a/packages/react-instantsearch-dom/src/components/Select.js
+++ b/packages/react-instantsearch-dom/src/components/Select.js
@@ -1,4 +1,3 @@
-import { has } from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 


### PR DESCRIPTION
replace mostly by item[key] === undefined or hasOwnProperty where rendering `undefined`  could be an option

remaining usages of `has` are removed in #2350 
