### PR TITLE
chore(examples): Update next.js to use React hooks

### DIFF
--- a/examples/next/pages/index.js
+++ b/examples/next/pages/index.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import Router from 'next/router';
+import Router, { withRouter } from 'next/router';
 import qs from 'qs';
 import { Head, App, findResultsState } from '../components';
 
@@ -11,61 +11,52 @@ const createURL = state => `?${qs.stringify(state)}`;
 const searchStateToUrl = searchState =>
   searchState ? `${window.location.pathname}?${qs.stringify(searchState)}` : '';
 
-export default class extends React.Component {
-  static propTypes = {
-    resultsState: PropTypes.object,
-    searchState: PropTypes.object,
-  };
+const SearchPage = ({ initialSearchState, resultsState }) => {
+  const [searchState, setSearchState] = useState(initialSearchState);
 
-  state = {
-    searchState: this.props.searchState,
-  };
+  useEffect(() => {
+    setSearchState(qs.parse(window.location.search.slice(1)));
+  }, []);
 
-  /*
-     nextjs params.query doesn't handle nested objects
-     once it does, params.query could be used directly here, but also inside the constructor
-     to initialize the searchState.
-  */
-  static async getInitialProps(params) {
-    const searchState = params.asPath.includes('?')
-      ? qs.parse(params.asPath.substring(params.asPath.indexOf('?') + 1))
-      : {};
-    const resultsState = await findResultsState(App, { searchState });
-    return { resultsState, searchState };
-  }
+  const onSearchStateChange = searchState => {
+    clearTimeout(debouncedSetState);
 
-  onSearchStateChange = searchState => {
-    clearTimeout(this.debouncedSetState);
-    this.debouncedSetState = setTimeout(() => {
+    const debouncedSetState = setTimeout(() => {
       const href = searchStateToUrl(searchState);
+
       Router.push(href, href, {
         shallow: true,
       });
     }, updateAfter);
-    this.setState({ searchState });
+
+    setSearchState(searchState);
   };
 
-  componentDidMount() {
-    this.setState({ searchState: qs.parse(window.location.search.slice(1)) });
-  }
-
-  componentWillReceiveProps() {
-    this.setState({ searchState: qs.parse(window.location.search.slice(1)) });
-  }
-
-  render() {
-    return (
+  return (
+    <div>
+      <Head title="Home" />
       <div>
-        <Head title="Home" />
-        <div>
-          <App
-            searchState={this.state.searchState}
-            resultsState={this.props.resultsState}
-            onSearchStateChange={this.onSearchStateChange}
-            createURL={createURL}
-          />
-        </div>
+        <App
+          searchState={searchState}
+          resultsState={resultsState}
+          onSearchStateChange={onSearchStateChange}
+          createURL={createURL}
+        />
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+SearchPage.propTypes = {
+  resultsState: PropTypes.object,
+  initialSearchState: PropTypes.object,
+};
+
+SearchPage.getInitialProps = async ({ query }) => {
+  const searchState = query ? qs.parse(query) : {};
+  const resultsState = await findResultsState(App, { searchState });
+
+  return { resultsState, initialSearchState: searchState };
+};
+
+export default withRouter(SearchPage);


### PR DESCRIPTION
**Summary**
This PR updates the Next.js example to use React Hooks. I end up doing this with every implementation of React InstantSearch + Next.js.

**Result**
Run the Next.js example and there should be no output differences. Significantly removes unnecessary boilerplate from the class based approach.