### PR TITLE
refactor(nextjs): move all fetch logic to `getInitialProps`

### DIFF
--- a/examples/next/components/app.js
+++ b/examples/next/components/app.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   RefinementList,
-  SearchBox,
   Hits,
   Configure,
   Highlight,
   Pagination,
   InstantSearch,
 } from 'react-instantsearch-dom';
+import SearchBox from './searchbox';
 
 const HitComponent = ({ hit }) => (
   <div className="hit">

--- a/examples/next/components/searchbox.js
+++ b/examples/next/components/searchbox.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+import { connectSearchBox, SearchBox } from 'react-instantsearch-dom';
+
+const updateAfter = 700;
+
+class SearchBoxWithDebounce extends Component {
+  timerId = null;
+
+  state = {
+    value: this.props.currentRefinement,
+  };
+
+  onChange = event => {
+    const value = event.currentTarget.value;
+    const { refine } = this.props;
+
+    clearTimeout(this.timerId);
+    this.timerId = setTimeout(() => refine(value), updateAfter);
+
+    this.setState(() => ({
+      value,
+    }));
+  };
+
+  render() {
+    const { value } = this.state;
+    return (
+      <SearchBox
+        {...this.props}
+        searchAsYouType={false}
+        currentRefinement={value}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+export default connectSearchBox(SearchBoxWithDebounce);

--- a/examples/next/pages/index.js
+++ b/examples/next/pages/index.js
@@ -1,4 +1,3 @@
-import { isEqual } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'next/router';
@@ -11,8 +10,6 @@ const searchClient = algoliasearch(
   'latency',
   '6be0576ff61c053d5f9a3225e2a90f76'
 );
-
-const updateAfter = 700;
 
 const createURL = state => `?${qs.stringify(state)}`;
 
@@ -34,11 +31,6 @@ class Page extends React.Component {
     searchState: PropTypes.object,
   };
 
-  state = {
-    searchState: this.props.searchState,
-    lastRouter: this.props.router,
-  };
-
   static async getInitialProps({ asPath }) {
     const searchState = pathToSearchState(asPath);
     const resultsState = await findResultsState(App, {
@@ -52,29 +44,9 @@ class Page extends React.Component {
     };
   }
 
-  static getDerivedStateFromProps(props, state) {
-    if (!isEqual(state.lastRouter, props.router)) {
-      return {
-        searchState: pathToSearchState(props.router.asPath),
-        lastRouter: props.router,
-      };
-    }
-
-    return null;
-  }
-
   onSearchStateChange = searchState => {
-    clearTimeout(this.debouncedSetState);
-
-    this.debouncedSetState = setTimeout(() => {
-      const href = searchStateToURL(searchState);
-
-      this.props.router.push(href, href, {
-        shallow: true,
-      });
-    }, updateAfter);
-
-    this.setState({ searchState });
+    const href = searchStateToURL(searchState);
+    this.props.router.push(href, href);
   };
 
   render() {
@@ -83,7 +55,7 @@ class Page extends React.Component {
         <Head title="Home" />
         <App
           {...DEFAULT_PROPS}
-          searchState={this.state.searchState}
+          searchState={this.props.searchState}
           resultsState={this.props.resultsState}
           onSearchStateChange={this.onSearchStateChange}
           createURL={createURL}


### PR DESCRIPTION
**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

After refining a search, it is usually necessary to fetch related content such as suggestions, banners, ads, ...
For this reason, I'm suggesting to to keep all the fetch logic inside a single method: `getInitialProps`. Another benefit of this change is that we can remove the `Page` state, making the component easier to understand.

From the [Nextjs docs](https://nextjs.org/learn/basics/fetching-data-for-pages):
> In practice, we usually need to fetch data from a remote data source. Next.js comes with a standard API to fetch data for pages. We do it using an async function called `getInitialProps`.

I believe that with this change users who are using NextJS will have an easier time understanding and adapting the application to be able to use Algolia.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

![algoliapullrequest-2](https://user-images.githubusercontent.com/7511692/66681721-b1b97580-ec49-11e9-87bb-5bd2729c1986.gif)
