### PR TITLE
fix(widgets): rename `ExperimentalConfigureRelatedItems` component

### DIFF
--- a/packages/react-instantsearch-core/src/index.ts
+++ b/packages/react-instantsearch-core/src/index.ts
@@ -9,7 +9,7 @@ export { default as translatable } from './core/translatable';
 // Widgets
 export { default as Configure } from './widgets/Configure';
 export {
-  default as EXPERIMENTAL_ConfigureRelatedItems,
+  default as ExperimentalConfigureRelatedItems,
 } from './widgets/ConfigureRelatedItems';
 export { default as QueryRuleContext } from './widgets/QueryRuleContext';
 export { default as Index } from './widgets/Index';

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -5,7 +5,7 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
-export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-core';
+export { ExperimentalConfigureRelatedItems } from 'react-instantsearch-core';
 export { QueryRuleContext } from 'react-instantsearch-core';
 export { Index } from 'react-instantsearch-core';
 export { InstantSearch } from 'react-instantsearch-core';

--- a/packages/react-instantsearch-native/src/index.ts
+++ b/packages/react-instantsearch-native/src/index.ts
@@ -5,7 +5,7 @@ export { translatable } from 'react-instantsearch-core';
 
 // Widget
 export { Configure } from 'react-instantsearch-core';
-export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-core';
+export { ExperimentalConfigureRelatedItems } from 'react-instantsearch-core';
 export { QueryRuleContext } from 'react-instantsearch-core';
 export { Index } from 'react-instantsearch-core';
 export { InstantSearch } from 'react-instantsearch-core';

--- a/packages/react-instantsearch/dom.js
+++ b/packages/react-instantsearch/dom.js
@@ -3,7 +3,7 @@ export { Index } from 'react-instantsearch-dom';
 export { Breadcrumb } from 'react-instantsearch-dom';
 export { ClearRefinements } from 'react-instantsearch-dom';
 export { Configure } from 'react-instantsearch-dom';
-export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-dom';
+export { ExperimentalConfigureRelatedItems } from 'react-instantsearch-dom';
 export { CurrentRefinements } from 'react-instantsearch-dom';
 export { HierarchicalMenu } from 'react-instantsearch-dom';
 export { Highlight } from 'react-instantsearch-dom';

--- a/packages/react-instantsearch/native.js
+++ b/packages/react-instantsearch/native.js
@@ -1,4 +1,4 @@
 export { InstantSearch } from 'react-instantsearch-native';
 export { Index } from 'react-instantsearch-native';
 export { Configure } from 'react-instantsearch-native';
-export { EXPERIMENTAL_ConfigureRelatedItems } from 'react-instantsearch-native';
+export { ExperimentalConfigureRelatedItems } from 'react-instantsearch-native';


### PR DESCRIPTION
The Vue InstantSearch widget is named `ExperimentalConfigureRelatedItems` so this uses the same name for React InstantSearch. The connector name remains `EXPERIMENTAL_connectConfigureRelatedItems`.