### PR TITLE
fix(connectQueryRules): fix crash when using connectQueryRules in multiple indexes

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectQueryRules.ts
@@ -622,6 +622,24 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           'ais-price-3000',
         ]);
       });
+
+      it('sets empty ruleContexts without search state', () => {
+        const props: ConnectedProps<QueryRulesProps> = {
+          ...defaultPropsMultiIndex,
+          trackedFilters: {
+            price: values => values,
+          },
+        };
+        const searchState = {};
+
+        const searchParameters = connect.getSearchParameters(
+          new SearchParameters(),
+          props,
+          searchState
+        );
+
+        expect(searchParameters.ruleContexts).toEqual([]);
+      });
     });
 
     describe('transformRuleContexts', () => {

--- a/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectQueryRules.ts
@@ -157,17 +157,18 @@ export default createConnector({
       return searchParameters;
     }
 
-    const indexSearchState = hasMultipleIndices({
-      ais: props.contextValue,
-      multiIndexContext: props.indexContextValue,
-    })
-      ? searchState.indices[
-          getIndexId({
-            ais: props.contextValue,
-            multiIndexContext: props.indexContextValue,
-          })
-        ]
-      : searchState;
+    const indexSearchState =
+      hasMultipleIndices({
+        ais: props.contextValue,
+        multiIndexContext: props.indexContextValue,
+      }) && searchState.indices
+        ? searchState.indices[
+            getIndexId({
+              ais: props.contextValue,
+              multiIndexContext: props.indexContextValue,
+            })
+          ]
+        : searchState;
 
     const newRuleContexts = getRuleContextsFromTrackedFilters({
       searchState: indexSearchState,


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Fixes #2902 

`searchState.indices` is `undefined` if the widget is initialized with an empty `searchState`, triggering an error during the initial call to `getSearchParameters`.

This PR fix it by adding a check on `searchState.indices` presence before trying to use it.
