### PR TITLE
refactor(lodash): get

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "42 kB"
+      "maxSize": "42.25 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",

--- a/packages/react-instantsearch-core/src/core/__tests__/utils.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/utils.js
@@ -157,6 +157,98 @@ describe('utils', () => {
     });
   });
 
+  describe('getPropertyByPath', () => {
+    it('returns undefined on non-object root', () => {
+      expect(utils.getPropertyByPath(false, 'fake')).toBe(undefined);
+      expect(utils.getPropertyByPath(undefined, 'fake')).toBe(undefined);
+      expect(utils.getPropertyByPath(null, 'fake.nested')).toBe(undefined);
+    });
+
+    it('returns path if exists', () => {
+      expect(utils.getPropertyByPath({ dog: true }, 'dog')).toBe(true);
+      expect(
+        utils.getPropertyByPath(
+          { i: { like: { properties: false } } },
+          'i.like.properties'
+        )
+      ).toBe(false);
+      expect(
+        utils.getPropertyByPath({ true: { nested: 'ok' } }, 'true.nested')
+      ).toBe('ok');
+    });
+
+    it('accepts a pre-split path as array', () => {
+      expect(utils.getPropertyByPath({ dog: true }, ['dog'])).toBe(true);
+      expect(
+        utils.getPropertyByPath({ i: { like: { properties: false } } }, [
+          'i',
+          'like',
+          'properties',
+        ])
+      ).toBe(false);
+      expect(
+        utils.getPropertyByPath({ true: { nested: 'ok' } }, ['true', 'nested'])
+      ).toBe('ok');
+    });
+
+    it('returns undefined if does not exist', () => {
+      expect(
+        utils.getPropertyByPath(
+          { name: { known: { value: '' } } },
+          'name.unkown'
+        )
+      ).toBe(undefined);
+
+      expect(utils.getPropertyByPath({ name: false }, 'name.unkown')).toBe(
+        undefined
+      );
+    });
+
+    it('returns indexed path if exists', () => {
+      expect(
+        utils.getPropertyByPath({ array: ['a', 'b', 'c'] }, 'array.2')
+      ).toBe('c');
+      expect(
+        utils.getPropertyByPath(
+          { array: [{ letter: 'a' }, { letter: 'b' }, { letter: 'c' }] },
+          'array.2.letter'
+        )
+      ).toBe('c');
+
+      expect(
+        utils.getPropertyByPath({ array: ['a', 'b', 'c'] }, 'array[2]')
+      ).toBe('c');
+      expect(
+        utils.getPropertyByPath(
+          { array: [{ letter: 'a' }, { letter: 'b' }, { letter: 'c' }] },
+          'array[2].letter'
+        )
+      ).toBe('c');
+    });
+
+    it('returns undefined if indexed path does not exist', () => {
+      expect(
+        utils.getPropertyByPath({ array: ['a', 'b', 'c'] }, 'array.4')
+      ).toBe(undefined);
+      expect(
+        utils.getPropertyByPath(
+          { array: [{ letter: 'a' }, { letter: 'b' }, { letter: 'c' }] },
+          'array.5.letter'
+        )
+      ).toBe(undefined);
+
+      expect(
+        utils.getPropertyByPath({ array: ['a', 'b', 'c'] }, 'array[4]')
+      ).toBe(undefined);
+      expect(
+        utils.getPropertyByPath(
+          { array: [{ letter: 'a' }, { letter: 'b' }, { letter: 'c' }] },
+          'array[5]letter'
+        )
+      ).toBe(undefined);
+    });
+  });
+
   describe('find', () => {
     test('returns the first match based on the comparator', () => {
       expect(

--- a/packages/react-instantsearch-core/src/core/__tests__/utils.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/utils.js
@@ -243,7 +243,7 @@ describe('utils', () => {
       expect(
         utils.getPropertyByPath(
           { array: [{ letter: 'a' }, { letter: 'b' }, { letter: 'c' }] },
-          'array[5]letter'
+          'array[5].letter'
         )
       ).toBe(undefined);
     });

--- a/packages/react-instantsearch-core/src/core/__tests__/utils.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/utils.js
@@ -159,9 +159,9 @@ describe('utils', () => {
 
   describe('getPropertyByPath', () => {
     it('returns undefined on non-object root', () => {
-      expect(utils.getPropertyByPath(false, 'fake')).toBe(undefined);
-      expect(utils.getPropertyByPath(undefined, 'fake')).toBe(undefined);
-      expect(utils.getPropertyByPath(null, 'fake.nested')).toBe(undefined);
+      expect(utils.getPropertyByPath(false, 'fake')).toBeUndefined();
+      expect(utils.getPropertyByPath(undefined, 'fake')).toBeUndefined();
+      expect(utils.getPropertyByPath(null, 'fake.nested')).toBeUndefined();
     });
 
     it('returns path if exists', () => {
@@ -191,13 +191,26 @@ describe('utils', () => {
       ).toBe('ok');
     });
 
+    it('does not split a pre-split path as array', () => {
+      expect(utils.getPropertyByPath({ dog: true }, ['dog'])).toBe(true);
+      expect(
+        utils.getPropertyByPath({ i: { like: { properties: false } } }, [
+          'i',
+          'like.properties',
+        ])
+      ).toBeUndefined();
+      expect(
+        utils.getPropertyByPath({ true: { nested: 'ok' } }, ['true.nested'])
+      ).toBeUndefined();
+    });
+
     it('returns undefined if does not exist', () => {
       expect(
         utils.getPropertyByPath(
           { name: { known: { value: '' } } },
           'name.unkown'
         )
-      ).toBe(undefined);
+      ).toBeUndefined();
 
       expect(utils.getPropertyByPath({ name: false }, 'name.unkown')).toBe(
         undefined
@@ -229,23 +242,23 @@ describe('utils', () => {
     it('returns undefined if indexed path does not exist', () => {
       expect(
         utils.getPropertyByPath({ array: ['a', 'b', 'c'] }, 'array.4')
-      ).toBe(undefined);
+      ).toBeUndefined();
       expect(
         utils.getPropertyByPath(
           { array: [{ letter: 'a' }, { letter: 'b' }, { letter: 'c' }] },
           'array.5.letter'
         )
-      ).toBe(undefined);
+      ).toBeUndefined();
 
       expect(
         utils.getPropertyByPath({ array: ['a', 'b', 'c'] }, 'array[4]')
-      ).toBe(undefined);
+      ).toBeUndefined();
       expect(
         utils.getPropertyByPath(
           { array: [{ letter: 'a' }, { letter: 'b' }, { letter: 'c' }] },
           'array[5].letter'
         )
-      ).toBe(undefined);
+      ).toBeUndefined();
     });
   });
 

--- a/packages/react-instantsearch-core/src/core/highlight.js
+++ b/packages/react-instantsearch-core/src/core/highlight.js
@@ -1,4 +1,5 @@
-import { get } from 'lodash';
+const getPropertyByPath = (object, path) =>
+  path.split('.').reduce((current, key) => current && current[key], object);
 
 export const HIGHLIGHT_TAGS = {
   highlightPreTag: `<ais-highlight-0000000000>`,
@@ -72,7 +73,8 @@ export function parseAlgoliaHit({
 }) {
   if (!hit) throw new Error('`hit`, the matching record, must be provided');
 
-  const highlightObject = get(hit[highlightProperty], attribute, {});
+  const highlightObject =
+    getPropertyByPath(hit[highlightProperty], attribute) || {};
 
   if (Array.isArray(highlightObject)) {
     return highlightObject.map(item =>

--- a/packages/react-instantsearch-core/src/core/highlight.js
+++ b/packages/react-instantsearch-core/src/core/highlight.js
@@ -1,5 +1,4 @@
-const getPropertyByPath = (object, path) =>
-  path.split('.').reduce((current, key) => current && current[key], object);
+import { getPropertyByPath } from './utils';
 
 export const HIGHLIGHT_TAGS = {
   highlightPreTag: `<ais-highlight-0000000000>`,

--- a/packages/react-instantsearch-core/src/core/utils.ts
+++ b/packages/react-instantsearch-core/src/core/utils.ts
@@ -102,3 +102,26 @@ export function omit(source: { [key: string]: any }, excluded: string[]) {
   }
   return target;
 }
+
+/**
+ * Retrieve the value at a path of the object:
+ *
+ * @example
+ * getPropertyByPath(
+ *   { test: { this: { function: [{ now: { everyone: true } }] } } },
+ *   'test.this.function[0].now.everyone'
+ * ); // true
+ *
+ * getPropertyByPath(
+ *   { test: { this: { function: [{ now: { everyone: true } }] } } },
+ *   ['test', 'this', 'function', 0, 'now', 'everyone']
+ * ); // true
+ *
+ * @param object Source object to query
+ * @param path either an array of properties, or a string form of the properties, separated by .
+ */
+export const getPropertyByPath = (object: object, path: string[] | string) =>
+  (Array.isArray(path)
+    ? path
+    : path.replace(/\[(\d+)]/g, '.$1').split('.')
+  ).reduce((current, key) => (current ? current[key] : undefined), object);


### PR DESCRIPTION
IFW-742

Now accepts (just like lodash.get): 

- `a.b.c`
- `a[5].c`
- `a.5.c` (even if it would be invalid JS, we just won't document this)

does _not_ accept (lodash.get does)

- `a['b.c']`