### PR TITLE
fix(ssr): add error when no indexName is passed

### DIFF
--- a/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
@@ -75,6 +75,20 @@ describe('findResultsState', () => {
     );
   });
 
+  it('throws an error if props does not have an `indexName`', () => {
+    const App = () => <div />;
+
+    const props = {
+      searchClient: createSearchClient(),
+    };
+
+    const trigger = () => findResultsState(App, props);
+
+    expect(() => trigger()).toThrowErrorMatchingInlineSnapshot(
+      `"The props provided to \`findResultsState\` must have an \`indexName\`"`
+    );
+  });
+
   it('adds expected Algolia agents', () => {
     const App = props => <InstantSearch {...props} />;
 

--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -113,6 +113,12 @@ export const findResultsState = function(App, props) {
     );
   }
 
+  if (!props.indexName) {
+    throw new Error(
+      'The props provided to `findResultsState` must have an `indexName`'
+    );
+  }
+
   const { indexName, searchClient } = props;
 
   const searchParameters = [];


### PR DESCRIPTION
This came up when writing the docs for SSR in v6, index name is required because it isn't set in SearchParameters by InstantSearch