### PR TITLE
Adds a missing peer dependency

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -44,6 +44,7 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 4",
     "react": ">= 15.3.0 < 17"
   }
 }

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -46,5 +46,10 @@
   "peerDependencies": {
     "algoliasearch": ">= 3.1 < 4",
     "react": ">= 15.3.0 < 17"
+  },
+  "peerDependenciesMeta": {
+    "algoliasearch": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
**Summary**

The `algoliasearch-helpers` package has a peer dependency on `algoliasearch`, but it's not provided by `react-instantsearch-core` and thus generates a warning.

Ref https://github.com/yarnpkg/berry/issues/418

**Result**

One less warning 🙂
