### PR TITLE
feat(widgets): introduce `ConfigureRelatedItems` as experimental

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,10 @@ const config = {
     // https://github.com/benmosher/eslint-plugin-import/issues/1174
     'import/no-extraneous-dependencies': 'off',
     '@typescript-eslint/explicit-member-accessibility': ['off'],
+    '@typescript-eslint/camelcase': [
+      'error',
+      { allow: ['^EXPERIMENTAL_', 'free_shipping'] },
+    ],
   },
   settings: {
     react: {
@@ -35,12 +39,18 @@ const config = {
       files: ['*.ts', '*.tsx'],
       rules: {
         // This rule has issues with the TypeScript parser, but tsc catches
-         // these sorts of errors anyway.
-         // See: https://github.com/typescript-eslint/typescript-eslint/issues/342
-         'no-undef': 'off',
-      }
-    }
-  ]
+        // these sorts of errors anyway.
+        // See: https://github.com/typescript-eslint/typescript-eslint/issues/342
+        'no-undef': 'off',
+      },
+    },
+    {
+      files: ['*.stories.tsx'],
+      rules: {
+        'react/prop-types': 'off',
+      },
+    },
+  ],
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -135,19 +135,19 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Connectors.min.js",
-      "maxSize": "21 kB"
+      "maxSize": "21.5 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "33.25 kB"
+      "maxSize": "33.5 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "24.5 kB"
+      "maxSize": "25 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "35.75 kB"
+      "maxSize": "36 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigureRelatedItems.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigureRelatedItems.ts
@@ -17,7 +17,6 @@ const hit = {
     lvl1: 'TV & Home Theater > Streaming Media Players',
   },
   price: 39.99,
