### PR TITLE
fix(core): searchState can be non-Object object

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/indexUtils.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/indexUtils.js
@@ -96,68 +96,115 @@ describe('utility method for manipulating the search state', () => {
       });
     });
 
-    it('retrieve the current refinement value', () => {
-      const searchState = {
-        page: 1,
-        last: 'last',
-        refinement: 'refinement',
-        another: 'another',
-        namespace: {
+    describe('getCurrentRefinementValue', () => {
+      it('retrieves the current refinement value', () => {
+        const searchState = {
+          page: 1,
+          last: 'last',
+          refinement: 'refinement',
+          another: 'another',
+          namespace: {
+            refinement: 'refinement',
+            another: 'another',
+            'nested.another': 'nested.another',
+          },
+        };
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'refinement',
+            null
+          )
+        ).toEqual('refinement');
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.another',
+            null
+          )
+        ).toEqual('another');
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.nested.another',
+            null
+          )
+        ).toEqual('nested.another');
+      });
+
+      it('retrieves default value', () => {
+        expect(
+          getCurrentRefinementValue(
+            {},
+            {},
+            context,
+            'refinement',
+            'defaultValue'
+          )
+        ).toEqual('defaultValue');
+
+        expect(
+          getCurrentRefinementValue(
+            { defaultRefinement: 'defaultRefinement' },
+            {},
+            context,
+            'refinement',
+            null
+          )
+        ).toEqual('defaultRefinement');
+      });
+
+      it('retrieves from objects without prototype', () => {
+        const searchState = Object.create(null);
+        searchState.page = 1;
+        searchState.last = 'last';
+        searchState.refinement = 'refinement';
+        searchState.another = 'another';
+        searchState.namespace = {
           refinement: 'refinement',
           another: 'another',
           'nested.another': 'nested.another',
-        },
-      };
+        };
 
-      let value = getCurrentRefinementValue(
-        {},
-        searchState,
-        context,
-        'refinement',
-        null
-      );
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'refinement',
+            null
+          )
+        ).toEqual('refinement');
 
-      expect(value).toEqual('refinement');
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.another',
+            null
+          )
+        ).toEqual('another');
 
-      value = getCurrentRefinementValue(
-        {},
-        searchState,
-        context,
-        'namespace.another',
-        null
-      );
-
-      expect(value).toEqual('another');
-
-      value = getCurrentRefinementValue(
-        {},
-        searchState,
-        context,
-        'namespace.nested.another',
-        null
-      );
-
-      expect(value).toEqual('nested.another');
-
-      value = getCurrentRefinementValue(
-        {},
-        {},
-        context,
-        'refinement',
-        'defaultValue'
-      );
-
-      expect(value).toEqual('defaultValue');
-
-      value = getCurrentRefinementValue(
-        { defaultRefinement: 'defaultRefinement' },
-        {},
-        context,
-        'refinement',
-        null
-      );
-
-      expect(value).toEqual('defaultRefinement');
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.nested.another',
+            null
+          )
+        ).toEqual('nested.another');
+      });
     });
 
     it('clean up values', () => {
@@ -325,11 +372,120 @@ describe('utility method for manipulating the search state', () => {
       });
     });
 
-    it('retrieve the current refinement value', () => {
-      const searchState = {
-        page: 1,
-        refinement: 'refinement',
-        indices: {
+    describe('getCurrentRefinementValue', () => {
+      it('retrieves the current refinement value', () => {
+        const searchState = {
+          page: 1,
+          refinement: 'refinement',
+          indices: {
+            first: {
+              refinement: 'refinement',
+              namespace: {
+                refinement: 'refinement',
+                another: 'another',
+                'nested.another': 'nested.another',
+              },
+            },
+          },
+        };
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'refinement',
+            null
+          )
+        ).toEqual('refinement');
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.refinement',
+            null
+          )
+        ).toEqual('refinement');
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.another',
+            null
+          )
+        ).toEqual('another');
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.nested.another',
+            null
+          )
+        ).toEqual('nested.another');
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            {},
+            context,
+            'refinement',
+            'defaultValue'
+          )
+        ).toEqual('defaultValue');
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'anotherNamespace.refinement.top',
+            'defaultValue'
+          )
+        ).toEqual('defaultValue');
+
+        expect(
+          getCurrentRefinementValue(
+            { defaultRefinement: 'defaultRefinement' },
+            {},
+            context,
+            'refinement',
+            null
+          )
+        ).toEqual('defaultRefinement');
+      });
+
+      it('retrieves default value', () => {
+        const searchState = {
+          page: 1,
+          refinement: 'refinement',
+          indices: {},
+        };
+
+        const defaultRefinement = null;
+
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'refinement',
+            defaultRefinement
+          )
+        ).toBe(defaultRefinement);
+      });
+
+      it('retrieves from objects without prototype', () => {
+        const searchState = Object.create(null);
+
+        searchState.page = 1;
+        searchState.refinement = 'refinement';
+        searchState.indices = {
           first: {
             refinement: 'refinement',
             namespace: {
@@ -338,98 +494,78 @@ describe('utility method for manipulating the search state', () => {
               'nested.another': 'nested.another',
             },
           },
-        },
-      };
+        };
 
-      let value = getCurrentRefinementValue(
-        {},
-        searchState,
-        context,
-        'refinement',
-        null
-      );
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'refinement',
+            null
+          )
+        ).toEqual('refinement');
 
