### PR TITLE
fix(InstantSearch): update the searchState on props update

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -631,7 +631,7 @@ describe('createInstantSearchManager', () => {
       const {
         mainParameters,
         derivedParameters,
-      } = wrapper.instance().aisManager.getSearchParameters();
+      } = wrapper.instance().state.instantSearchManager.getSearchParameters();
 
       expect(mainParameters).toEqual(
         expect.objectContaining({
@@ -704,7 +704,7 @@ describe('createInstantSearchManager', () => {
       const {
         mainParameters,
         derivedParameters,
-      } = wrapper.instance().aisManager.getSearchParameters();
+      } = wrapper.instance().state.instantSearchManager.getSearchParameters();
 
       expect(mainParameters).toEqual(
         expect.objectContaining({

--- a/packages/react-instantsearch-core/src/widgets/__tests__/InstantSearch.js
+++ b/packages/react-instantsearch-core/src/widgets/__tests__/InstantSearch.js
@@ -7,25 +7,33 @@ import { InstantSearchConsumer } from '../../core/context';
 
 Enzyme.configure({ adapter: new Adapter() });
 
+jest.mock('../../core/createInstantSearchManager');
+
+const createFakeStore = (rest = {}) => ({
+  getState: jest.fn(() => ({})),
+  setState: jest.fn(),
+  subscribe: jest.fn(),
+  ...rest,
+});
+
 const createFakeInstantSearchManager = (rest = {}) => ({
   context: {},
-  updateIndex: jest.fn(() => {}),
-  updateClient: jest.fn(() => {}),
+  store: createFakeStore(),
+  clearCache: jest.fn(),
+  updateIndex: jest.fn(),
+  updateClient: jest.fn(),
+  skipSearch: jest.fn(),
+  getWidgetsIds: jest.fn(),
+  onExternalStateUpdate: jest.fn(),
+  onSearchForFacetValues: jest.fn(),
+  transitionState: jest.fn(),
   ...rest,
 });
 
 const createFakeSearchClient = (rest = {}) => ({
-  search: jest.fn(() => {}),
+  search: jest.fn(),
   ...rest,
 });
-
-jest.mock('../../core/createInstantSearchManager', () =>
-  jest.fn(() => ({
-    context: {},
-    updateIndex: () => {},
-    updateClient: () => {},
-  }))
-);
 
 const DEFAULT_PROPS = {
   appId: 'foo',
@@ -39,6 +47,12 @@ const DEFAULT_PROPS = {
 };
 
 describe('InstantSearch', () => {
+  beforeEach(() => {
+    createInstantSearchManager.mockImplementation(() =>
+      createFakeInstantSearchManager()
+    );
+  });
+
   afterEach(() => {
     createInstantSearchManager.mockClear();
   });
@@ -135,9 +149,7 @@ describe('InstantSearch', () => {
   });
 
   it('updates Algolia client when new one is given in props', () => {
-    const ism = createFakeInstantSearchManager({
-      updateClient: jest.fn(),
-    });
+    const ism = createFakeInstantSearchManager();
 
     createInstantSearchManager.mockImplementation(() => ism);
 
@@ -160,7 +172,6 @@ describe('InstantSearch', () => {
   it('works as a controlled input', () => {
     const ism = createFakeInstantSearchManager({
       transitionState: searchState => ({ ...searchState, transitioned: true }),
-      onExternalStateUpdate: jest.fn(),
     });
     createInstantSearchManager.mockImplementation(() => ism);
     const initialState = { a: 0 };
@@ -204,7 +215,6 @@ describe('InstantSearch', () => {
   it('works as an uncontrolled input', () => {
     const ism = createFakeInstantSearchManager({
       transitionState: searchState => ({ ...searchState, transitioned: true }),
-      onExternalStateUpdate: jest.fn(),
     });
     createInstantSearchManager.mockImplementation(() => ism);
 
@@ -241,10 +251,7 @@ describe('InstantSearch', () => {
   });
 
   it("exposes the isManager's store and widgetsManager in context", () => {
-    const ism = createFakeInstantSearchManager({
-      store: {},
-      widgetsManager: {},
-    });
+    const ism = createFakeInstantSearchManager();
     createInstantSearchManager.mockImplementation(() => ism);
     let childContext = false;
     mount(
@@ -263,9 +270,7 @@ describe('InstantSearch', () => {
   });
 
   it('onSearchStateChange should not be called and search should be skipped if the widget is unmounted', () => {
-    const ism = createFakeInstantSearchManager({
-      skipSearch: jest.fn(),
-    });
+    const ism = createFakeInstantSearchManager();
     let childContext;
     createInstantSearchManager.mockImplementation(() => ism);
     const onSearchStateChangeMock = jest.fn();
@@ -291,9 +296,7 @@ describe('InstantSearch', () => {
   });
 
   it('refreshes the cache when the refresh prop is set to true', () => {
-    const ism = createFakeInstantSearchManager({
-      clearCache: jest.fn(),
-    });
+    const ism = createFakeInstantSearchManager();
 
     createInstantSearchManager.mockImplementation(() => ism);
 
@@ -321,9 +324,7 @@ describe('InstantSearch', () => {
   });
 
   it('refreshes the cache only once if the refresh prop stay to true', () => {
-    const ism = createFakeInstantSearchManager({
-      clearCache: jest.fn(),
-    });
+    const ism = createFakeInstantSearchManager();
 
     createInstantSearchManager.mockImplementation(() => ism);
 
@@ -350,9 +351,7 @@ describe('InstantSearch', () => {
   });
 
   it('updates the index when the the index changes', () => {
-    const ism = createFakeInstantSearchManager({
-      updateIndex: jest.fn(),
-    });
+    const ism = createFakeInstantSearchManager();
 
     createInstantSearchManager.mockImplementation(() => ism);
 
@@ -386,10 +385,7 @@ describe('InstantSearch', () => {
   });
 
   it('calls onSearchParameters with the right values if function provided', () => {
-    const ism = createFakeInstantSearchManager({
-      store: {},
-      widgetsManager: {},
-    });
+    const ism = createFakeInstantSearchManager();
     createInstantSearchManager.mockImplementation(() => ism);
     const onSearchParametersMock = jest.fn();
     const getSearchParameters = jest.fn();
@@ -511,9 +507,7 @@ describe('InstantSearch', () => {
     });
 
     it('search for facet values should be called if triggered', () => {
-      const ism = createFakeInstantSearchManager({
-        onSearchForFacetValues: jest.fn(),
-      });
+      const ism = createFakeInstantSearchManager();
       createInstantSearchManager.mockImplementation(() => ism);
       let childContext;
       mount(


### PR DESCRIPTION
**Summary**

This PR fixes an issue where an infinite loop occurs with the controlled mode. The update of the `searchState` was done too late. With V5 the update was done inside `cWRP` but with V6 we move the update inside `cDU`. This change has an impact on when the `searchState` is updated. With `cWRP` it was executed before the `render` of the children, it's not the case anymore with `cDU`. It's done after.

Those children can read the `searchState` provided by the manager. When it's not up to date they alter the previous version of the state. With an `onSearchStateChange` function that relies on the value of `searchState` to add remove parameters, it can lead to infinite loop because the props are changes/reverted at each render.

The fix uses `getDerivedStateFromProps` to keep the `searchState` up to date. The issue with this solution (on V5 too) is that we might trigger one useless request when the props change. It's because the update and the search are tied together inside `onExternalStateUpdate`. One solution to this would be to decouple the two. Apply the `searchState` update as soon as possible but trigger the search on `cDU` once we've computed the state from the children.

**Before**

![before](https://user-images.githubusercontent.com/6513513/66131368-9c15d180-e5f3-11e9-9aad-c46ea6fca340.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/66131378-9f10c200-e5f3-11e9-8980-e6a6e5d626a4.gif)