### PR TITLE
fix(geo): remove lifecycle compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",
-      "maxSize": "6.75 kB"
+      "maxSize": "6 kB"
     }
   ]
 }

--- a/packages/react-instantsearch-dom-maps/package.json
+++ b/packages/react-instantsearch-dom-maps/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "prop-types": "^15.5.10",
-    "react-lifecycles-compat": "^3.0.4",
     "scriptjs": "^2.5.8"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-dom-maps/src/Connector.js
+++ b/packages/react-instantsearch-dom-maps/src/Connector.js
@@ -1,5 +1,4 @@
 import { Component } from 'react';
-import { polyfill } from 'react-lifecycles-compat';
 import PropTypes from 'prop-types';
 import { connectGeoSearch } from 'react-instantsearch-dom';
 import { LatLngPropType, BoundingBoxPropType } from './propTypes';
@@ -106,7 +105,5 @@ export class Connector extends Component {
     });
   }
 }
-
-polyfill(Connector);
 
 export default connectGeoSearch(Connector);


### PR DESCRIPTION
This is no longer necessary, since we now require React 16.3 as a peer dependency (#2626)

Result: smaller bundle size :)