### PR TITLE
 refactor(lodash): replace isEqual

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "algoliasearch-helper": "^2.26.0",
+    "fast-deep-equal": "^2.0.1",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10"
   },

--- a/packages/react-instantsearch-core/src/core/createConnector.tsx
+++ b/packages/react-instantsearch-core/src/core/createConnector.tsx
@@ -1,5 +1,5 @@
-import { isEqual } from 'lodash';
 import React, { Component, ReactType } from 'react';
+import isEqual from 'fast-deep-equal';
 import { shallowEqual, getDisplayName, removeEmptyKey } from './utils';
 import {
   InstantSearchConsumer,

--- a/packages/react-instantsearch-dom-maps/src/Connector.js
+++ b/packages/react-instantsearch-dom-maps/src/Connector.js
@@ -1,9 +1,25 @@
-import { isEqual } from 'lodash';
 import { Component } from 'react';
 import { polyfill } from 'react-lifecycles-compat';
 import PropTypes from 'prop-types';
 import { connectGeoSearch } from 'react-instantsearch-dom';
 import { LatLngPropType, BoundingBoxPropType } from './propTypes';
+
+function isEqualPosition(a, b) {
+  if (a === b) {
+    return true;
+  }
+  return a.lat === b.lat && a.lng === b.lng;
+}
+
+function isEqualCurrentRefinement(a, b) {
+  if (a === b) {
+    return true;
+  }
+  return (
+    isEqualPosition(a.northEast, b.northEast) &&
+    isEqualPosition(a.southWest, b.southWest)
+  );
+}
 
 export class Connector extends Component {
   static propTypes = {
@@ -20,8 +36,8 @@ export class Connector extends Component {
     const { position, currentRefinement } = props;
     const { previousPosition, previousCurrentRefinement } = state;
 
-    const positionChanged = !isEqual(previousPosition, position);
-    const currentRefinementChanged = !isEqual(
+    const positionChanged = !isEqualPosition(previousPosition, position);
+    const currentRefinementChanged = !isEqualCurrentRefinement(
       previousCurrentRefinement,
       currentRefinement
     );


### PR DESCRIPTION
1. specified function for maps
2. `fast-deep-equal` for createConnector, because it is generic enough for our use case & in a hot path

IFW-735