### PR TITLE
chore(index): don't require `indexId` on `IndexWrapper`

### DIFF
--- a/packages/react-instantsearch-core/src/widgets/Index.tsx
+++ b/packages/react-instantsearch-core/src/widgets/Index.tsx
@@ -123,7 +123,12 @@ class Index extends Component<InnerProps, State> {
   }
 }
 
-const IndexWrapper: React.FC<Props> = props => {
+type IndexWrapperProps = {
+  indexName: string;
+  indexId?: string;
+};
+
+const IndexWrapper: React.FC<IndexWrapperProps> = props => {
   const inferredIndexId = props.indexName;
   return (
     <InstantSearchConsumer>

--- a/packages/react-instantsearch-core/src/widgets/Index.tsx
+++ b/packages/react-instantsearch-core/src/widgets/Index.tsx
@@ -140,7 +140,7 @@ const IndexWrapper: React.FC<Props> = props => {
 
 IndexWrapper.propTypes = {
   indexName: PropTypes.string.isRequired,
-  indexId: PropTypes.string.isRequired,
+  indexId: PropTypes.string,
 };
 
 export const IndexComponentWithoutContext = Index;


### PR DESCRIPTION
This loosens the PropType requirement on `IndexWrapper` to allow it to work as it seems to be intended (inferring the `indexId` from the `indexName` during the transition phase).

This fixes #2832.