### PR TITLE
build(release): align website version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -99,7 +99,7 @@ conventional-changelog --preset angular --infile CHANGELOG.md --same-file
 
 # git add and tag
 commitMessage="v$newVersion\n\n$changelog"
-git add package.json lerna.json CHANGELOG.md README.md packages/ yarn.lock
+git add package.json lerna.json CHANGELOG.md README.md packages/ website/ yarn.lock
 printf "$commitMessage" | git commit --file -
 git tag "v$newVersion"
 


### PR DESCRIPTION
The release script uses [Lerna](https://github.com/lerna/lerna) to bump the version of the different packages. It's handy because it bumps the package version but also the dependencies between the packages.

The issue is that the `version` command doesn't support filtering like `run` does.  Earlier this year we've introduced private packages into the workspaces (for the website). Because we can't filter them their versions are also incremented when the command is run. It left the project in a dirty state with changes uncommit.

Lerna is able to ignore private package, only when the version is omitted. But Yarn workspaces don't support [a package without a version](https://github.com/yarnpkg/yarn/issues/5936). The package is completely ignored and the dependencies aren't installed.

The simple fix is to commit those changes until Yarn supports workspaces without version.