### PR TITLE
refactor(nextjs): move all fetch logic to `getInitialProps`

### DIFF
--- a/examples/next/components/app.js
+++ b/examples/next/components/app.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   RefinementList,
-  SearchBox,
   Hits,
   Configure,
   Highlight,
   Pagination,
 } from 'react-instantsearch-dom';
 import { InstantSearch } from './instantsearch';
+import SearchBox from './searchbox';
 
 const HitComponent = ({ hit }) => (
   <div className="hit">

--- a/examples/next/components/searchbox.js
+++ b/examples/next/components/searchbox.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import { connectSearchBox, SearchBox as SearchBox } from 'react-instantsearch-dom';
+
+class SearchBoxWithDebounce extends Component {
+  timerId = null;
+
+  state = {
+    value: this.props.currentRefinement
+  };
+
+  onChange = event => {
+    const value = event.currentTarget.value;
+    const { refine, delay = 1000 } = this.props;
+
+    clearTimeout(this.timerId);
+    this.timerId = setTimeout(() => refine(value), delay);
+
+    this.setState(() => ({
+      value
+    }));
+  };
+
+  render() {
+    const { value } = this.state;
+    return (
+      <SearchBox
+        {...this.props}
+        searchAsYouType={false}
+        currentRefinement={value}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+export default connectSearchBox(SearchBoxWithDebounce);

--- a/examples/next/pages/index.js
+++ b/examples/next/pages/index.js
@@ -4,8 +4,6 @@ import Router from 'next/router';
 import qs from 'qs';
 import { Head, App, findResultsState } from '../components';
 
-const updateAfter = 700;
-
 const createURL = state => `?${qs.stringify(state)}`;
 
 const searchStateToUrl = searchState =>
@@ -15,10 +13,6 @@ export default class extends React.Component {
   static propTypes = {
     resultsState: PropTypes.object,
     searchState: PropTypes.object,
-  };
-
-  state = {
-    searchState: this.props.searchState,
   };
 
   /*
@@ -35,23 +29,10 @@ export default class extends React.Component {
   }
 
   onSearchStateChange = searchState => {
-    clearTimeout(this.debouncedSetState);
-    this.debouncedSetState = setTimeout(() => {
-      const href = searchStateToUrl(searchState);
-      Router.push(href, href, {
-        shallow: true,
-      });
-    }, updateAfter);
-    this.setState({ searchState });
+    const href = searchStateToUrl(searchState);
+    Router.push(href, href);
   };
 
-  componentDidMount() {
-    this.setState({ searchState: qs.parse(window.location.search.slice(1)) });
-  }
-
-  componentWillReceiveProps() {
-    this.setState({ searchState: qs.parse(window.location.search.slice(1)) });
-  }
 
   render() {
     return (
@@ -59,7 +40,7 @@ export default class extends React.Component {
         <Head title="Home" />
         <div>
           <App
-            searchState={this.state.searchState}
+            searchState={this.props.searchState}
             resultsState={this.props.resultsState}
             onSearchStateChange={this.onSearchStateChange}
             createURL={createURL}


### PR DESCRIPTION
**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

After refining a search, it is usually necessary to fetch related content such as suggestions, banners, ads, ...
For this reason, I'm suggesting to to keep all the fetch logic inside a single method: `getInitialProps`. Another benefit of this change is that we can remove the `Page` state, making the component easier to understand.

From the [Nextjs docs](https://nextjs.org/learn/basics/fetching-data-for-pages):
> In practice, we usually need to fetch data from a remote data source. Next.js comes with a standard API to fetch data for pages. We do it using an async function called `getInitialProps`.

I believe that with this change users who are using NextJS will have an easier time understanding and adapting the application to be able to use Algolia.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

I'm still trying to solve this issue, but after this change the component is **searching twice**. Any help will be appreciated.

![algolia-pull-request](https://user-images.githubusercontent.com/7511692/66669880-d0f6d980-ec2e-11e9-8620-a47ef3b4417b.gif)
