### PR TITLE
fix(ssr): avoid duplicate serializing

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -39,7 +39,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "0.0.0-27095c0",
+    "@types/algoliasearch": "^3.30.16",
+    "algoliasearch-helper": "0.0.0-6ac260d",
     "fast-deep-equal": "^2.0.1",
     "prop-types": "^15.5.10"
   },

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
@@ -5,13 +5,15 @@ const runAllMicroTasks = () => new Promise(setImmediate);
 const createSearchClient = () => ({
   search: jest.fn(requests =>
     Promise.resolve({
-      results: requests.map(request => ({
-        index: request.indexName,
-        query: request.params.query,
-        page: request.params.page,
-        hitsPerPage: request.params.hitsPerPage,
-        hits: [],
-      })),
+      results: requests.map(
+        ({ indexName, params: { page, query, hitsPerPage } }) => ({
+          index: indexName,
+          query,
+          page,
+          hitsPerPage,
+          hits: [],
+        })
+      ),
     })
   ),
   searchForFacetValues() {

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -69,14 +69,12 @@ describe('createInstantSearchManager', () => {
       });
 
       const resultsState = {
-        _originalResponse: {
-          results: [
-            {
-              index: 'index',
-              query: 'query',
-            },
-          ],
-        },
+        rawResults: [
+          {
+            index: 'index',
+            query: 'query',
+          },
+        ],
         state: {
           index: 'index',
           query: 'query',
@@ -112,14 +110,12 @@ describe('createInstantSearchManager', () => {
       const resultsState = [
         {
           _internalIndexId: 'index1',
-          _originalResponse: {
-            results: [
-              {
-                index: 'index1',
-                query: 'query1',
-              },
-            ],
-          },
+          rawResults: [
+            {
+              index: 'index1',
+              query: 'query1',
+            },
+          ],
           state: {
             index: 'index1',
             query: 'query1',
@@ -127,14 +123,12 @@ describe('createInstantSearchManager', () => {
         },
         {
           _internalIndexId: 'index2',
-          _originalResponse: {
-            results: [
-              {
-                index: 'index2',
-                query: 'query2',
-              },
-            ],
-          },
+          rawResults: [
+            {
+              index: 'index2',
+              query: 'query2',
+            },
+          ],
           state: {
             index: 'index2',
             query: 'query2',
@@ -187,14 +181,12 @@ describe('createInstantSearchManager', () => {
       };
 
       const resultsState = {
-        _originalResponse: {
-          results: [
-            {
-              index: 'indexName',
-              query: 'query',
-            },
-          ],
-        },
+        rawResults: [
+          {
+            index: 'indexName',
+            query: 'query',
+          },
+        ],
         state: {
           index: 'indexName',
           query: 'query',
@@ -218,14 +210,12 @@ describe('createInstantSearchManager', () => {
       });
 
       const resultsState = {
-        _originalResponse: {
-          results: [
-            {
-              index: 'indexName',
-              query: 'query',
-            },
-          ],
-        },
+        rawResults: [
+          {
+            index: 'indexName',
+            query: 'query',
+          },
+        ],
         state: {
           index: 'indexName',
           query: 'query',
@@ -250,14 +240,12 @@ describe('createInstantSearchManager', () => {
         indexName: 'index',
         searchClient: createSearchClient(),
         resultsState: {
-          _originalResponse: {
-            results: [
-              {
-                index: 'indexName',
-                query: 'query',
-              },
-            ],
-          },
+          rawResults: [
+            {
+              index: 'indexName',
+              query: 'query',
+            },
+          ],
           state: {
             index: 'indexName',
             query: 'query',
@@ -276,14 +264,12 @@ describe('createInstantSearchManager', () => {
         resultsState: [
           {
             _internalIndexId: 'index1',
-            _originalResponse: {
-              results: [
-                {
-                  index: 'index1',
-                  query: 'query1',
-                },
-              ],
-            },
+            rawResults: [
+              {
+                index: 'index1',
+                query: 'query1',
+              },
+            ],
             state: {
               index: 'index1',
               query: 'query1',
@@ -291,14 +277,12 @@ describe('createInstantSearchManager', () => {
           },
           {
             _internalIndexId: 'index2',
-            _originalResponse: {
-              results: [
-                {
-                  index: 'index2',
-                  query: 'query2',
-                },
-              ],
-            },
+            rawResults: [
+              {
+                index: 'index2',
+                query: 'query2',
+              },
+            ],
             state: {
               index: 'index2',
               query: 'query2',

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -322,7 +322,7 @@ export default function createInstantSearchManager({
       requests: results.reduce(
         (acc, result) =>
           acc.concat(
-            result._originalResponse.results.map(request => ({
+            result.rawResults.map(request => ({
               indexName: request.index,
               params: request.params,
             }))
@@ -335,7 +335,7 @@ export default function createInstantSearchManager({
       ...client.cache,
       [key]: {
         results: results.reduce(
-          (acc, result) => acc.concat(result._originalResponse.results),
+          (acc, result) => acc.concat(result.rawResults),
           []
         ),
       },
@@ -349,7 +349,7 @@ export default function createInstantSearchManager({
     // computation of the key inside the client (see link below).
     // https://github.com/algolia/algoliasearch-client-javascript/blob/c27e89ff92b2a854ae6f40dc524bffe0f0cbc169/src/AlgoliaSearchCore.js#L232-L240
     const key = `/1/indexes/*/queries_body_${JSON.stringify({
-      requests: results._originalResponse.results.map(request => ({
+      requests: results.rawResults.map(request => ({
         indexName: request.index,
         params: request.params,
       })),
@@ -357,7 +357,9 @@ export default function createInstantSearchManager({
 
     client.cache = {
       ...client.cache,
-      [key]: results._originalResponse,
+      [key]: {
+        results: results.rawResults,
+      },
     };
   }
 
@@ -372,7 +374,7 @@ export default function createInstantSearchManager({
           ...acc,
           [result._internalIndexId]: new algoliasearchHelper.SearchResults(
             new algoliasearchHelper.SearchParameters(result.state),
-            result._originalResponse.results
+            result.rawResults
           ),
         }),
         {}
@@ -381,7 +383,7 @@ export default function createInstantSearchManager({
 
     return new algoliasearchHelper.SearchResults(
       new algoliasearchHelper.SearchParameters(results.state),
-      results._originalResponse.results
+      results.rawResults
     );
   }
 

--- a/packages/react-instantsearch-core/src/widgets/InstantSearch.tsx
+++ b/packages/react-instantsearch-core/src/widgets/InstantSearch.tsx
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types';
 import createInstantSearchManager from '../core/createInstantSearchManager';
 import { InstantSearchProvider, InstantSearchContext } from '../core/context';
 import { Store } from '../core/createStore';
+import { PlainSearchParameters, SearchParameters } from 'algoliasearch-helper';
+import { MultiResponse } from 'algoliasearch';
 
-function isControlled(props: Props) {
-  return Boolean(props.searchState);
-}
-
-// @TODO: move this to the helper?
-type SearchParameters = any; // algoliaHelper.SearchParameters
-type SearchResults = any; // algoliaHelper.SearchResults
+type ResultsState = {
+  state: PlainSearchParameters;
+  rawResults: MultiResponse;
+};
 
 // @TODO: move to createInstantSearchManager when it's TS
 type InstantSearchManager = {
@@ -53,12 +52,16 @@ type Props = {
     searchState: SearchState
   ) => void;
   stalledSearchDelay?: number;
-  resultsState: SearchResults | { [indexId: string]: SearchResults };
+  resultsState: ResultsState | { [indexId: string]: ResultsState };
 };
 
 type State = {
   contextValue: InstantSearchContext;
 };
+
+function isControlled(props: Props) {
+  return Boolean(props.searchState);
+}
 
 /**
  * @description

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,6 +3510,11 @@
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
 
+"@types/algoliasearch@^3.30.16":
+  version "3.30.16"
+  resolved "https://registry.yarnpkg.com/@types/algoliasearch/-/algoliasearch-3.30.16.tgz#df71aa3eee3648441075ee6dcc428e54dd861196"
+  integrity sha512-47FcMwJuW5NJnzjgkX6O9LKyUeNuVFaeU5iEjCAPH21LQNqev1l6PL/LhGSkme89YIcT0DAl27dqA/woq4BBrw==
+
 "@types/babel__core@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.0.tgz#710f2487dda4dcfd010ca6abb2b4dc7394365c51"
@@ -4118,6 +4123,13 @@ algoliasearch-helper@0.0.0-27095c0:
   version "0.0.0-27095c0"
   resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-27095c0.tgz#8aa246e23fc665403917eeaf9cf7beeea70866f1"
   integrity sha512-d0wlSReMpnz7sT5ibojXucYsWHTigu83ge+qktQ9m0u+kG7bHqRErzBUOZ03BMr9zd1sWSNR1TMR9l6AHHrqow==
+  dependencies:
+    events "^1.1.1"
+
+algoliasearch-helper@0.0.0-6ac260d:
+  version "0.0.0-6ac260d"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-6ac260d.tgz#9f4a0f2c8f89eafe23559375907b4070afa4cbb1"
+  integrity sha512-wG1oVPEq4bXmNUeF2voio+0UpNRtDLTG7+OPCvTxMDIQvD2Exc0s2UsWl5fh6/Dc7O++b8Ic2g+YSVo5l+nBFg==
   dependencies:
     events "^1.1.1"
 


### PR DESCRIPTION
Response of `findResultsState` (and `resultsState` prop) before:

```js
const resultsState = {
  content: SearchResults(state: searchParameters, results: rawResults),
  state: searchParameters,
  _originalResponse: {
    results: rawResults
  },
};
```

Note that `SearchResults` has the properties `_rawResults` & `_state`. This means that when we serialize, we are retrieving the original response and state twice.

Then on further searching, I also find that we don't need to serialize the `SearchResults` object at all, since only the raw response and state is used.

I modified this to be more consistent and no longer have duplication:

```js
const resultsState = {
  state: searchParameters,
  rawResults,
};
```

The `SearchParameters` object gets serialized without issue, as before.

This change in shape has of course also an impact on the shape of `resultsState`, the prop, but that is fine, since it was previously typed as `any`.

To be able to type it correctly, I had to add `@types/algoliasearch` & update `algoliasearch-helper` for typescript though.

This was initially noticed by @cloakedninjas, thanks!


(this can also be done in user land by manually dropping the references, and recreating the expected shape, but this is better, since it needs no user work)