### PR TITLE
refactor(lodash): isPlainObject

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/utils.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/utils.js
@@ -38,7 +38,7 @@ describe('utils', () => {
     });
   });
 
-  describe.only('remove empty key', () => {
+  describe('remove empty key', () => {
     it('empty key should be removed', () => {
       const state = {
         query: '',

--- a/packages/react-instantsearch-core/src/core/__tests__/utils.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/utils.js
@@ -38,7 +38,7 @@ describe('utils', () => {
     });
   });
 
-  describe('remove empty key', () => {
+  describe.only('remove empty key', () => {
     it('empty key should be removed', () => {
       const state = {
         query: '',
@@ -96,6 +96,25 @@ describe('utils', () => {
             },
           },
         },
+      });
+    });
+
+    it('does not do anything on empty root', () => {
+      expect(utils.removeEmptyKey({})).toEqual({});
+    });
+
+    it('does empty out objects', () => {
+      expect(utils.removeEmptyKey({ test: {} })).toEqual({});
+      expect(utils.removeEmptyKey({ test: { dog: {} } })).toEqual({
+        // this one stays, because we have no multipass algorithm
+        test: {},
+      });
+    });
+
+    it('does not empty out arrays', () => {
+      expect(utils.removeEmptyKey({ test: [] })).toEqual({ test: [] });
+      expect(utils.removeEmptyKey({ test: { dog: [] } })).toEqual({
+        test: { dog: [] },
       });
     });
   });

--- a/packages/react-instantsearch-core/src/core/utils.ts
+++ b/packages/react-instantsearch-core/src/core/utils.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isPlainObject } from 'lodash';
+import { isEmpty } from 'lodash';
 
 // From https://github.com/reactjs/react-redux/blob/master/src/utils/shallowEqual.js
 export const shallowEqual = (objA, objB) => {
@@ -33,13 +33,19 @@ export const defer = f => {
   resolved.then(f);
 };
 
-export const removeEmptyKey = obj => {
+const isPlainObject = (value: any): value is object =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const removeEmptyKey = (obj: object) => {
   Object.keys(obj).forEach(key => {
-    const value = obj[key];
-    if (isEmpty(value) && isPlainObject(value)) {
+    if (!isPlainObject(obj[key])) {
+      return;
+    }
+
+    if (isEmpty(obj[key])) {
       delete obj[key];
-    } else if (isPlainObject(value)) {
-      removeEmptyKey(value);
+    } else {
+      removeEmptyKey(obj[key]);
     }
   });
 

--- a/packages/react-instantsearch-core/src/core/utils.ts
+++ b/packages/react-instantsearch-core/src/core/utils.ts
@@ -33,19 +33,21 @@ export const defer = f => {
   resolved.then(f);
 };
 
-const isPlainObject = (value: any): value is object =>
+const isPlainObject = (value: unknown): value is object =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
 export const removeEmptyKey = (obj: object) => {
   Object.keys(obj).forEach(key => {
-    if (!isPlainObject(obj[key])) {
+    const value = obj[key];
+
+    if (!isPlainObject(value)) {
       return;
     }
 
-    if (isEmpty(obj[key])) {
+    if (isEmpty(value)) {
       delete obj[key];
     } else {
-      removeEmptyKey(obj[key]);
+      removeEmptyKey(value);
     }
   });
 


### PR DESCRIPTION

The values this function was used for seemed like they can only be arrays or objects to me.

We will only want to empty out "breadth-first", so empty objects will stay in the output if they became empty because of the function itself.

isEmpty here is removed in #2442, and still works the same (but will need a rebase)

The newly added tests also pass with the previous implementation

The function is only used in `onSearchStateChange` as a response to a `cleanUp` (caused by unmount) on a widget

IFW-743