### PR TITLE
refactor(lodash): remove difference

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/connectConfigure.js
+++ b/packages/react-instantsearch-core/src/connectors/connectConfigure.js
@@ -1,4 +1,4 @@
-import { omit, difference } from 'lodash';
+import { omit } from 'lodash';
 import createConnector from '../core/createConnector';
 import {
   refineValue,
@@ -22,8 +22,9 @@ export default createConnector({
   transitionState(props, prevSearchState, nextSearchState) {
     const id = getId();
     const { children, contextValue, indexContextValue, ...items } = props;
+    const propKeys = Object.keys(props);
     const nonPresentKeys = this._props
-      ? difference(Object.keys(this._props), Object.keys(props))
+      ? Object.keys(this._props).filter(prop => propKeys.indexOf(prop) === -1)
       : [];
     this._props = props;
     const nextValue = {


### PR DESCRIPTION

Both are arrays & always defined, so it's really enough to find all props in this._props (prevProps), but not in `props`