### PR TITLE
chore(rollup): leverage support of sideEffects

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,11 +130,11 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Connectors.min.js",
-      "maxSize": "40.75 kB"
+      "maxSize": "38.50 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "63.25 kB"
+      "maxSize": "62.00 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/packages/react-instantsearch/index.umd.js
+++ b/packages/react-instantsearch/index.umd.js
@@ -1,8 +1,0 @@
-/* eslint-disable */
-
-// This file exists only for the legacy UMD `Core` file. Sinc eRollup
-// is not able to correctly tree-shake the file we directly import the
-// exported file. It avoid to have a huge jump in filesize (8KB => 40 KB).
-
-// prettier-ignore
-export { default as createConnector } from 'react-instantsearch-core/dist/es/core/createConnector';

--- a/packages/react-instantsearch/rollup.config.js
+++ b/packages/react-instantsearch/rollup.config.js
@@ -66,11 +66,11 @@ const createConfiguration = ({ input, name, minify = false } = {}) => ({
 export default [
   // Core
   createConfiguration({
-    input: 'index.umd.js',
+    input: 'index.js',
     name: 'Core',
   }),
   createConfiguration({
-    input: 'index.umd.js',
+    input: 'index.js',
     name: 'Core',
     minify: true,
   }),


### PR DESCRIPTION
**Summary**

Rollup released the support of the [`sideEffects`](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) attribute. Without the support of this option Rollup was not able to effectively tree-shake the module `index.js`. That's why we've introduced a specific module for the UMD build. Now it's not the case anymore! We can drop this dedicated module. I've also adjust the threshold for the bundle size.