### PR TITLE
feat(insights): show an error when 'clickAnalytics: true' is missing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "24.25 kB"
+      "maxSize": "24.5 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHitInsights.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHitInsights.ts
@@ -102,4 +102,39 @@ describe('connectHitInsights', () => {
       );
     });
   });
+
+  describe('when queryID is undefined', () => {
+    it('should throw an error message inviting to add clickAnalytics: true', () => {
+      const insightsClient = jest.fn();
+
+      const contextValue = {
+        mainTargetedIndex: 'firstIndex',
+      };
+      const indexContextValue = {
+        targetedIndex: 'theIndex',
+      };
+
+      const hit = {
+        objectID: 'objectID_42',
+        __position: 42,
+        // no queryID
+      };
+
+      const searchResults = { results: { theIndex: { index: 'theIndex' } } };
+      const props = connect(insightsClient).getProvidedProps(
+        { hit, contextValue, indexContextValue },
+        null,
+        searchResults
+      );
+
+      expect(() => {
+        props.insights('clickedObjectIDsAfterSearch', {
+          eventName: 'Add to wishlist',
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"Could not infer \`queryID\`. Ensure \`clickAnalytics: true\` was added with the Configure widget.
+See: https://alg.li/lNiZZ7"
+`);
+    });
+  });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHitInsights.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHitInsights.ts
@@ -133,7 +133,7 @@ describe('connectHitInsights', () => {
         });
       }).toThrowErrorMatchingInlineSnapshot(`
 "Could not infer \`queryID\`. Ensure \`clickAnalytics: true\` was added with the Configure widget.
-See: https://alg.li/lNiZZ7"
+See: https://alg.li/VpPpLt"
 `);
     });
   });

--- a/packages/react-instantsearch-core/src/connectors/connectHitInsights.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectHitInsights.ts
@@ -33,6 +33,12 @@ function inferPayload({
   const { index } = results;
   const queryID = currentHit.__queryID;
   const objectIDs = [currentHit.objectID];
+
+  if (!queryID) {
+    throw new Error(`Could not infer \`queryID\`. Ensure \`clickAnalytics: true\` was added with the Configure widget.
+See: https://alg.li/lNiZZ7`);
+  }
+
   switch (method) {
     case 'clickedObjectIDsAfterSearch': {
       const positions = [currentHit.__position];

--- a/packages/react-instantsearch-core/src/connectors/connectHitInsights.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectHitInsights.ts
@@ -36,7 +36,7 @@ function inferPayload({
 
   if (!queryID) {
     throw new Error(`Could not infer \`queryID\`. Ensure \`clickAnalytics: true\` was added with the Configure widget.
-See: https://alg.li/lNiZZ7`);
+See: https://alg.li/VpPpLt`);
   }
 
   switch (method) {


### PR DESCRIPTION
**Summary**
Similar to its InstantSearch.js counterpart https://github.com/algolia/instantsearch.js/pull/4231 
When clickAnalytics: true is missing, we fire an error inviting the user to add `clickAnalytics: true`

**Result**

N/A
