### PR TITLE
refactor(helper): replace Helper usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,23 +126,23 @@
   "bundlesize": [
     {
       "path": "packages/react-instantsearch/dist/umd/Core.min.js",
-      "maxSize": "3 kB"
+      "maxSize": "2.75 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Connectors.min.js",
-      "maxSize": "39.25 kB"
+      "maxSize": "21 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "51.50 kB"
+      "maxSize": "33.25 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "42.50 kB"
+      "maxSize": "24.25 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "53.75 kB"
+      "maxSize": "35.50 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "0.0.0-8ee79ed",
+    "algoliasearch-helper": "0.0.0-27095c0",
     "fast-deep-equal": "^2.0.1",
     "prop-types": "^15.5.10"
   },

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^2.26.0",
+    "algoliasearch-helper": "0.0.0-8ee79ed",
     "fast-deep-equal": "^2.0.1",
     "prop-types": "^15.5.10"
   },

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigure.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigure.js
@@ -27,21 +27,10 @@ describe('connectConfigure', () => {
           contextValue,
         })
       );
-      expect(searchParameters.getQueryParameter('distinct')).toEqual(1);
-      expect(searchParameters.getQueryParameter('whatever')).toEqual('please');
-      expect(
-        searchParameters.getQueryParameter.bind(searchParameters, 'children')
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"Parameter 'children' is not an attribute of SearchParameters (http://algolia.github.io/algoliasearch-helper-js/docs/SearchParameters.html)"`
-      );
-      expect(
-        searchParameters.getQueryParameter.bind(
-          searchParameters,
-          'contextValue'
-        )
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"Parameter 'contextValue' is not an attribute of SearchParameters (http://algolia.github.io/algoliasearch-helper-js/docs/SearchParameters.html)"`
-      );
+      expect(searchParameters.distinct).toEqual(1);
+      expect(searchParameters.whatever).toEqual('please');
+      expect(searchParameters.children).toBeUndefined();
+      expect(searchParameters.contextValue).toBeUndefined();
     });
 
     it('calling transitionState should add configure parameters to the search state', () => {
@@ -116,31 +105,11 @@ describe('connectConfigure', () => {
         },
         {}
       );
-      expect(searchParameters.getQueryParameter('distinct')).toEqual(1);
-      expect(searchParameters.getQueryParameter('whatever')).toEqual('please');
-      expect(
-        searchParameters.getQueryParameter.bind(searchParameters, 'children')
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"Parameter 'children' is not an attribute of SearchParameters (http://algolia.github.io/algoliasearch-helper-js/docs/SearchParameters.html)"`
-      );
-
-      expect(
-        searchParameters.getQueryParameter.bind(
-          searchParameters,
-          'contextValue'
-        )
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"Parameter 'contextValue' is not an attribute of SearchParameters (http://algolia.github.io/algoliasearch-helper-js/docs/SearchParameters.html)"`
-      );
-
-      expect(
-        searchParameters.getQueryParameter.bind(
-          searchParameters,
-          'indexContextValue'
-        )
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"Parameter 'indexContextValue' is not an attribute of SearchParameters (http://algolia.github.io/algoliasearch-helper-js/docs/SearchParameters.html)"`
-      );
+      expect(searchParameters.distinct).toEqual(1);
+      expect(searchParameters.whatever).toEqual('please');
+      expect(searchParameters.children).toBeUndefined();
+      expect(searchParameters.contextValue).toBeUndefined();
+      expect(searchParameters.indexContextValue).toBeUndefined();
     });
 
     it('calling transitionState should add configure parameters to the search state', () => {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectToggleRefinement.js
@@ -343,7 +343,7 @@ describe('connectToggleRefinement', () => {
         }
       );
 
-      expect(params.query).toEqual('');
+      expect(params.query).toBeUndefined();
     });
 
     it('registers its filter in metadata', () => {
@@ -831,7 +831,7 @@ describe('connectToggleRefinement', () => {
         }
       );
 
-      expect(params.query).toEqual('');
+      expect(params.query).toBeUndefined();
     });
 
     it('registers its filter in metadata', () => {

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
@@ -108,7 +108,6 @@ describe('createInstantSearchManager with multi index', () => {
       expect.objectContaining({
         query: 'second query 1',
         index: 'second',
-        page: 0,
       })
     );
 
@@ -140,7 +139,6 @@ describe('createInstantSearchManager with multi index', () => {
       expect.objectContaining({
         query: 'second query 2',
         index: 'second',
-        page: 0,
       })
     );
   });
@@ -207,7 +205,6 @@ describe('createInstantSearchManager with multi index', () => {
       expect.objectContaining({
         index: 'third',
         query: 'query',
-        page: 0,
       })
     );
 
@@ -215,7 +212,6 @@ describe('createInstantSearchManager with multi index', () => {
       expect.objectContaining({
         index: 'second',
         query: 'query',
-        page: 0,
       })
     );
   });
@@ -459,7 +455,6 @@ describe('createInstantSearchManager with multi index', () => {
       expect.objectContaining({
         index: 'second',
         query: 'second query 1',
-        page: 0,
       })
     );
 
@@ -477,7 +472,6 @@ describe('createInstantSearchManager with multi index', () => {
       expect.objectContaining({
         index: 'first',
         query: 'first query 2',
-        page: 0,
       })
     );
 
@@ -537,7 +531,6 @@ describe('createInstantSearchManager with multi index', () => {
       expect.objectContaining({
         index: 'second',
         query: 'second query 2',
-        page: 0,
       })
     );
   });

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -610,7 +610,6 @@ describe('createInstantSearchManager', () => {
       expect(mainParameters).toEqual(
         expect.objectContaining({
           index: 'index',
-          query: '',
         })
       );
 

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -222,7 +222,7 @@ export default function createInstantSearchManager({
   }
 
   function handleSearchSuccess({ indexId }) {
-    return content => {
+    return event => {
       const state = store.getState();
       const isDerivedHelpersEmpty = !helper.derivedHelpers.length;
 
@@ -234,9 +234,9 @@ export default function createInstantSearchManager({
       results = !isDerivedHelpersEmpty && results.getFacetByName ? {} : results;
 
       if (!isDerivedHelpersEmpty) {
-        results[indexId] = content;
+        results[indexId] = event.results;
       } else {
-        results = content;
+        results = event.results;
       }
 
       const currentState = store.getState();
@@ -259,7 +259,7 @@ export default function createInstantSearchManager({
     };
   }
 
-  function handleSearchError(error) {
+  function handleSearchError({ error }) {
     const currentState = store.getState();
 
     let nextIsSearchStalled = currentState.isSearchStalled;

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^2.26.0",
+    "algoliasearch-helper": "0.0.0-8ee79ed",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.10",
     "react-instantsearch-core": "^5.7.0"

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "0.0.0-8ee79ed",
+    "algoliasearch-helper": "0.0.0-27095c0",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.10",
     "react-instantsearch-core": "^5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4114,10 +4114,10 @@ algolia-aerial@^1.5.3:
   resolved "https://registry.yarnpkg.com/algolia-aerial/-/algolia-aerial-1.5.3.tgz#c8b8ca6bc484164ffc7b36717689a424ea6bfe6c"
   integrity sha512-LZTpVlYnhqNFd+ru/Spm73omhsagiRQLmjrosa5bJ6/I9OMRp4Sb9pYZkAxcx3RSr+ZNXZqthL7rpXqMFdrnPA==
 
-algoliasearch-helper@0.0.0-8ee79ed:
-  version "0.0.0-8ee79ed"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-8ee79ed.tgz#8d7a92d1fee6ad26e5dbd4b6ffa8d974744d81bb"
-  integrity sha512-3PBAuw1rbIGKJySVJmBo/ibTLcW70Qw8Tki9vCXSp3mNCNcve2JlifEKroIZaYF/XJfme/H6Yc0+l7BJ0yTMlA==
+algoliasearch-helper@0.0.0-27095c0:
+  version "0.0.0-27095c0"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-27095c0.tgz#8aa246e23fc665403917eeaf9cf7beeea70866f1"
+  integrity sha512-d0wlSReMpnz7sT5ibojXucYsWHTigu83ge+qktQ9m0u+kG7bHqRErzBUOZ03BMr9zd1sWSNR1TMR9l6AHHrqow==
   dependencies:
     events "^1.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4114,15 +4114,12 @@ algolia-aerial@^1.5.3:
   resolved "https://registry.yarnpkg.com/algolia-aerial/-/algolia-aerial-1.5.3.tgz#c8b8ca6bc484164ffc7b36717689a424ea6bfe6c"
   integrity sha512-LZTpVlYnhqNFd+ru/Spm73omhsagiRQLmjrosa5bJ6/I9OMRp4Sb9pYZkAxcx3RSr+ZNXZqthL7rpXqMFdrnPA==
 
-algoliasearch-helper@^2.26.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.26.0.tgz#cb784b692a5aacf17062493cb0b94f6d60d30d0f"
-  integrity sha512-Yt9ARVC2eY48G2UdxCG+qGTGufh0+mQD2jh9qXTraQKunTSQGj+4Ah5OotuaUVdUBEBRRE3cvUoK+pZpwidQ0Q==
+algoliasearch-helper@0.0.0-8ee79ed:
+  version "0.0.0-8ee79ed"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-8ee79ed.tgz#8d7a92d1fee6ad26e5dbd4b6ffa8d974744d81bb"
+  integrity sha512-3PBAuw1rbIGKJySVJmBo/ibTLcW70Qw8Tki9vCXSp3mNCNcve2JlifEKroIZaYF/XJfme/H6Yc0+l7BJ0yTMlA==
   dependencies:
     events "^1.1.1"
-    lodash "^4.17.5"
-    qs "^6.5.1"
-    util "^0.10.3"
 
 algoliasearch@3.33.0, algoliasearch@^3.27.1:
   version "3.33.0"
@@ -14153,7 +14150,7 @@ q@^1.1.2, q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
+qs@6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

A new `algoliasearch-helper` major version will be released with a few breaking changes ([Migration guide](https://gist.github.com/Haroenv/87b32d4c6dca5deb940ba030bd7a38d8)).

This PR updates `algoliasearch-helper` dependency to use the new major version (released as canary for now) and fix `react-instantsearch` (and its tests) to handle the changes:

* `getQueryParameter` removal (https://github.com/algolia/algoliasearch-helper-js/pull/713)
* Default values removal (https://github.com/algolia/algoliasearch-helper-js/pull/670)
* Emit object instead of an argument list (https://github.com/algolia/algoliasearch-helper-js/pull/699, https://github.com/algolia/algoliasearch-helper-js/pull/700)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->