### PR TITLE
refactor(example): remove usage of aroundLatLng

### DIFF
--- a/examples/geo-search/src/App.js
+++ b/examples/geo-search/src/App.js
@@ -11,7 +11,10 @@ import {
 
 const searchClient = algoliasearch(
   'latency',
-  '6be0576ff61c053d5f9a3225e2a90f76'
+  '6be0576ff61c053d5f9a3225e2a90f76',
+  {
+    _useRequestCache: true,
+  }
 );
 
 const updateAfter = 700;
@@ -22,15 +25,8 @@ class App extends Component {
   constructor() {
     super();
 
-    // retrieve searchState and aroundLatLng properties from the URL at first rendering
-    const initialSearchState = qs.parse(window.location.search.slice(1));
-    const aroundLatLng = initialSearchState.configure
-      ? initialSearchState.configure.aroundLatLng
-      : null;
-
     this.state = {
-      searchState: initialSearchState,
-      aroundLatLng,
+      searchState: qs.parse(window.location.search.slice(1)),
     };
 
     window.addEventListener('popstate', ({ state: searchState }) => {
@@ -50,13 +46,11 @@ class App extends Component {
     }, updateAfter);
 
     this.setState(previousState => {
-      // when a new query is performed, removed the aroundLatLng + boundingBox
       const hasQueryChanged =
         previousState.searchState.query !== searchState.query;
 
       return {
         ...previousState,
-        aroundLatLng: !hasQueryChanged ? previousState.aroundLatLng : null,
         searchState: {
           ...searchState,
           boundingBox: !hasQueryChanged ? searchState.boundingBox : null,
@@ -66,12 +60,10 @@ class App extends Component {
   };
 
   render() {
-    const { aroundLatLng, searchState } = this.state;
+    const { searchState } = this.state;
 
     const parameters = {};
-    if (aroundLatLng && !searchState.boundingBox) {
-      parameters.aroundLatLng = aroundLatLng;
-    } else if (!searchState.boundingBox) {
+    if (!searchState.boundingBox) {
       parameters.aroundLatLngViaIP = true;
       parameters.aroundRadius = 'all';
     }


### PR DESCRIPTION
**Summary**

This PR removes the usage of `aroundLatLng` inside the geo-search example. The logic to apply the parameter was present, but the App doesn't expose a way to use it. We don't have to support it since it uses either the IP of the user of the bounding box of the map.