### PR TITLE
chore(examples): add empty results design to e-commerce demo

### DIFF
--- a/website/examples/e-commerce/App.css
+++ b/website/examples/e-commerce/App.css
@@ -241,6 +241,44 @@ mark {
   padding: 0 4px;
 }
 
+.hits-empty-state {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  margin: auto;
+  max-width: 300px;
+}
+
+.hits-empty-state-title {
+  font-family: Hind;
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 0;
+  text-align: center;
+}
+
+.hits-empty-state-description {
+  color: rgba(35, 37, 51, 0.6);
+  font-size: 0.875rem;
+  text-align: center;
+}
+
+.hits-empty-state .ais-ClearRefinements {
+  margin-top: 1rem;
+}
+
+.hits-empty-state .ais-ClearRefinements-button--disabled {
+  display: none;
+}
+
+.hits-empty-state .ais-ClearRefinements-button {
+  background: rgba(10, 8, 41, 0.04);
+  border-radius: 3px;
+  color: #21243d;
+  min-height: 48px;
+  padding: 16px 24px;
+}
+
 /* RangeSlider */
 
 .ais-RangeSlider .rheostat-tooltip::before {

--- a/website/examples/e-commerce/App.js
+++ b/website/examples/e-commerce/App.js
@@ -157,6 +157,7 @@ const App = props => {
       <Configure
         attributesToSnippet={['description:10']}
         snippetEllipsisText="…"
+        removeWordsIfNoResults="allOptional"
       />
 
       <main className="container" ref={containerRef}>

--- a/website/examples/e-commerce/App.js
+++ b/website/examples/e-commerce/App.js
@@ -18,8 +18,9 @@ import {
 import algoliasearch from 'algoliasearch/lite';
 import {
   ClearFiltersMobile,
-  Ratings,
   PriceSlider,
+  NoResults,
+  Ratings,
   ResultsNumberMobile,
   SaveFiltersMobile,
 } from './widgets';
@@ -285,6 +286,7 @@ const App = props => {
           </header>
 
           <Hits hitComponent={Hit} />
+          <NoResults />
 
           <footer className="container-footer">
             <Pagination

--- a/website/examples/e-commerce/App.mobile.css
+++ b/website/examples/e-commerce/App.mobile.css
@@ -260,6 +260,10 @@
     flex: 2;
   }
 
+  .hits-empty-state-image {
+    display: none;
+  }
+
   /* Hide all desktop-specific design on mobile */
 
   [data-layout='desktop'] {

--- a/website/examples/e-commerce/widgets/NoResults.js
+++ b/website/examples/e-commerce/widgets/NoResults.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import { connectStateResults, ClearRefinements } from 'react-instantsearch-dom';
+
+const NoResults = ({ searchResults }) => {
+  if (!searchResults || searchResults.nbHits > 0) {
+    return null;
+  }
+
+  const hasRefinements = searchResults.getRefinements().length > 0;
+  const description = hasRefinements
+    ? 'Try to reset your applied filters.'
+    : 'Please try another query.';
+
+  return (
+    <div className="hits-empty-state">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        xmlnsXlink="http://www.w3.org/1999/xlink"
+        width="138"
+        height="138"
+        className="hits-empty-state-image"
+      >
+        <defs>
+          <linearGradient id="c" x1="50%" x2="50%" y1="100%" y2="0%">
+            <stop offset="0%" stopColor="#F5F5FA" />
+            <stop offset="100%" stopColor="#FFF" />
+          </linearGradient>
+          <path
+            id="b"
+            d="M68.71 114.25a45.54 45.54 0 1 1 0-91.08 45.54 45.54 0 0 1 0 91.08z"
+          />
+          <filter
+            id="a"
+            width="140.6%"
+            height="140.6%"
+            x="-20.3%"
+            y="-15.9%"
+            filterUnits="objectBoundingBox"
+          >
+            <feOffset dy="4" in="SourceAlpha" result="shadowOffsetOuter1" />
+            <feGaussianBlur
+              in="shadowOffsetOuter1"
+              result="shadowBlurOuter1"
+              stdDeviation="5.5"
+            />
+            <feColorMatrix
+              in="shadowBlurOuter1"
+              result="shadowMatrixOuter1"
+              values="0 0 0 0 0.145098039 0 0 0 0 0.17254902 0 0 0 0 0.380392157 0 0 0 0.15 0"
+            />
+            <feOffset dy="2" in="SourceAlpha" result="shadowOffsetOuter2" />
+            <feGaussianBlur
+              in="shadowOffsetOuter2"
+              result="shadowBlurOuter2"
+              stdDeviation="1.5"
+            />
+            <feColorMatrix
+              in="shadowBlurOuter2"
+              result="shadowMatrixOuter2"
+              values="0 0 0 0 0.364705882 0 0 0 0 0.392156863 0 0 0 0 0.580392157 0 0 0 0.2 0"
+            />
+            <feMerge>
+              <feMergeNode in="shadowMatrixOuter1" />
+              <feMergeNode in="shadowMatrixOuter2" />
+            </feMerge>
+          </filter>
+        </defs>
+        <g fill="none" fillRule="evenodd">
+          <circle
+            cx="68.85"
+            cy="68.85"
+            r="68.85"
+            fill="#5468FF"
+            opacity=".07"
+          />
+          <circle
+            cx="68.85"
+            cy="68.85"
+            r="52.95"
+            fill="#5468FF"
+            opacity=".08"
+          />
+          <use fill="#000" filter="url(#a)" xlinkHref="#b" />
+          <use fill="url(#c)" xlinkHref="#b" />
+          <path
+            d="M76.01 75.44c5-5 5.03-13.06.07-18.01a12.73 12.73 0 0 0-18 .07c-5 4.99-5.03 13.05-.07 18a12.73 12.73 0 0 0 18-.06zm2.5 2.5a16.28 16.28 0 0 1-23.02.09A16.29 16.29 0 0 1 55.57 55a16.28 16.28 0 0 1 23.03-.1 16.28 16.28 0 0 1-.08 23.04zm1.08-1.08l-2.15 2.16 8.6 8.6 2.16-2.15-8.6-8.6z"
+            fill="#5369FF"
+          />
+        </g>
+      </svg>
+
+      <p className="hits-empty-state-title">
+        Sorry, we can&apos;t find any matches to your query!
+      </p>
+      <p className="hits-empty-state-description">{description}</p>
+
+      <ClearRefinements
+        translations={{
+          reset: (
+            <div className="clear-filters">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="11"
+                height="11"
+                viewBox="0 0 11 11"
+              >
+                <g fill="none" fillRule="evenodd">
+                  <path d="M0 0h11v11H0z" />
+                  <path
+                    fill="#000"
+                    fillRule="nonzero"
+                    d="M8.26 2.75a3.896 3.896 0 1 0 1.102 3.262l.007-.056a.49.49 0 0 1 .485-.456c.253 0 .451.206.437.457 0 0 .012-.109-.006.061a4.813 4.813 0 1 1-1.348-3.887v-.987a.458.458 0 1 1 .917.002v2.062a.459.459 0 0 1-.459.459H7.334a.458.458 0 1 1-.002-.917h.928z"
+                  />
+                </g>
+              </svg>
+              Clear filters
+            </div>
+          ),
+        }}
+      />
+    </div>
+  );
+};
+
+export default connectStateResults(NoResults);

--- a/website/examples/e-commerce/widgets/index.js
+++ b/website/examples/e-commerce/widgets/index.js
@@ -1,4 +1,5 @@
 export { default as ClearFiltersMobile } from './ClearFiltersMobile';
+export { default as NoResults } from './NoResults';
 export { default as Ratings } from './Ratings';
 export { default as ResultsNumberMobile } from './ResultsNumberMobile';
 export { default as PriceSlider } from './PriceSlider';


### PR DESCRIPTION
This adds the empty state when no hits are returned by the engine. It doesn't change the SFFV no results design.

## Implementation

If no filter are applied, the empty message asks the user to change the query. If there are filters applied, the empty message shows a different message and offers the user to clear the filters.

I added `removeWordsIfNoResults` to `allOptional` so that results are returned most of the time.

## Preview

- [Preview with only query leading to empty results](https://deploy-preview-2601--react-instantsearch.netlify.com/examples/e-commerce/?query=hellll)
- [Preview with filters leading to empty results](https://deploy-preview-2601--react-instantsearch.netlify.com/examples/e-commerce/?query=helll&page=1&configure%5BattributesToSnippet%5D%5B0%5D=description%3A10&configure%5BsnippetEllipsisText%5D=%E2%80%A6&configure%5BremoveWordsIfNoResults%5D=allOptional&hierarchicalMenu%5BhierarchicalCategories.lvl0%5D=Cameras%20%26%20Camcorders)
- [Default preview](https://deploy-preview-2601--react-instantsearch.netlify.com/examples/e-commerce/)

## Related

- [Desktop design](https://app.zeplin.io/project/5acc8becfc0c980068fc12cc/screen/5d133b0a7695220487ab06e7)
- [Mobile design](https://app.zeplin.io/project/5acc8becfc0c980068fc12cc/screen/5d133b6fc0b0e869459947ca)