### PR TITLE
fix(createInstantSearchManager): do not trigger search on index update

### DIFF
--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -343,6 +343,7 @@ export default function createInstantSearchManager({
 
   function updateIndex(newIndex) {
     initialSearchParameters = initialSearchParameters.setIndex(newIndex);
+    // No need to trigger a new search here as the widgets will also update and trigger it if needed.
   }
 
   function getWidgetsIds() {

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -343,7 +343,6 @@ export default function createInstantSearchManager({
 
   function updateIndex(newIndex) {
     initialSearchParameters = initialSearchParameters.setIndex(newIndex);
-    search();
   }
 
   function getWidgetsIds() {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

When updating the `indexName` prop on the `InstantSearch` component, a new search was retriggered by `createInstantSearchManager.updateIndex()` to get the new results. But at the same time the widgets (that are children of `InstantSearch`) where updated and the `onWidgetsUpdate` listener was also retriggering the search.

**Result**

This change removes the `search()` call from `createInstantSearchManager.updateIndex()`, we now only rely on the widgets to retrigger the search if needed.

No new tests were added since `createInstantSearchManager` is mocked in `InstantSearch` test suite and testing that `createInstantSearchManager.updateIndex()` does not trigger a search is testing implementation details. IMHO this should be tested by an integration test. WDYT?

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
