### PR TITLE
fix(geo): check for undefined in isEqual

### DIFF
--- a/packages/react-instantsearch-dom-maps/src/Connector.js
+++ b/packages/react-instantsearch-dom-maps/src/Connector.js
@@ -8,6 +8,10 @@ function isEqualPosition(a, b) {
   if (a === b) {
     return true;
   }
+  if (a === undefined || b === undefined) {
+    return false;
+  }
+
   return a.lat === b.lat && a.lng === b.lng;
 }
 
@@ -15,6 +19,11 @@ function isEqualCurrentRefinement(a, b) {
   if (a === b) {
     return true;
   }
+
+  if (a === undefined || b === undefined) {
+    return false;
+  }
+
   return (
     isEqualPosition(a.northEast, b.northEast) &&
     isEqualPosition(a.southWest, b.southWest)


### PR DESCRIPTION
issue introduced in #2467

IFW-851

Before the refine function would crash the first time, because isEqualCurrentRefinement was called with undefined as the  first (previous)  refinement. We tried to get the `northWest` from that which throws an error

story: https://deploy-preview-2643--react-instantsearch.netlify.com/storybook/?path=/story/geosearch--default