### PR TITLE
fix(ssr): make `page` param in `searchState` to be included in query

### DIFF
--- a/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
@@ -221,6 +221,7 @@ describe('findResultsState', () => {
         ...requiredProps,
         searchState: {
           query: 'iPhone',
+          page: 3,
         },
       };
 
@@ -228,9 +229,17 @@ describe('findResultsState', () => {
 
       expect(data).toEqual({
         rawResults: [
-          expect.objectContaining({ index: 'indexName', query: 'iPhone' }),
+          expect.objectContaining({
+            index: 'indexName',
+            query: 'iPhone',
+            page: 3,
+          }),
         ],
-        state: expect.objectContaining({ index: 'indexName', query: 'iPhone' }),
+        state: expect.objectContaining({
+          index: 'indexName',
+          query: 'iPhone',
+          page: 3,
+        }),
       });
     });
   });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

In SSR, adding `page` into `searchState` doesn't work. `page` isn't included in the query.

**Result**

This test should pass. (which currently doesn't)
