### PR TITLE
fix(peerDependencies): update React

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -44,6 +44,6 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": ">= 15.3.0 < 17"
+    "react": ">= 16.3.0 < 17"
   }
 }

--- a/packages/react-instantsearch-dom-maps/package.json
+++ b/packages/react-instantsearch-dom-maps/package.json
@@ -47,8 +47,8 @@
     "scriptjs": "^2.5.8"
   },
   "peerDependencies": {
-    "react": ">= 15.3.0 < 17",
-    "react-dom": ">= 15.3.0 < 17",
+    "react": ">= 16.3.0 < 17",
+    "react-dom": ">= 16.3.0 < 17",
     "react-instantsearch-dom": ">= 5.2.0"
   }
 }

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -48,6 +48,6 @@
   },
   "peerDependencies": {
     "react": ">= 16.3.0 < 17",
-    "react-dom": ">= 15.3.0 < 17"
+    "react-dom": ">= 16.3.0 < 17"
   }
 }

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -47,7 +47,7 @@
     "react-instantsearch-core": "^5.7.0"
   },
   "peerDependencies": {
-    "react": ">= 15.3.0 < 17",
+    "react": ">= 16.3.0 < 17",
     "react-dom": ">= 15.3.0 < 17"
   }
 }

--- a/packages/react-instantsearch-native/package.json
+++ b/packages/react-instantsearch-native/package.json
@@ -43,7 +43,7 @@
     "react-instantsearch-core": "^5.7.0"
   },
   "peerDependencies": {
-    "react": ">= 15.3.0 < 17",
-    "react-native": ">= 0.32.0"
+    "react": ">= 16.3.0 < 17",
+    "react-native": ">= 0.54.0"
   }
 }


### PR DESCRIPTION
We are now relying on React 16.3 features like `static getDerivedStateFromProps` & `createContext` in the library, which thus won't work with lower versions.

The lowest version of React Native which requires React 16.3 (albeit an alpha) is 0.54.0 (released 5th of March 2018).
