### PR TITLE
docs(stories): remove stories which highlight a custom root

### DIFF
--- a/stories/InstantSearch.stories.js
+++ b/stories/InstantSearch.stories.js
@@ -17,23 +17,6 @@ stories
       <Hits />
     </InstantSearch>
   ))
-  .add('with custom root', () => (
-    <InstantSearch
-      searchClient={searchClient}
-      indexName="instant_search"
-      root={{
-        Root: 'div',
-        props: {
-          style: {
-            border: '1px solid red',
-          },
-        },
-      }}
-    >
-      <SearchBox />
-      <Hits />
-    </InstantSearch>
-  ))
   .add('with custom search client', () => (
     <InstantSearch
       indexName="instant_search"

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -169,26 +169,6 @@ stories
         <Pagination />
       </Index>
     </InstantSearch>
-  ))
-  .add('with custom root', () => (
-    <InstantSearch searchClient={searchClient} indexName="instant_search">
-      <Configure hitsPerPage={5} />
-
-      <SearchBox />
-      <Index
-        indexName="products"
-        root={{
-          Root: 'div',
-          props: {
-            style: {
-              border: '1px solid red',
-            },
-          },
-        }}
-      >
-        <CustomProducts />
-      </Index>
-    </InstantSearch>
   ));
 
 const AutoComplete = connectAutoComplete(


### PR DESCRIPTION
This has been removed in #2339, so no longer works (nor necessary)

Result can be seen in the InstantSearch & MultiIndex stories now being two stories smaller