-      expect(value).toEqual('refinement');
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.refinement',
+            null
+          )
+        ).toEqual('refinement');
 
-      value = getCurrentRefinementValue(
-        {},
-        searchState,
-        context,
-        'namespace.refinement',
-        null
-      );
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.another',
+            null
+          )
+        ).toEqual('another');
 
-      expect(value).toEqual('refinement');
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'namespace.nested.another',
+            null
+          )
+        ).toEqual('nested.another');
 
-      value = getCurrentRefinementValue(
-        {},
-        searchState,
-        context,
-        'namespace.another',
-        null
-      );
+        expect(
+          getCurrentRefinementValue(
+            {},
+            {},
+            context,
+            'refinement',
+            'defaultValue'
+          )
+        ).toEqual('defaultValue');
 
-      expect(value).toEqual('another');
+        expect(
+          getCurrentRefinementValue(
+            {},
+            searchState,
+            context,
+            'anotherNamespace.refinement.top',
+            'defaultValue'
+          )
+        ).toEqual('defaultValue');
 
-      value = getCurrentRefinementValue(
-        {},
-        searchState,
-        context,
-        'namespace.nested.another',
-        null
-      );
-
-      expect(value).toEqual('nested.another');
-
-      value = getCurrentRefinementValue(
-        {},
-        {},
-        context,
-        'refinement',
-        'defaultValue'
-      );
-
-      expect(value).toEqual('defaultValue');
-
-      value = getCurrentRefinementValue(
-        {},
-        searchState,
-        context,
-        'anotherNamespace.refinement.top',
-        'defaultValue'
-      );
-
-      expect(value).toEqual('defaultValue');
-
-      value = getCurrentRefinementValue(
-        { defaultRefinement: 'defaultRefinement' },
-        {},
-        context,
-        'refinement',
-        null
-      );
-
-      expect(value).toEqual('defaultRefinement');
-    });
-
-    it('retrieve the default refinement value there is no current refinement', () => {
-      const searchState = {
-        page: 1,
-        refinement: 'refinement',
-        indices: {},
-      };
-
-      const defaultRefinement = null;
-
-      const value = getCurrentRefinementValue(
-        {},
-        searchState,
-        context,
-        'refinement',
-        defaultRefinement
-      );
-
-      expect(value).toBe(defaultRefinement);
+        expect(
+          getCurrentRefinementValue(
+            { defaultRefinement: 'defaultRefinement' },
+            {},
+            context,
+            'refinement',
+            null
+          )
+        ).toEqual('defaultRefinement');
+      });
     });
 
     it('clean up values', () => {

--- a/packages/react-instantsearch-core/src/core/indexUtils.js
+++ b/packages/react-instantsearch-core/src/core/indexUtils.js
@@ -174,7 +174,7 @@ function hasRefinements({
       searchState.indices &&
       searchState.indices[indexId] &&
       searchState.indices[indexId][namespace] &&
-      searchState.indices[indexId][namespace].hasOwnProperty(attributeName)
+      Object.hasOwnProperty.call(searchState.indices[indexId][namespace], attributeName)
     );
   }
 
@@ -182,18 +182,18 @@ function hasRefinements({
     return (
       searchState.indices &&
       searchState.indices[indexId] &&
-      searchState.indices[indexId].hasOwnProperty(id)
+      Object.hasOwnProperty.call(searchState.indices[indexId], id)
     );
   }
 
   if (namespace) {
     return (
       searchState[namespace] &&
-      searchState[namespace].hasOwnProperty(attributeName)
+      Object.hasOwnProperty.call(searchState[namespace], attributeName)
     );
   }
 
-  return searchState.hasOwnProperty(id);
+  return Object.hasOwnProperty.call(searchState, id);
 }
 
 function getRefinements({

--- a/packages/react-instantsearch-core/src/core/indexUtils.js
+++ b/packages/react-instantsearch-core/src/core/indexUtils.js
@@ -174,7 +174,10 @@ function hasRefinements({
       searchState.indices &&
       searchState.indices[indexId] &&
       searchState.indices[indexId][namespace] &&
-      Object.hasOwnProperty.call(searchState.indices[indexId][namespace], attributeName)
+      Object.hasOwnProperty.call(
+        searchState.indices[indexId][namespace],
+        attributeName
+      )
     );
   }
 


### PR DESCRIPTION
If someone calls `Object.create(null)` and then adds the expected properties, `hasOwnProperty` will not be available on the object itself. 

fixes #2568 


TODO:

- [x] add a test for this behaviour with `Object.create(null)`