-  // eslint-disable-next-line @typescript-eslint/camelcase
   free_shipping: false,
   rating: 4,
   _snippetResult: {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigureRelatedItems.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigureRelatedItems.ts
@@ -68,7 +68,7 @@ describe('connectConfigure', () => {
 
       expect(searchParameters).toEqual(
         expect.objectContaining({
-          filters: 'NOT objectID:1',
+          facetFilters: ['objectID:-1'],
           sumOrFiltersScores: true,
           optionalFilters: [
             'brand:Amazon<score=3>',
@@ -103,7 +103,7 @@ describe('connectConfigure', () => {
 
       expect(searchParameters).toEqual(
         expect.objectContaining({
-          filters: 'NOT objectID:1',
+          facetFilters: ['objectID:-1'],
           sumOrFiltersScores: true,
           optionalFilters: [
             'brand:Amazon<score=3>',
@@ -159,7 +159,7 @@ describe('connectConfigure', () => {
 
       expect(searchParameters).toEqual(
         expect.objectContaining({
-          filters: 'NOT objectID:1',
+          facetFilters: ['objectID:-1'],
           sumOrFiltersScores: true,
           optionalFilters: [
             'brand:Amazon<score=3>',
@@ -194,7 +194,7 @@ describe('connectConfigure', () => {
 
       expect(searchState).toEqual({
         configure: {
-          filters: 'NOT objectID:1',
+          facetFilters: ['objectID:-1'],
           sumOrFiltersScores: true,
           optionalFilters: [
             'brand:Amazon<score=3>',
@@ -215,16 +215,16 @@ describe('connectConfigure', () => {
             brand: { score: 3 },
           },
         },
-        { configure: { facetFilters: ['categories'] } },
-        { configure: { facetFilters: ['categories'] } }
+        { configure: { facets: ['categories'] } },
+        { configure: { facets: ['categories'] } }
       );
 
       expect(searchState).toEqual({
         configure: {
-          filters: 'NOT objectID:1',
+          facetFilters: ['objectID:-1'],
           sumOrFiltersScores: true,
           optionalFilters: ['brand:Amazon<score=3>'],
-          facetFilters: ['categories'],
+          facets: ['categories'],
         },
       });
     });
@@ -260,17 +260,17 @@ describe('connectConfigure', () => {
         },
         {
           configure: {
-            filters: 'NOT objectID:1',
+            facetFilters: ['objectID:-1'],
             sumOrFiltersScores: true,
             optionalFilters: ['brand:Amazon<score=3>'],
-            facetFilters: ['categories'],
+            facets: ['categories'],
           },
         }
       );
 
       expect(searchState).toEqual({
         configure: {
-          facetFilters: ['categories'],
+          facets: ['categories'],
         },
       });
 
@@ -286,7 +286,7 @@ describe('connectConfigure', () => {
         },
         {
           configure: {
-            filters: 'NOT objectID:1',
+            facetFilters: ['objectID:-1'],
             sumOrFiltersScores: true,
             optionalFilters: ['brand:Amazon<score=3>'],
           },
@@ -330,7 +330,7 @@ describe('connectConfigure', () => {
 
       expect(searchParameters).toEqual(
         expect.objectContaining({
-          filters: 'NOT objectID:1',
+          facetFilters: ['objectID:-1'],
           sumOrFiltersScores: true,
           optionalFilters: [
             'brand:Amazon<score=3>',
@@ -365,7 +365,7 @@ describe('connectConfigure', () => {
 
       expect(searchParameters).toEqual(
         expect.objectContaining({
-          filters: 'NOT objectID:1',
+          facetFilters: ['objectID:-1'],
           sumOrFiltersScores: true,
           optionalFilters: [
             'brand:Amazon<score=3>',
@@ -421,7 +421,7 @@ describe('connectConfigure', () => {
 
       expect(searchParameters).toEqual(
         expect.objectContaining({
-          filters: 'NOT objectID:1',
+          facetFilters: ['objectID:-1'],
           sumOrFiltersScores: true,
           optionalFilters: [
             'brand:Amazon<score=3>',
@@ -458,7 +458,7 @@ describe('connectConfigure', () => {
         indices: {
           second: {
             configure: {
-              filters: 'NOT objectID:1',
+              facetFilters: ['objectID:-1'],
               sumOrFiltersScores: true,
               optionalFilters: [
                 'brand:Amazon<score=3>',
@@ -506,10 +506,10 @@ describe('connectConfigure', () => {
           indices: {
             second: {
               configure: {
-                filters: 'NOT objectID:1',
+                facetFilters: ['objectID:-1'],
                 sumOrFiltersScores: true,
                 optionalFilters: ['brand:Amazon<score=3>'],
-                facetFilters: ['categories'],
+                facets: ['categories'],
               },
             },
           },
@@ -520,7 +520,7 @@ describe('connectConfigure', () => {
         indices: {
           second: {
             configure: {
-              facetFilters: ['categories'],
+              facets: ['categories'],
             },
           },
         },
@@ -540,7 +540,7 @@ describe('connectConfigure', () => {
           indices: {
             second: {
               configure: {
-                filters: 'NOT objectID:1',
+                facetFilters: ['objectID:-1'],
                 sumOrFiltersScores: true,
                 optionalFilters: ['brand:Amazon<score=3>'],
               },

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigureRelatedItems.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigureRelatedItems.ts
@@ -1,0 +1,556 @@
+import { SearchParameters } from 'algoliasearch-helper';
+import connectConfigureRelatedItems from '../connectConfigureRelatedItems';
+
+jest.mock('../../core/createConnector', () => x => x);
+
+const connect = connectConfigureRelatedItems as any;
+
+const hit = {
+  objectID: '1',
+  name: 'Amazon - Fire TV Stick with Alexa Voice Remote - Black',
+  description:
+    'Enjoy smart access to videos, games and apps with this Amazon Fire TV stick.',
+  brand: 'Amazon',
+  categories: ['TV & Home Theater', 'Streaming Media Players'],
+  hierarchicalCategories: {
+    lvl0: 'TV & Home Theater',
+    lvl1: 'TV & Home Theater > Streaming Media Players',
+  },
+  price: 39.99,
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  free_shipping: false,
+  rating: 4,
+  _snippetResult: {
+    description: {
+      value:
+        'Enjoy smart access to videos, games and apps with this Amazon Fire TV stick. Its […]',
+      matchLevel: 'none',
+    },
+  },
+  _highlightResult: {
+    description: {
+      value:
+        'Enjoy smart access to videos, games and apps with this Amazon Fire TV stick. Its […]',
+      matchLevel: 'none',
+      matchedWords: [],
+    },
+  },
+};
+
+describe('connectConfigure', () => {
+  describe('single index', () => {
+    const contextValue = { mainTargetedIndex: 'index' };
+    const defaultProps = {
+      transformSearchParameters: x => x,
+      contextValue,
+    };
+
+    it('does not provide props', () => {
+      const providedProps = connect.getProvidedProps({ contextValue }, null, {
+        results: {},
+      });
+
+      expect(providedProps).toEqual({});
+    });
+
+    it('sets the optionalFilters search parameter based on matchingPatterns', () => {
+      const searchParameters = connect.getSearchParameters.call(
+        { contextValue },
+        new SearchParameters(),
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        }
+      );
+
+      expect(searchParameters).toEqual(
+        expect.objectContaining({
+          filters: 'NOT objectID:1',
+          sumOrFiltersScores: true,
+          optionalFilters: [
+            'brand:Amazon<score=3>',
+            [
+              'categories:TV & Home Theater<score=2>',
+              'categories:Streaming Media Players<score=2>',
+            ],
+          ],
+        })
+      );
+    });
+
+    it('sets transformed search parameters based on transformSearchParameters', () => {
+      const searchParameters = connect.getSearchParameters.call(
+        { contextValue },
+        new SearchParameters(),
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+          transformSearchParameters(parameters) {
+            return {
+              ...parameters,
+              optionalWords: hit.name.split(' '),
+            };
+          },
+        }
+      );
+
+      expect(searchParameters).toEqual(
+        expect.objectContaining({
+          filters: 'NOT objectID:1',
+          sumOrFiltersScores: true,
+          optionalFilters: [
+            'brand:Amazon<score=3>',
+            [
+              'categories:TV & Home Theater<score=2>',
+              'categories:Streaming Media Players<score=2>',
+            ],
+          ],
+          optionalWords: [
+            'Amazon',
+            '-',
+            'Fire',
+            'TV',
+            'Stick',
+            'with',
+            'Alexa',
+            'Voice',
+            'Remote',
+            '-',
+            'Black',
+          ],
+        })
+      );
+    });
+
+    it('filters out and warns for incorrect optionalFilters value type', () => {
+      // We need to simulate being in development mode and to mock the global console object
+      // in this test to assert that development warnings are displayed correctly.
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const searchParameters = connect.getSearchParameters.call(
+        { contextValue },
+        new SearchParameters(),
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            rating: { score: 1 }, // `rating` is a number, which is not supported by the `optionalFilters` API
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        }
+      );
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'The `matchingPatterns` option returned a value of type Number for the "rating" key. This value was not sent to Algolia because `optionalFilters` only supports strings and array of strings.\n\n' +
+          'You can remove the "rating" key from the `matchingPatterns` option.\n\n' +
+          'See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/'
+      );
+
+      expect(searchParameters).toEqual(
+        expect.objectContaining({
+          filters: 'NOT objectID:1',
+          sumOrFiltersScores: true,
+          optionalFilters: [
+            'brand:Amazon<score=3>',
+            [
+              'categories:TV & Home Theater<score=2>',
+              'categories:Streaming Media Players<score=2>',
+            ],
+          ],
+        })
+      );
+
+      process.env.NODE_ENV = originalNodeEnv;
+      warnSpy.mockRestore();
+    });
+
+    it('calling transitionState should add configure parameters to the search state', () => {
+      const instance = {};
+
+      let searchState = connect.transitionState.call(
+        instance,
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        },
+        {},
+        {}
+      );
+
+      expect(searchState).toEqual({
+        configure: {
+          filters: 'NOT objectID:1',
+          sumOrFiltersScores: true,
+          optionalFilters: [
+            'brand:Amazon<score=3>',
+            [
+              'categories:TV & Home Theater<score=2>',
+              'categories:Streaming Media Players<score=2>',
+            ],
+          ],
+        },
+      });
+
+      searchState = connect.transitionState.call(
+        instance,
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+          },
+        },
+        { configure: { facetFilters: ['categories'] } },
+        { configure: { facetFilters: ['categories'] } }
+      );
+
+      expect(searchState).toEqual({
+        configure: {
+          filters: 'NOT objectID:1',
+          sumOrFiltersScores: true,
+          optionalFilters: ['brand:Amazon<score=3>'],
+          facetFilters: ['categories'],
+        },
+      });
+    });
+
+    it('calling cleanUp should remove configure parameters from the search state', () => {
+      const instance = {};
+
+      // Running `transitionState` allows to set previous search parameters
+      // in the connector state.
+      let searchState = connect.transitionState.call(
+        instance,
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        },
+        {},
+        {}
+      );
+
+      searchState = connect.cleanUp.call(
+        instance,
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        },
+        {
+          configure: {
+            filters: 'NOT objectID:1',
+            sumOrFiltersScores: true,
+            optionalFilters: ['brand:Amazon<score=3>'],
+            facetFilters: ['categories'],
+          },
+        }
+      );
+
+      expect(searchState).toEqual({
+        configure: {
+          facetFilters: ['categories'],
+        },
+      });
+
+      searchState = connect.cleanUp.call(
+        instance,
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        },
+        {
+          configure: {
+            filters: 'NOT objectID:1',
+            sumOrFiltersScores: true,
+            optionalFilters: ['brand:Amazon<score=3>'],
+          },
+        }
+      );
+
+      expect(searchState).toEqual({ configure: {} });
+    });
+  });
+
+  describe('multi index', () => {
+    const contextValue = { mainTargetedIndex: 'first' };
+    const indexContextValue = { targetedIndex: 'second' };
+    const defaultProps = {
+      transformSearchParameters: x => x,
+      contextValue,
+      indexContextValue,
+    };
+
+    it('does not provide props', () => {
+      const providedProps = connect.getProvidedProps({ contextValue }, null, {
+        results: {},
+      });
+
+      expect(providedProps).toEqual({});
+    });
+
+    it('sets the optionalFilters search parameter based on matchingPatterns', () => {
+      const searchParameters = connect.getSearchParameters.call(
+        { contextValue },
+        new SearchParameters(),
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        }
+      );
+
+      expect(searchParameters).toEqual(
+        expect.objectContaining({
+          filters: 'NOT objectID:1',
+          sumOrFiltersScores: true,
+          optionalFilters: [
+            'brand:Amazon<score=3>',
+            [
+              'categories:TV & Home Theater<score=2>',
+              'categories:Streaming Media Players<score=2>',
+            ],
+          ],
+        })
+      );
+    });
+
+    it('sets transformed search parameters based on transformSearchParameters', () => {
+      const searchParameters = connect.getSearchParameters.call(
+        { contextValue },
+        new SearchParameters(),
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+          transformSearchParameters(parameters) {
+            return {
+              ...parameters,
+              optionalWords: hit.name.split(' '),
+            };
+          },
+        }
+      );
+
+      expect(searchParameters).toEqual(
+        expect.objectContaining({
+          filters: 'NOT objectID:1',
+          sumOrFiltersScores: true,
+          optionalFilters: [
+            'brand:Amazon<score=3>',
+            [
+              'categories:TV & Home Theater<score=2>',
+              'categories:Streaming Media Players<score=2>',
+            ],
+          ],
+          optionalWords: [
+            'Amazon',
+            '-',
+            'Fire',
+            'TV',
+            'Stick',
+            'with',
+            'Alexa',
+            'Voice',
+            'Remote',
+            '-',
+            'Black',
+          ],
+        })
+      );
+    });
+
+    it('filters out and warns for incorrect optionalFilters value type', () => {
+      // We need to simulate being in development mode and to mock the global console object
+      // in this test to assert that development warnings are displayed correctly.
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const searchParameters = connect.getSearchParameters.call(
+        { contextValue },
+        new SearchParameters(),
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            rating: { score: 1 }, // `rating` is a number, which is not supported by the `optionalFilters` API
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        }
+      );
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'The `matchingPatterns` option returned a value of type Number for the "rating" key. This value was not sent to Algolia because `optionalFilters` only supports strings and array of strings.\n\n' +
+          'You can remove the "rating" key from the `matchingPatterns` option.\n\n' +
+          'See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/'
+      );
+
+      expect(searchParameters).toEqual(
+        expect.objectContaining({
+          filters: 'NOT objectID:1',
+          sumOrFiltersScores: true,
+          optionalFilters: [
+            'brand:Amazon<score=3>',
+            [
+              'categories:TV & Home Theater<score=2>',
+              'categories:Streaming Media Players<score=2>',
+            ],
+          ],
+        })
+      );
+
+      process.env.NODE_ENV = originalNodeEnv;
+      warnSpy.mockRestore();
+    });
+
+    it('calling transitionState should add configure parameters to the search state', () => {
+      const instance = {};
+
+      const searchState = connect.transitionState.call(
+        instance,
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        },
+        {},
+        {}
+      );
+
+      expect(searchState).toEqual({
+        indices: {
+          second: {
+            configure: {
+              filters: 'NOT objectID:1',
+              sumOrFiltersScores: true,
+              optionalFilters: [
+                'brand:Amazon<score=3>',
+                [
+                  'categories:TV & Home Theater<score=2>',
+                  'categories:Streaming Media Players<score=2>',
+                ],
+              ],
+            },
+          },
+        },
+      });
+    });
+
+    it('calling cleanUp should remove configure parameters from the search state', () => {
+      const instance = {};
+
+      // Running `transitionState` allows to set previous search parameters
+      // in the connector state.
+      let searchState = connect.transitionState.call(
+        instance,
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        },
+        {},
+        {}
+      );
+
+      searchState = connect.cleanUp.call(
+        instance,
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        },
+        {
+          indices: {
+            second: {
+              configure: {
+                filters: 'NOT objectID:1',
+                sumOrFiltersScores: true,
+                optionalFilters: ['brand:Amazon<score=3>'],
+                facetFilters: ['categories'],
+              },
+            },
+          },
+        }
+      );
+
+      expect(searchState).toEqual({
+        indices: {
+          second: {
+            configure: {
+              facetFilters: ['categories'],
+            },
+          },
+        },
+      });
+
+      searchState = connect.cleanUp.call(
+        instance,
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            categories: { score: 2 },
+          },
+        },
+        {
+          indices: {
+            second: {
+              configure: {
+                filters: 'NOT objectID:1',
+                sumOrFiltersScores: true,
+                optionalFilters: ['brand:Amazon<score=3>'],
+              },
+            },
+          },
+        }
+      );
+
+      expect(searchState).toEqual({ indices: { second: { configure: {} } } });
+    });
+  });
+});

--- a/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
@@ -122,7 +122,7 @@ See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/`
       // `sumOrFiltersScores`.
       // See https://github.com/algolia/algoliasearch-helper-js/pull/753
       sumOrFiltersScores: true,
-      filters: `NOT objectID:${props.hit.objectID}`,
+      facetFilters: [`objectID:-${props.hit.objectID}`],
       optionalFilters,
     })
   );

--- a/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
@@ -1,0 +1,220 @@
+import algoliasearchHelper, {
+  PlainSearchParameters,
+  SearchParameters,
+} from 'algoliasearch-helper';
+import createConnector, { ConnectedProps } from '../core/createConnector';
+import {
+  omit,
+  getObjectType,
+  removeEmptyKey,
+  removeEmptyArraysFromObject,
+} from '../core/utils';
+import {
+  refineValue,
+  getIndexId,
+  hasMultipleIndices,
+} from '../core/indexUtils';
+
+type Hit = any;
+
+export type MatchingPatterns = {
+  [attribute: string]: {
+    /**
+     * The score of the optional filter.
+     *
+     * @see https://www.algolia.com/doc/guides/managing-results/rules/merchandising-and-promoting/in-depth/optional-filters/
+     */
+    score: number;
+  };
+};
+
+interface ConfigureRelatedItemsProps {
+  /**
+   * The reference hit to extract the filters from.
+   */
+  hit: Hit;
+  /**
+   * The schema to create the optional filters.
+   * Each key represents an attribute from the hit.
+   */
+  matchingPatterns: MatchingPatterns;
+  /**
+   * Function called to transform the search parameters generated.
+   */
+  transformSearchParameters?(
+    searchParameters: SearchParameters
+  ): PlainSearchParameters;
+}
+
+function createOptionalFilter({
+  attributeName,
+  attributeValue,
+  attributeScore,
+}) {
+  return `${attributeName}:${attributeValue}<score=${attributeScore || 1}>`;
+}
+
+const defaultProps: Partial<ConfigureRelatedItemsProps> = {
+  transformSearchParameters: x => ({ ...x }),
+};
+
+function getId(): string {
+  // We store the search state of this widget in `configure`.
+  return 'configure';
+}
+
+type InternalConfigureRelatedItemsProps = ConfigureRelatedItemsProps &
+  Required<typeof defaultProps>;
+
+function getSearchParametersFromProps(
+  props: ConnectedProps<InternalConfigureRelatedItemsProps>
+): PlainSearchParameters {
+  const optionalFilters = Object.keys(props.matchingPatterns).reduce<
+    Array<string | string[]>
+  >((acc, attributeName) => {
+    const attribute = props.matchingPatterns[attributeName];
+    const attributeValue = props.hit[attributeName];
+    const attributeScore = attribute.score;
+
+    if (Array.isArray(attributeValue)) {
+      return [
+        ...acc,
+        attributeValue.map(attributeSubValue => {
+          return createOptionalFilter({
+            attributeName,
+            attributeValue: attributeSubValue,
+            attributeScore,
+          });
+        }),
+      ];
+    }
+
+    if (typeof attributeValue === 'string') {
+      return [
+        ...acc,
+        createOptionalFilter({
+          attributeName,
+          attributeValue,
+          attributeScore,
+        }),
+      ];
+    }
+
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `The \`matchingPatterns\` option returned a value of type ${getObjectType(
+          attributeValue
+        )} for the "${attributeName}" key. This value was not sent to Algolia because \`optionalFilters\` only supports strings and array of strings.
+
+You can remove the "${attributeName}" key from the \`matchingPatterns\` option.
+
+See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/`
+      );
+    }
+
+    return acc;
+  }, []);
+
+  return props.transformSearchParameters(
+    new algoliasearchHelper.SearchParameters({
+      // @ts-ignore @TODO algoliasearch-helper@3.0.1 will contain the type
+      // `sumOrFiltersScores`.
+      // See https://github.com/algolia/algoliasearch-helper-js/pull/753
+      sumOrFiltersScores: true,
+      filters: `NOT objectID:${props.hit.objectID}`,
+      optionalFilters,
+    })
+  );
+}
+
+interface ConnectorState {
+  _searchParameters: PlainSearchParameters;
+}
+
+export default createConnector({
+  displayName: 'AlgoliaConfigureRelatedItems',
+
+  defaultProps,
+
+  getProvidedProps() {
+    return {};
+  },
+
+  getSearchParameters(
+    searchParameters: SearchParameters,
+    props: ConnectedProps<InternalConfigureRelatedItemsProps>
+  ) {
+    return searchParameters.setQueryParameters(
+      getSearchParametersFromProps(props)
+    );
+  },
+
+  transitionState(
+    this: ConnectorState,
+    props,
+    _prevSearchState,
+    nextSearchState
+  ) {
+    const id = getId();
+    // We need to transform the exhaustive search parameters back to clean
+    // search parameters without the empty default keys so we don't pollute the
+    // `configure` search state.
+    const searchParameters = removeEmptyArraysFromObject(
+      removeEmptyKey(getSearchParametersFromProps(props))
+    );
+
+    const searchParametersKeys = Object.keys(searchParameters);
+    const nonPresentKeys = this._searchParameters
+      ? Object.keys(this._searchParameters).filter(
+          prop => searchParametersKeys.indexOf(prop) === -1
+        )
+      : [];
+    this._searchParameters = searchParameters;
+    const nextValue = {
+      [id]: {
+        ...omit(nextSearchState[id], nonPresentKeys),
+        ...searchParameters,
+      },
+    };
+
+    return refineValue(nextSearchState, nextValue, {
+      ais: props.contextValue,
+      multiIndexContext: props.indexContextValue,
+    });
+  },
+
+  cleanUp(this: ConnectorState, props, searchState) {
+    const id = getId();
+    const indexId = getIndexId({
+      ais: props.contextValue,
+      multiIndexContext: props.indexContextValue,
+    });
+
+    const subState =
+      hasMultipleIndices({
+        ais: props.contextValue,
+        multiIndexContext: props.indexContextValue,
+      }) && searchState.indices
+        ? searchState.indices[indexId]
+        : searchState;
+
+    const configureKeys =
+      subState && subState[id] ? Object.keys(subState[id]) : [];
+
+    const configureState = configureKeys.reduce((acc, item) => {
+      if (!this._searchParameters[item]) {
+        acc[item] = subState[id][item];
+      }
+
+      return acc;
+    }, {});
+
+    const nextValue = { [id]: configureState };
+
+    return refineValue(searchState, nextValue, {
+      ais: props.contextValue,
+      multiIndexContext: props.indexContextValue,
+    });
+  },
+});

--- a/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
@@ -39,7 +39,7 @@ interface ConfigureRelatedItemsProps {
    */
   matchingPatterns: MatchingPatterns;
   /**
-   * Function called to transform the search parameters generated.
+   * Function to transform the generated search parameters.
    */
   transformSearchParameters?(
     searchParameters: SearchParameters

--- a/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
@@ -72,9 +72,9 @@ function getSearchParametersFromProps(
   const optionalFilters = Object.keys(props.matchingPatterns).reduce<
     Array<string | string[]>
   >((acc, attributeName) => {
-    const attribute = props.matchingPatterns[attributeName];
+    const attributePattern = props.matchingPatterns[attributeName];
     const attributeValue = props.hit[attributeName];
-    const attributeScore = attribute.score;
+    const attributeScore = attributePattern.score;
 
     if (Array.isArray(attributeValue)) {
       return [

--- a/packages/react-instantsearch-core/src/core/__tests__/utils.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/utils.js
@@ -119,6 +119,28 @@ describe('utils', () => {
     });
   });
 
+  describe('removeEmptyArraysFromObject', () => {
+    it('removes empty arrays from objects', () => {
+      expect(
+        utils.removeEmptyArraysFromObject({
+          disjunctiveFacets: [],
+          facetFilters: ['categories'],
+          facets: [],
+          filters: 'NOT objectID:1',
+          hierarchicalFacets: [],
+          optionalFilters: ['brand:Amazon<score=3>'],
+          sumOrFiltersScores: true,
+          tagRefinements: [],
+        })
+      ).toEqual({
+        facetFilters: ['categories'],
+        filters: 'NOT objectID:1',
+        optionalFilters: ['brand:Amazon<score=3>'],
+        sumOrFiltersScores: true,
+      });
+    });
+  });
+
   describe('addAbsolutePositions', () => {
     const allHits = [
       { objectID: '1' },
@@ -297,6 +319,45 @@ describe('utils', () => {
       expect(function() {
         utils.find([1, 2, 3], undefined);
       }).toThrow();
+    });
+  });
+
+  describe('getObjectType', () => {
+    test('returns the type of a string', () => {
+      expect(utils.getObjectType('string')).toEqual('String');
+    });
+
+    test('returns the type of a number', () => {
+      expect(utils.getObjectType(2)).toEqual('Number');
+    });
+
+    test('returns the type of a boolean', () => {
+      expect(utils.getObjectType(true)).toEqual('Boolean');
+      expect(utils.getObjectType(false)).toEqual('Boolean');
+    });
+
+    test('returns the type of an object', () => {
+      expect(utils.getObjectType({})).toEqual('Object');
+    });
+
+    test('returns the type of an array', () => {
+      expect(utils.getObjectType([])).toEqual('Array');
+    });
+
+    test('returns the type of a date', () => {
+      expect(utils.getObjectType(new Date())).toEqual('Date');
+    });
+
+    test('returns the type of a function', () => {
+      expect(utils.getObjectType(function() {})).toEqual('Function');
+    });
+
+    test('returns the type of undefined', () => {
+      expect(utils.getObjectType(undefined)).toEqual('Undefined');
+    });
+
+    test('returns the type of null', () => {
+      expect(utils.getObjectType(null)).toEqual('Null');
     });
   });
 });

--- a/packages/react-instantsearch-core/src/core/utils.ts
+++ b/packages/react-instantsearch-core/src/core/utils.ts
@@ -51,6 +51,18 @@ export const removeEmptyKey = (obj: object) => {
   return obj;
 };
 
+export const removeEmptyArraysFromObject = (obj: object) => {
+  Object.keys(obj).forEach(key => {
+    const value = obj[key];
+
+    if (Array.isArray(value) && value.length === 0) {
+      delete obj[key];
+    }
+  });
+
+  return obj;
+};
+
 export function addAbsolutePositions(hits, hitsPerPage, page) {
   return hits.map((hit, index) => ({
     ...hit,
@@ -128,3 +140,7 @@ export const getPropertyByPath = (object: object, path: string[] | string) =>
     ? path
     : path.replace(/\[(\d+)]/g, '.$1').split('.')
   ).reduce((current, key) => (current ? current[key] : undefined), object);
+
+export function getObjectType(object: unknown): string {
+  return Object.prototype.toString.call(object).slice(8, -1);
+}

--- a/packages/react-instantsearch-core/src/index.ts
+++ b/packages/react-instantsearch-core/src/index.ts
@@ -9,7 +9,6 @@ export { default as translatable } from './core/translatable';
 // Widgets
 export { default as Configure } from './widgets/Configure';
 export {
-  // eslint-disable-next-line @typescript-eslint/camelcase
   default as EXPERIMENTAL_ConfigureRelatedItems,
 } from './widgets/ConfigureRelatedItems';
 export { default as QueryRuleContext } from './widgets/QueryRuleContext';
@@ -23,7 +22,6 @@ export {
 export { default as connectBreadcrumb } from './connectors/connectBreadcrumb';
 export { default as connectConfigure } from './connectors/connectConfigure';
 export {
-  // eslint-disable-next-line @typescript-eslint/camelcase
   default as EXPERIMENTAL_connectConfigureRelatedItems,
 } from './connectors/connectConfigureRelatedItems';
 export {

--- a/packages/react-instantsearch-core/src/index.ts
+++ b/packages/react-instantsearch-core/src/index.ts
@@ -8,6 +8,10 @@ export { default as translatable } from './core/translatable';
 
 // Widgets
 export { default as Configure } from './widgets/Configure';
+export {
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  default as EXPERIMENTAL_ConfigureRelatedItems,
+} from './widgets/ConfigureRelatedItems';
 export { default as QueryRuleContext } from './widgets/QueryRuleContext';
 export { default as Index } from './widgets/Index';
 export { default as InstantSearch } from './widgets/InstantSearch';
@@ -18,6 +22,10 @@ export {
 } from './connectors/connectAutoComplete';
 export { default as connectBreadcrumb } from './connectors/connectBreadcrumb';
 export { default as connectConfigure } from './connectors/connectConfigure';
+export {
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  default as EXPERIMENTAL_connectConfigureRelatedItems,
+} from './connectors/connectConfigureRelatedItems';
 export {
   default as connectCurrentRefinements,
 } from './connectors/connectCurrentRefinements';

--- a/packages/react-instantsearch-core/src/widgets/ConfigureRelatedItems.tsx
+++ b/packages/react-instantsearch-core/src/widgets/ConfigureRelatedItems.tsx
@@ -1,0 +1,14 @@
+import connectConfigureRelatedItems from '../connectors/connectConfigureRelatedItems';
+import PropTypes from 'prop-types';
+
+function ConfigureRelatedItems() {
+  return null;
+}
+
+ConfigureRelatedItems.propTypes = {
+  hit: PropTypes.object.isRequired,
+  matchingPatterns: PropTypes.object.isRequired,
+  transformSearchParameters: PropTypes.func,
+};
+
+export default connectConfigureRelatedItems(ConfigureRelatedItems);

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -5,7 +5,6 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
-// eslint-disable-next-line @typescript-eslint/camelcase
 export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-core';
 export { QueryRuleContext } from 'react-instantsearch-core';
 export { Index } from 'react-instantsearch-core';
@@ -16,7 +15,6 @@ export { connectAutoComplete } from 'react-instantsearch-core';
 export { connectBreadcrumb } from 'react-instantsearch-core';
 export { connectConfigure } from 'react-instantsearch-core';
 export {
-  // eslint-disable-next-line @typescript-eslint/camelcase
   EXPERIMENTAL_connectConfigureRelatedItems,
 } from 'react-instantsearch-core';
 export { connectCurrentRefinements } from 'react-instantsearch-core';

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -5,6 +5,8 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
+// eslint-disable-next-line @typescript-eslint/camelcase
+export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-core';
 export { QueryRuleContext } from 'react-instantsearch-core';
 export { Index } from 'react-instantsearch-core';
 export { InstantSearch } from 'react-instantsearch-core';
@@ -13,6 +15,10 @@ export { InstantSearch } from 'react-instantsearch-core';
 export { connectAutoComplete } from 'react-instantsearch-core';
 export { connectBreadcrumb } from 'react-instantsearch-core';
 export { connectConfigure } from 'react-instantsearch-core';
+export {
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  EXPERIMENTAL_connectConfigureRelatedItems,
+} from 'react-instantsearch-core';
 export { connectCurrentRefinements } from 'react-instantsearch-core';
 export { connectGeoSearch } from 'react-instantsearch-core';
 export { connectHierarchicalMenu } from 'react-instantsearch-core';

--- a/packages/react-instantsearch-native/src/index.ts
+++ b/packages/react-instantsearch-native/src/index.ts
@@ -5,7 +5,6 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
-// eslint-disable-next-line @typescript-eslint/camelcase
 export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-core';
 export { QueryRuleContext } from 'react-instantsearch-core';
 export { Index } from 'react-instantsearch-core';
@@ -16,7 +15,6 @@ export { connectAutoComplete } from 'react-instantsearch-core';
 export { connectBreadcrumb } from 'react-instantsearch-core';
 export { connectConfigure } from 'react-instantsearch-core';
 export {
-  // eslint-disable-next-line @typescript-eslint/camelcase
   EXPERIMENTAL_connectConfigureRelatedItems,
 } from 'react-instantsearch-core';
 export { connectCurrentRefinements } from 'react-instantsearch-core';

--- a/packages/react-instantsearch-native/src/index.ts
+++ b/packages/react-instantsearch-native/src/index.ts
@@ -5,6 +5,8 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
+// eslint-disable-next-line @typescript-eslint/camelcase
+export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-core';
 export { QueryRuleContext } from 'react-instantsearch-core';
 export { Index } from 'react-instantsearch-core';
 export { InstantSearch } from 'react-instantsearch-core';
@@ -13,6 +15,10 @@ export { InstantSearch } from 'react-instantsearch-core';
 export { connectAutoComplete } from 'react-instantsearch-core';
 export { connectBreadcrumb } from 'react-instantsearch-core';
 export { connectConfigure } from 'react-instantsearch-core';
+export {
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  EXPERIMENTAL_connectConfigureRelatedItems,
+} from 'react-instantsearch-core';
 export { connectCurrentRefinements } from 'react-instantsearch-core';
 export { connectGeoSearch } from 'react-instantsearch-core';
 export { connectHierarchicalMenu } from 'react-instantsearch-core';

--- a/packages/react-instantsearch/connectors.js
+++ b/packages/react-instantsearch/connectors.js
@@ -1,6 +1,10 @@
 export { connectAutoComplete } from 'react-instantsearch-core';
 export { connectBreadcrumb } from 'react-instantsearch-core';
 export { connectConfigure } from 'react-instantsearch-core';
+export {
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  EXPERIMENTAL_connectConfigureRelatedItems,
+} from 'react-instantsearch-core';
 export { connectCurrentRefinements } from 'react-instantsearch-core';
 export { connectGeoSearch } from 'react-instantsearch-core';
 export { connectHierarchicalMenu } from 'react-instantsearch-core';

--- a/packages/react-instantsearch/connectors.js
+++ b/packages/react-instantsearch/connectors.js
@@ -2,7 +2,6 @@ export { connectAutoComplete } from 'react-instantsearch-core';
 export { connectBreadcrumb } from 'react-instantsearch-core';
 export { connectConfigure } from 'react-instantsearch-core';
 export {
-  // eslint-disable-next-line @typescript-eslint/camelcase
   EXPERIMENTAL_connectConfigureRelatedItems,
 } from 'react-instantsearch-core';
 export { connectCurrentRefinements } from 'react-instantsearch-core';

--- a/packages/react-instantsearch/dom.js
+++ b/packages/react-instantsearch/dom.js
@@ -3,7 +3,6 @@ export { Index } from 'react-instantsearch-dom';
 export { Breadcrumb } from 'react-instantsearch-dom';
 export { ClearRefinements } from 'react-instantsearch-dom';
 export { Configure } from 'react-instantsearch-dom';
-// eslint-disable-next-line @typescript-eslint/camelcase
 export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-dom';
 export { CurrentRefinements } from 'react-instantsearch-dom';
 export { HierarchicalMenu } from 'react-instantsearch-dom';

--- a/packages/react-instantsearch/dom.js
+++ b/packages/react-instantsearch/dom.js
@@ -3,6 +3,8 @@ export { Index } from 'react-instantsearch-dom';
 export { Breadcrumb } from 'react-instantsearch-dom';
 export { ClearRefinements } from 'react-instantsearch-dom';
 export { Configure } from 'react-instantsearch-dom';
+// eslint-disable-next-line @typescript-eslint/camelcase
+export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-dom';
 export { CurrentRefinements } from 'react-instantsearch-dom';
 export { HierarchicalMenu } from 'react-instantsearch-dom';
 export { Highlight } from 'react-instantsearch-dom';

--- a/packages/react-instantsearch/native.js
+++ b/packages/react-instantsearch/native.js
@@ -1,5 +1,4 @@
 export { InstantSearch } from 'react-instantsearch-native';
 export { Index } from 'react-instantsearch-native';
 export { Configure } from 'react-instantsearch-native';
-// eslint-disable-next-line @typescript-eslint/camelcase
 export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-native';

--- a/packages/react-instantsearch/native.js
+++ b/packages/react-instantsearch/native.js
@@ -1,3 +1,5 @@
 export { InstantSearch } from 'react-instantsearch-native';
 export { Index } from 'react-instantsearch-native';
 export { Configure } from 'react-instantsearch-native';
+// eslint-disable-next-line @typescript-eslint/camelcase
+export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-native';

--- a/stories/ConfigureRelatedItems.stories.tsx
+++ b/stories/ConfigureRelatedItems.stories.tsx
@@ -1,0 +1,115 @@
+/* eslint react/prop-types: 0 */
+
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import {
+  Configure,
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  EXPERIMENTAL_ConfigureRelatedItems,
+  Hits,
+  Index,
+  connectPagination,
+} from 'react-instantsearch-dom';
+import { WrapWithHits } from './util';
+
+type Hit = any;
+
+const stories = storiesOf('ConfigureRelatedItems', module);
+
+stories.add('default', () => <ConfigureRelatedItemsExample />);
+
+function RelatedHit({ hit }: { hit: Hit }) {
+  return (
+    <div>
+      <div className="ais-RelatedHits-item-image">
+        <img src={hit.image} alt={hit.name} />
+      </div>
+
+      <div className="ais-RelatedHits-item-title">
+        <h4>{hit.name}</h4>
+      </div>
+    </div>
+  );
+}
+
+const PreviousPagination = connectPagination(
+  ({ currentRefinement, refine }) => {
+    return (
+      <button
+        className="ais-RelatedHits-button"
+        disabled={currentRefinement === 1}
+        onClick={() => {
+          refine(currentRefinement - 1);
+        }}
+      >
+        ←
+      </button>
+    );
+  }
+);
+
+const NextPagination = connectPagination(
+  ({ currentRefinement, refine, nbPages }) => {
+    return (
+      <button
+        className="ais-RelatedHits-button"
+        disabled={currentRefinement + 1 === nbPages}
+        onClick={() => {
+          refine(currentRefinement + 1);
+        }}
+      >
+        →
+      </button>
+    );
+  }
+);
+
+function ConfigureRelatedItemsExample() {
+  const [referenceHit, setReferenceHit] = useState<Hit | null>(null);
+
+  const ReferenceHit = React.memo<{ hit: Hit }>(
+    ({ hit }) => {
+      return (
+        <div ref={() => setReferenceHit(hit)}>
+          <img src={hit.image} alt={hit.name} />
+          <h3>{hit.name}</h3>
+        </div>
+      );
+    },
+    (prevProps, nextProps) => {
+      return prevProps.hit.objectID === nextProps.hit.objectID;
+    }
+  );
+
+  return (
+    <WrapWithHits linkedStoryGroup="ConfigureRelatedItems">
+      <Index indexName="instant_search" indexId="mainIndex">
+        <Configure hitsPerPage={1} />
+
+        <Hits hitComponent={ReferenceHit} />
+      </Index>
+
+      {referenceHit && (
+        <Index indexName="instant_search" indexId="relatedIndex">
+          <Configure hitsPerPage={4} />
+          <EXPERIMENTAL_ConfigureRelatedItems
+            hit={referenceHit}
+            matchingPatterns={{
+              brand: { score: 3 },
+              type: { score: 10 },
+              categories: { score: 2 },
+            }}
+          />
+
+          <h2>Related items</h2>
+
+          <div className="related-items">
+            <PreviousPagination />
+            <Hits hitComponent={RelatedHit} />
+            <NextPagination />
+          </div>
+        </Index>
+      )}
+    </WrapWithHits>
+  );
+}

--- a/stories/ConfigureRelatedItems.stories.tsx
+++ b/stories/ConfigureRelatedItems.stories.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import {
   Configure,
-  // eslint-disable-next-line @typescript-eslint/camelcase
   EXPERIMENTAL_ConfigureRelatedItems,
   Hits,
   Index,

--- a/stories/ConfigureRelatedItems.stories.tsx
+++ b/stories/ConfigureRelatedItems.stories.tsx
@@ -1,5 +1,3 @@
-/* eslint react/prop-types: 0 */
-
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import {

--- a/storybook/public/util.css
+++ b/storybook/public/util.css
@@ -222,3 +222,51 @@
   font-size: 2rem;
   color: #555;
 }
+
+/* Related items */
+
+.related-items {
+  display: flex;
+  align-items: center;
+}
+
+.related-items .ais-Hits-list {
+  margin-left: 0;
+  margin-right: 1rem;
+}
+
+.ais-RelatedHits-item-image {
+  height: 150px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  background-color: #fff;
+}
+
+.ais-RelatedHits-item-image img {
+  max-height: 120px;
+}
+
+.ais-RelatedHits-item-title {
+  text-align: center;
+  padding: 1rem;
+}
+
+.ais-RelatedHits-item-title h4 {
+  margin: 0;
+}
+
+.ais-RelatedHits-button {
+  height: 40px;
+  width: 40px;
+  border-radius: 3px;
+  background-color: #dfe2ee;
+  border: none;
+  color: #3a4570;
+  cursor: pointer;
+}
+
+.ais-RelatedHits-button[disabled] {
+  cursor: not-allowed;
+}


### PR DESCRIPTION
This PR introduces a new set of experimental widgets:

- `EXPERIMENTAL_ConfigureRelatedItems`
- `EXPERIMENTAL_connectConfigureRelatedItems`

Combined with the `Hits` component, these widgets allow to create related items experiences as seen in e-commerce and media use cases:

![Example](https://user-images.githubusercontent.com/6137112/69717292-12bedf00-110c-11ea-9a47-8ddd7c8ed2a6.png)

<details>

<summary>See more examples</summary>

![Example](https://user-images.githubusercontent.com/6137112/69970627-d54cbe00-151e-11ea-85bc-04304077f78e.png)

![Example](https://user-images.githubusercontent.com/6270048/67220965-ff449800-f42a-11e9-9896-2db8adb9b786.png)

</details>

## Result

- [Usage](https://github.com/algolia/react-instantsearch/blob/4ab5da03bc35e2739f9dd0ce6974d55ebb8e1840/stories/ConfigureRelatedItems.stories.tsx)
- [Story](https://deploy-preview-2880--react-instantsearch.netlify.com/storybook/?path=/story/configurerelateditems--default)

## Related

- Widgets in InstantSearch.js: algolia/instantsearch.js#4233
- In the story I used `React.memo` for the component not to rerender when the `objectID` doesn't change between renders. Our PropTypes don't support memoized components because we expect [`hitComponent` to be a `func`](https://github.com/algolia/react-instantsearch/blob/621656a8f25377094c6a3b06debc8d43f4e3d6c6/packages/react-instantsearch-dom/src/components/Hits.tsx#L60) while it should be an `elementType`. We can tackle that in another PR.