### PR TITLE
feat(autocomplete): add queryID & position to provided hits

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectAutoComplete.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectAutoComplete.js
@@ -13,11 +13,11 @@ describe('connectAutoComplete', () => {
         { contextValue },
         {},
         {
-          results: { hits },
+          results: { hits, page: 0, hitsPerPage: 20 },
         }
       );
       expect(props).toEqual({
-        hits,
+        hits: [{ __position: 1 }],
         currentRefinement: '',
       });
 
@@ -25,11 +25,11 @@ describe('connectAutoComplete', () => {
         { contextValue },
         { query: 'query' },
         {
-          results: { hits },
+          results: { hits, page: 0, hitsPerPage: 20 },
         }
       );
       expect(props).toEqual({
-        hits,
+        hits: [{ __position: 1 }],
         currentRefinement: 'query',
       });
 
@@ -37,27 +37,27 @@ describe('connectAutoComplete', () => {
         { defaultRefinement: 'query', contextValue },
         {},
         {
-          results: { hits },
+          results: { hits, page: 0, hitsPerPage: 20 },
         }
       );
       expect(props).toEqual({
-        hits,
+        hits: [{ __position: 1 }],
         currentRefinement: 'query',
       });
     });
 
-    it('provides current hits to the component with queryID', () => {
+    it('provides current hits to the component with extra info', () => {
       const hits = [{}];
-      const hitsWithQueryID = [{ __queryID: 'zombo.com' }];
+      const hitsWithExtraInfo = [{ __queryID: 'zombo.com', __position: 1 }];
       let props = connect.getProvidedProps(
         { contextValue },
         {},
         {
-          results: { hits, queryID: 'zombo.com' },
+          results: { hits, page: 0, hitsPerPage: 20, queryID: 'zombo.com' },
         }
       );
       expect(props).toEqual({
-        hits: hitsWithQueryID,
+        hits: hitsWithExtraInfo,
         currentRefinement: '',
       });
 
@@ -65,11 +65,11 @@ describe('connectAutoComplete', () => {
         { contextValue },
         { query: 'query' },
         {
-          results: { hits, queryID: 'zombo.com' },
+          results: { hits, page: 0, hitsPerPage: 20, queryID: 'zombo.com' },
         }
       );
       expect(props).toEqual({
-        hits: hitsWithQueryID,
+        hits: hitsWithExtraInfo,
         currentRefinement: 'query',
       });
 
@@ -77,11 +77,11 @@ describe('connectAutoComplete', () => {
         { defaultRefinement: 'query', contextValue },
         {},
         {
-          results: { hits, queryID: 'zombo.com' },
+          results: { hits, page: 0, hitsPerPage: 20, queryID: 'zombo.com' },
         }
       );
       expect(props).toEqual({
-        hits: hitsWithQueryID,
+        hits: hitsWithExtraInfo,
         currentRefinement: 'query',
       });
     });
@@ -127,22 +127,43 @@ describe('connectAutoComplete', () => {
     it('provides current hits to the component', () => {
       const firstHits = [{}];
       const secondHits = [{}];
-      const firstHitsWithQueryID = [{ __queryID: 'zombo.com' }];
-      const secondHitsWithQueryID = [{ __queryID: 'html5zombo.com' }];
+      const firstHitsWithExtraInfo = [
+        { __queryID: 'zombo.com', __position: 1 },
+      ];
+      const secondHitsWithExtraInfo = [
+        { __queryID: 'html5zombo.com', __position: 1 },
+      ];
       let props = connect.getProvidedProps(
         { contextValue, indexContextValue },
         {},
         {
           results: {
-            first: { hits: firstHits, queryID: 'zombo.com' },
-            second: { hits: secondHits, queryID: 'html5zombo.com' },
+            first: {
+              hits: firstHits,
+              page: 0,
+              hitsPerPage: 20,
+              queryID: 'zombo.com',
+            },
+            second: {
+              hits: secondHits,
+              page: 0,
+              hitsPerPage: 20,
+              queryID: 'html5zombo.com',
+            },
           },
         }
       );
       expect(props).toEqual({
         hits: [
-          { hits: firstHitsWithQueryID, index: 'first' },
-          { hits: secondHitsWithQueryID, index: 'second' },
+          {
+            hits: firstHitsWithExtraInfo,
+            index: 'first',
+          },
+          {
+            hits: secondHitsWithExtraInfo,
+
+            index: 'second',
+          },
         ],
         currentRefinement: '',
       });
@@ -152,15 +173,25 @@ describe('connectAutoComplete', () => {
         { indices: { second: { query: 'query' } } },
         {
           results: {
-            first: { hits: firstHits, queryID: 'zombo.com' },
-            second: { hits: secondHits, queryID: 'html5zombo.com' },
+            first: {
+              hits: firstHits,
+              page: 0,
+              hitsPerPage: 20,
+              queryID: 'zombo.com',
+            },
+            second: {
+              hits: secondHits,
+              page: 0,
+              hitsPerPage: 20,
+              queryID: 'html5zombo.com',
+            },
           },
         }
       );
       expect(props).toEqual({
         hits: [
-          { hits: firstHitsWithQueryID, index: 'first' },
-          { hits: secondHitsWithQueryID, index: 'second' },
+          { hits: firstHitsWithExtraInfo, index: 'first' },
+          { hits: secondHitsWithExtraInfo, index: 'second' },
         ],
         currentRefinement: 'query',
       });
@@ -170,15 +201,25 @@ describe('connectAutoComplete', () => {
         {},
         {
           results: {
-            first: { hits: firstHits, queryID: 'zombo.com' },
-            second: { hits: secondHits, queryID: 'html5zombo.com' },
+            first: {
+              hits: firstHits,
+              page: 0,
+              hitsPerPage: 20,
+              queryID: 'zombo.com',
+            },
+            second: {
+              hits: secondHits,
+              page: 0,
+              hitsPerPage: 20,
+              queryID: 'html5zombo.com',
+            },
           },
         }
       );
       expect(props).toEqual({
         hits: [
-          { hits: firstHitsWithQueryID, index: 'first' },
-          { hits: secondHitsWithQueryID, index: 'second' },
+          { hits: firstHitsWithExtraInfo, index: 'first' },
+          { hits: secondHitsWithExtraInfo, index: 'second' },
         ],
         currentRefinement: 'query',
       });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectAutoComplete.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectAutoComplete.js
@@ -45,6 +45,47 @@ describe('connectAutoComplete', () => {
         currentRefinement: 'query',
       });
     });
+
+    it('provides current hits to the component with queryID', () => {
+      const hits = [{}];
+      const hitsWithQueryID = [{ __queryID: 'zombo.com' }];
+      let props = connect.getProvidedProps(
+        { contextValue },
+        {},
+        {
+          results: { hits, queryID: 'zombo.com' },
+        }
+      );
+      expect(props).toEqual({
+        hits: hitsWithQueryID,
+        currentRefinement: '',
+      });
+
+      props = connect.getProvidedProps(
+        { contextValue },
+        { query: 'query' },
+        {
+          results: { hits, queryID: 'zombo.com' },
+        }
+      );
+      expect(props).toEqual({
+        hits: hitsWithQueryID,
+        currentRefinement: 'query',
+      });
+
+      props = connect.getProvidedProps(
+        { defaultRefinement: 'query', contextValue },
+        {},
+        {
+          results: { hits, queryID: 'zombo.com' },
+        }
+      );
+      expect(props).toEqual({
+        hits: hitsWithQueryID,
+        currentRefinement: 'query',
+      });
+    });
+
     it('refines the query parameter', () => {
       const params = connect.getSearchParameters(
         new SearchParameters(),
@@ -86,17 +127,22 @@ describe('connectAutoComplete', () => {
     it('provides current hits to the component', () => {
       const firstHits = [{}];
       const secondHits = [{}];
+      const firstHitsWithQueryID = [{ __queryID: 'zombo.com' }];
+      const secondHitsWithQueryID = [{ __queryID: 'html5zombo.com' }];
       let props = connect.getProvidedProps(
         { contextValue, indexContextValue },
         {},
         {
-          results: { first: { hits: firstHits }, second: { hits: secondHits } },
+          results: {
+            first: { hits: firstHits, queryID: 'zombo.com' },
+            second: { hits: secondHits, queryID: 'html5zombo.com' },
+          },
         }
       );
       expect(props).toEqual({
         hits: [
-          { hits: firstHits, index: 'first' },
-          { hits: secondHits, index: 'second' },
+          { hits: firstHitsWithQueryID, index: 'first' },
+          { hits: secondHitsWithQueryID, index: 'second' },
         ],
         currentRefinement: '',
       });
@@ -105,13 +151,16 @@ describe('connectAutoComplete', () => {
         { contextValue, indexContextValue },
         { indices: { second: { query: 'query' } } },
         {
-          results: { first: { hits: firstHits }, second: { hits: secondHits } },
+          results: {
+            first: { hits: firstHits, queryID: 'zombo.com' },
+            second: { hits: secondHits, queryID: 'html5zombo.com' },
+          },
         }
       );
       expect(props).toEqual({
         hits: [
-          { hits: firstHits, index: 'first' },
-          { hits: secondHits, index: 'second' },
+          { hits: firstHitsWithQueryID, index: 'first' },
+          { hits: secondHitsWithQueryID, index: 'second' },
         ],
         currentRefinement: 'query',
       });
@@ -120,13 +169,16 @@ describe('connectAutoComplete', () => {
         { defaultRefinement: 'query', contextValue, indexContextValue },
         {},
         {
-          results: { first: { hits: firstHits }, second: { hits: secondHits } },
+          results: {
+            first: { hits: firstHits, queryID: 'zombo.com' },
+            second: { hits: secondHits, queryID: 'html5zombo.com' },
+          },
         }
       );
       expect(props).toEqual({
         hits: [
-          { hits: firstHits, index: 'first' },
-          { hits: secondHits, index: 'second' },
+          { hits: firstHitsWithQueryID, index: 'first' },
+          { hits: secondHitsWithQueryID, index: 'second' },
         ],
         currentRefinement: 'query',
       });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectAutoComplete.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectAutoComplete.js
@@ -46,7 +46,7 @@ describe('connectAutoComplete', () => {
       });
     });
 
-    it('provides current hits to the component with extra info', () => {
+    it('provides current hits to the component with queryID & position', () => {
       const hits = [{}];
       const hitsWithExtraInfo = [{ __queryID: 'zombo.com', __position: 1 }];
       let props = connect.getProvidedProps(

--- a/packages/react-instantsearch-core/src/connectors/connectAutoComplete.js
+++ b/packages/react-instantsearch-core/src/connectors/connectAutoComplete.js
@@ -4,7 +4,7 @@ import {
   refineValue,
   getCurrentRefinementValue,
 } from '../core/indexUtils';
-import { addQueryID } from '../core/utils';
+import { addQueryID, addAbsolutePositions } from '../core/utils';
 
 const getId = () => 'query';
 
@@ -30,9 +30,10 @@ function getHits(searchResults) {
       searchResults.results.hits &&
       Array.isArray(searchResults.results.hits)
     ) {
-      return addQueryID(
-        searchResults.results.hits,
-        searchResults.results.queryID
+      return addAbsolutePositions(
+        addQueryID(searchResults.results.hits, searchResults.results.queryID),
+        searchResults.results.hitsPerPage,
+        searchResults.results.page
       );
     } else {
       return Object.keys(searchResults.results).reduce(
@@ -40,9 +41,13 @@ function getHits(searchResults) {
           ...hits,
           {
             index,
-            hits: addQueryID(
-              searchResults.results[index].hits,
-              searchResults.results[index].queryID
+            hits: addAbsolutePositions(
+              addQueryID(
+                searchResults.results[index].hits,
+                searchResults.results[index].queryID
+              ),
+              searchResults.results[index].hitsPerPage,
+              searchResults.results[index].page
             ),
           },
         ],

--- a/packages/react-instantsearch-core/src/connectors/connectAutoComplete.js
+++ b/packages/react-instantsearch-core/src/connectors/connectAutoComplete.js
@@ -4,6 +4,7 @@ import {
   refineValue,
   getCurrentRefinementValue,
 } from '../core/indexUtils';
+import { addQueryID } from '../core/utils';
 
 const getId = () => 'query';
 
@@ -29,14 +30,20 @@ function getHits(searchResults) {
       searchResults.results.hits &&
       Array.isArray(searchResults.results.hits)
     ) {
-      return searchResults.results.hits;
+      return addQueryID(
+        searchResults.results.hits,
+        searchResults.results.queryID
+      );
     } else {
       return Object.keys(searchResults.results).reduce(
         (hits, index) => [
           ...hits,
           {
             index,
-            hits: searchResults.results[index].hits,
+            hits: addQueryID(
+              searchResults.results[index].hits,
+              searchResults.results[index].queryID
+            ),
           },
         ],
         []


### PR DESCRIPTION
This was accidentally forgotten when we added the queryID to hits & infinite hits.

The PR is made to `next`, because I was already on that branch, can also make a PR to develop if that's what we want.

IFW-902

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

you need to be able to retrieve the query ID & absolute position if you are implementing insights. However, you need to nest a StateResults inside connectAutoComplete if you'd want to do this now because the results object isn't exposed.

Absolute position is less important in autocomplete, because you're usually on page 0, but you never know!

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

queryID is injected like in Hits & InfiniteHits
