### PR TITLE
chore(renovate): disable rebaseStalePRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":automergePr",
     "algolia"
   ],
-  "rebaseStalePRs": false,
+  "rebaseStalePrs": false,
   "ignorePresets": [
     ":ignoreModulesAndTests"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":automergePr",
     "algolia"
   ],
+  "rebaseStalePRs": false,
   "ignorePresets": [
     ":ignoreModulesAndTests"
   ],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR disables `rebaseStalePrs` configuration of renovate.
It's rebasing too many PRs and we cannot fix all the broken tests there.
Let's deal with each PR when we want to merge them.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
