### PR TITLE
feat(insights): add getInsightsAnonymousUserToken helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "36 kB"
+      "maxSize": "36.25 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "33.5 kB"
+      "maxSize": "33.75 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/packages/react-instantsearch-dom/src/core/__tests__/getInsightsAnonymousUserToken.ts
+++ b/packages/react-instantsearch-dom/src/core/__tests__/getInsightsAnonymousUserToken.ts
@@ -29,7 +29,7 @@ describe('getInsightsAnonymousUserToken', () => {
     expect(getInsightsAnonymousUserToken()).toBe('anonymous-uuid');
   });
 
-  it("should not care about other cookies and fail if they're malformed", () => {
+  it('should return the anonymous uuid when other cookies are invalid', () => {
     document.cookie = `${ANONYMOUS_TOKEN_COOKIE_KEY}=anonymous-uuid;expires=${DATE_TOMORROW};`;
     document.cookie = `BAD_COOKIE=val%ue;expires=${DATE_TOMORROW};path=/`;
     expect(getInsightsAnonymousUserToken()).toBe('anonymous-uuid');

--- a/packages/react-instantsearch-dom/src/core/__tests__/getInsightsAnonymousUserToken.ts
+++ b/packages/react-instantsearch-dom/src/core/__tests__/getInsightsAnonymousUserToken.ts
@@ -15,13 +15,13 @@ describe('getInsightsAnonymousUserToken', () => {
     resetCookie(ANONYMOUS_TOKEN_COOKIE_KEY);
   });
 
-  it('should return null when no cookies', () => {
-    expect(getInsightsAnonymousUserToken()).toBe(null);
+  it('should return undefined when no cookies', () => {
+    expect(getInsightsAnonymousUserToken()).toBe(undefined);
   });
 
-  it('should return null when cookie present but expired', () => {
+  it('should return undefined when cookie present but expired', () => {
     document.cookie = `${ANONYMOUS_TOKEN_COOKIE_KEY}=anonymous-uuid;expires=${DATE_YESTERDAY};`;
-    expect(getInsightsAnonymousUserToken()).toBe(null);
+    expect(getInsightsAnonymousUserToken()).toBe(undefined);
   });
 
   it('should return the anonymous uuid when cookie present and valid', () => {

--- a/packages/react-instantsearch-dom/src/core/__tests__/getInsightsAnonymousUserToken.ts
+++ b/packages/react-instantsearch-dom/src/core/__tests__/getInsightsAnonymousUserToken.ts
@@ -1,0 +1,31 @@
+import getInsightsAnonymousUserToken, {
+  ANONYMOUS_TOKEN_COOKIE_KEY,
+} from '../getInsightsAnonymousUserToken';
+
+const DAY = 86400000; /* 1 day in ms*/
+const DATE_TOMORROW = new Date(Date.now() + DAY).toUTCString();
+const DATE_YESTERDAY = new Date(Date.now() - DAY).toUTCString();
+
+const resetCookie = cookieKey => {
+  document.cookie = `${cookieKey}=;expires=Thu, 01-Jan-1970 00:00:01 GMT;`;
+};
+
+describe('getInsightsAnonymousUserToken', () => {
+  beforeEach(() => {
+    resetCookie(ANONYMOUS_TOKEN_COOKIE_KEY);
+  });
+
+  it('should return null when no cookies', () => {
+    expect(getInsightsAnonymousUserToken()).toBe(null);
+  });
+
+  it('should return null when cookie present but expired', () => {
+    document.cookie = `${ANONYMOUS_TOKEN_COOKIE_KEY}=anonymous-uuid;expires=${DATE_YESTERDAY};`;
+    expect(getInsightsAnonymousUserToken()).toBe(null);
+  });
+
+  it('should return the anonymous uuid when cookie present and valid', () => {
+    document.cookie = `${ANONYMOUS_TOKEN_COOKIE_KEY}=anonymous-uuid;expires=${DATE_TOMORROW};`;
+    expect(getInsightsAnonymousUserToken()).toBe('anonymous-uuid');
+  });
+});

--- a/packages/react-instantsearch-dom/src/core/__tests__/getInsightsAnonymousUserToken.ts
+++ b/packages/react-instantsearch-dom/src/core/__tests__/getInsightsAnonymousUserToken.ts
@@ -28,4 +28,10 @@ describe('getInsightsAnonymousUserToken', () => {
     document.cookie = `${ANONYMOUS_TOKEN_COOKIE_KEY}=anonymous-uuid;expires=${DATE_TOMORROW};`;
     expect(getInsightsAnonymousUserToken()).toBe('anonymous-uuid');
   });
+
+  it("should not care about other cookies and fail if they're malformed", () => {
+    document.cookie = `${ANONYMOUS_TOKEN_COOKIE_KEY}=anonymous-uuid;expires=${DATE_TOMORROW};`;
+    document.cookie = `BAD_COOKIE=val%ue;expires=${DATE_TOMORROW};path=/`;
+    expect(getInsightsAnonymousUserToken()).toBe('anonymous-uuid');
+  });
 });

--- a/packages/react-instantsearch-dom/src/core/getInsightsAnonymousUserToken.ts
+++ b/packages/react-instantsearch-dom/src/core/getInsightsAnonymousUserToken.ts
@@ -1,0 +1,21 @@
+export const ANONYMOUS_TOKEN_COOKIE_KEY = '_ALGOLIA';
+
+function getCookie(name: string): string {
+  const prefix = `${name}=`;
+  const cookies = document.cookie.split(';');
+  for (let i = 0; i < cookies.length; i++) {
+    let cookie = cookies[i];
+    while (cookie.charAt(0) === ' ') {
+      cookie = cookie.substring(1);
+    }
+    if (cookie.indexOf(prefix) === 0) {
+      return cookie.substring(prefix.length, cookie.length);
+    }
+  }
+  return '';
+}
+
+export default function getInsightsAnonymousUserToken(): string | null {
+  const anonymousUserToken = getCookie(ANONYMOUS_TOKEN_COOKIE_KEY);
+  return anonymousUserToken || null;
+}

--- a/packages/react-instantsearch-dom/src/core/getInsightsAnonymousUserToken.ts
+++ b/packages/react-instantsearch-dom/src/core/getInsightsAnonymousUserToken.ts
@@ -1,6 +1,6 @@
 export const ANONYMOUS_TOKEN_COOKIE_KEY = '_ALGOLIA';
 
-function getCookie(name: string): string {
+function getCookie(name: string): string | undefined {
   const prefix = `${name}=`;
   const cookies = document.cookie.split(';');
   for (let i = 0; i < cookies.length; i++) {
@@ -12,10 +12,9 @@ function getCookie(name: string): string {
       return cookie.substring(prefix.length, cookie.length);
     }
   }
-  return '';
+  return undefined;
 }
 
-export default function getInsightsAnonymousUserToken(): string | null {
-  const anonymousUserToken = getCookie(ANONYMOUS_TOKEN_COOKIE_KEY);
-  return anonymousUserToken || null;
+export default function getInsightsAnonymousUserToken(): string | undefined {
+  return getCookie(ANONYMOUS_TOKEN_COOKIE_KEY);
 }

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -72,3 +72,8 @@ export { createClassNames } from './core/utils';
 
 // voiceSearchHelper
 export { default as createVoiceSearchHelper } from './lib/voiceSearchHelper';
+
+// insights
+export {
+  default as getInsightsAnonymousUserToken,
+} from './core/getInsightsAnonymousUserToken';

--- a/packages/react-instantsearch/dom.js
+++ b/packages/react-instantsearch/dom.js
@@ -26,3 +26,4 @@ export { Snippet } from 'react-instantsearch-dom';
 export { SortBy } from 'react-instantsearch-dom';
 export { Stats } from 'react-instantsearch-dom';
 export { ToggleRefinement } from 'react-instantsearch-dom';
+export { getInsightsAnonymousUserToken } from 'react-instantsearch-dom';


### PR DESCRIPTION
**Summary**

This PR adds getInsightsAnonymousUserToken to `react-instantsearch-dom`.
Related RFC: https://github.com/algolia/instantsearch-rfcs/pull/27


```js
// usage
import { Configure, getInsightsAnonymousUserToken } from 'react-instantsearch-dom';

<Configure
  enablePersonalization={true}
  userToken={getInsightsAnonymousUserToken()}
/>
```