### PR TITLE
fix: serialize cache value on hydrate

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -91,7 +91,8 @@ describe('createInstantSearchManager', () => {
 
       expect(Object.keys(searchClient.cache)).toHaveLength(1);
       Object.keys(searchClient.cache).forEach(key => {
-        expect(searchClient.cache[key]).toEqual({
+        expect(typeof searchClient.cache[key]).toBe('string');
+        expect(JSON.parse(searchClient.cache[key])).toEqual({
           results: [
             {
               index: 'index',
@@ -146,7 +147,8 @@ describe('createInstantSearchManager', () => {
 
       expect(Object.keys(searchClient.cache)).toHaveLength(1);
       Object.keys(searchClient.cache).forEach(key => {
-        expect(searchClient.cache[key]).toEqual({
+        expect(typeof searchClient.cache[key]).toBe('string');
+        expect(JSON.parse(searchClient.cache[key])).toEqual({
           results: [
             {
               index: 'index1',

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -333,12 +333,12 @@ export default function createInstantSearchManager({
 
     client.cache = {
       ...client.cache,
-      [key]: {
+      [key]: JSON.stringify({
         results: results.reduce(
           (acc, result) => acc.concat(result.rawResults),
           []
         ),
-      },
+      }),
     };
   }
 
@@ -357,9 +357,9 @@ export default function createInstantSearchManager({
 
     client.cache = {
       ...client.cache,
-      [key]: {
+      [key]: JSON.stringify({
         results: results.rawResults,
-      },
+      }),
     };
   }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

It appears the search client cache uses string for values `{ [key: string]: string }`.
When hydrating it for preventing a new request on the client, we need to
serialize the value into a JSON string.

fixes: #2828

**Result**

N/A

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
