### PR TITLE
fix(deps): fix "too much recursion" error with circular deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,23 +134,23 @@
   "bundlesize": [
     {
       "path": "packages/react-instantsearch/dist/umd/Core.min.js",
-      "maxSize": "2.75 kB"
+      "maxSize": "2.95 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Connectors.min.js",
-      "maxSize": "21.5 kB"
+      "maxSize": "21.75 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "34 kB"
+      "maxSize": "34.25 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "25 kB"
+      "maxSize": "25.25 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "36.50 kB"
+      "maxSize": "36.75 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "algoliasearch-helper": "^3.1.0",
-    "fast-deep-equal": "^2.0.1",
+    "react-fast-compare": "^3.0.0",
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-core/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch-core/src/connectors/connectInfiniteHits.js
@@ -1,4 +1,4 @@
-import isEqual from 'fast-deep-equal';
+import isEqual from 'react-fast-compare';
 
 import createConnector from '../core/createConnector';
 import {

--- a/packages/react-instantsearch-core/src/core/createConnector.tsx
+++ b/packages/react-instantsearch-core/src/core/createConnector.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ReactType } from 'react';
-import isEqual from 'fast-deep-equal';
+import isEqual from 'react-fast-compare';
 import { shallowEqual, getDisplayName, removeEmptyKey } from './utils';
 import {
   InstantSearchConsumer,

--- a/packages/react-instantsearch-core/src/widgets/InstantSearch.tsx
+++ b/packages/react-instantsearch-core/src/widgets/InstantSearch.tsx
@@ -1,5 +1,5 @@
 import React, { Component, Children } from 'react';
-import isEqual from 'fast-deep-equal';
+import isEqual from 'react-fast-compare';
 import PropTypes from 'prop-types';
 import createInstantSearchManager from '../core/createInstantSearchManager';
 import { InstantSearchProvider, InstantSearchContext } from '../core/context';

--- a/yarn.lock
+++ b/yarn.lock
@@ -15864,6 +15864,11 @@ react-fast-compare@^2.0.2:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-fast-compare@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.0.1.tgz#884d339ce1341aad22392e7a88664c71da48600e"
+  integrity sha512-C5vP0J644ofZGd54P8++O7AvrqMEbrGf8Ue0eAUJLJyw168dAX2aiYyX/zcY/eSNwO0IDjsKUaLE6n83D+TnEg==
+
 react-focus-lock@^1.17.7:
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-1.18.3.tgz#19d84afeab935c0b5de196922f71db7c481baba4"


### PR DESCRIPTION
Since React InstantSearch 6, there's an issue with props equality with circular dependencies because of the dep `fast-deep-equal` that was introduced.

Errors like "too much recursion" appeared in browsers (mostly Firefox). More and more users [face this issue](https://discourse.algolia.com/t/instantsearch-conditional-display-too-much-recursion/9555), and I also faced this issue in some apps I built.

I tried upgrading the `fast-deep-equal` dependency to [`^3.1.0`](https://github.com/epoberezkin/fast-deep-equal/releases) which supposedly fixes this, but the build seems broken since I get an error about no default exports exist in this package.

I tried [`react-fast-compare`](https://github.com/FormidableLabs/react-fast-compare) and although it's a bit bigger, it fixes the issue. I tried in the Next app that the user sent.