### PR TITLE
fix(connectQueryRules): avoid to throw an error with undefined values

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
@@ -132,6 +132,23 @@ describe('connectQueryRules', () => {
         expect(searchParameters.ruleContexts).toEqual(['initial-rule']);
       });
 
+      it('does not throw an error with search state that contains `undefined` value', () => {
+        const props: QueryRulesProps = {
+          ...defaultProps,
+          trackedFilters: {
+            price: values => values,
+          },
+        };
+
+        const searchState = {
+          refinementList: undefined,
+        };
+
+        expect(() => {
+          getSearchParameters(SearchParameters.make({}), props, searchState);
+        }).not.toThrow();
+      });
+
       it('sets ruleContexts based on range', () => {
         const priceSpy = jest.fn(values => values);
         const props: QueryRulesProps = {

--- a/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
@@ -66,7 +66,9 @@ function getRefinements(
 ): TrackedFilterRefinement[] {
   const refinements = Object.keys(searchState)
     .filter(
-      widgetKey => typeof searchState[widgetKey][attribute] !== 'undefined'
+      widgetKey =>
+        searchState[widgetKey] !== undefined &&
+        searchState[widgetKey][attribute] !== undefined
     )
     .map(widgetKey => getWidgetRefinements(attribute, widgetKey, searchState))
     .reduce((acc, current) => acc.concat(current), []); // flatten the refinements


### PR DESCRIPTION
**Summary**

This PR aims to fix an error thrown by the `connectQueryRules` connector. Once we have a value `undefined` inside the `searchState` the connector throws an error. The `searchState` usually does not contains those values but since the URLSync is managed by the user it might happen. The fix ensures that the value is defined.

Note that the implementation could be more "strict". Inside the function `getWidgetRefinements` we have a switch that represents the list of widgets supported by the connector (`refinementList`, `menu`, `range`, ...). We could leverage this information inside the filter function. Right now we check every widget even the non-supported e.g. `query`. The original issue happened because the `query` was `undefined`. We can tackle this into another PR though. The fix is still valid even for this implementation.

**Contexts**

> https://algolia.slack.com/archives/C2XP6HBKQ/p1557760264091900
