### PR TITLE
feat(SearchBox): provide input element ref

### DIFF
--- a/packages/react-instantsearch-dom/src/components/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/SearchBox.js
@@ -84,9 +84,7 @@ class SearchBox extends Component {
 
     inputRef: PropTypes.oneOfType([
       PropTypes.func,
-      PropTypes.shape({
-        current: PropTypes.instanceOf(HTMLInputElement),
-      }),
+      PropTypes.exact({ current: PropTypes.object }),
     ]),
   };
 

--- a/packages/react-instantsearch-dom/src/components/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/SearchBox.js
@@ -82,8 +82,7 @@ class SearchBox extends Component {
     isSearchStalled: PropTypes.bool,
     showLoadingIndicator: PropTypes.bool,
 
-    // For testing purposes
-    __inputRef: PropTypes.func,
+    inputRef: PropTypes.func,
   };
 
   static defaultProps = {
@@ -133,8 +132,8 @@ class SearchBox extends Component {
 
   onInputMount = input => {
     this.input = input;
-    if (this.props.__inputRef) {
-      this.props.__inputRef(input);
+    if (this.props.inputRef) {
+      this.props.inputRef(input);
     }
   };
 

--- a/packages/react-instantsearch-dom/src/components/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/SearchBox.js
@@ -82,7 +82,12 @@ class SearchBox extends Component {
     isSearchStalled: PropTypes.bool,
     showLoadingIndicator: PropTypes.bool,
 
-    inputRef: PropTypes.func,
+    inputRef: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.shape({
+        current: PropTypes.instanceOf(HTMLInputElement),
+      }),
+    ]),
   };
 
   static defaultProps = {
@@ -132,8 +137,11 @@ class SearchBox extends Component {
 
   onInputMount = input => {
     this.input = input;
-    if (this.props.inputRef) {
+    if (!this.props.inputRef) return;
+    if (typeof this.props.inputRef === 'function') {
       this.props.inputRef(input);
+    } else {
+      this.props.inputRef.current = input;
     }
   };
 

--- a/packages/react-instantsearch-dom/src/components/__tests__/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/SearchBox.js
@@ -297,12 +297,9 @@ describe('SearchBox', () => {
   });
 
   it('should point created refs to its input element', () => {
-    let inputRef = React.createRef();
+    const inputRef = React.createRef();
     const wrapper = mount(
-      <SearchBox
-        refine={() => null}
-        inputRef={inputRef}
-      />
+      <SearchBox refine={() => null} inputRef={inputRef} />
     );
 
     const refSpy = jest.spyOn(inputRef.current, 'focus');

--- a/packages/react-instantsearch-dom/src/components/__tests__/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/SearchBox.js
@@ -296,7 +296,25 @@ describe('SearchBox', () => {
     expect(wrapper.state()).toEqual({ query: '' });
   });
 
-  it('should provide a ref to its input element', () => {
+  it('should point created refs to its input element', () => {
+    let inputRef = React.createRef();
+    const wrapper = mount(
+      <SearchBox
+        refine={() => null}
+        inputRef={inputRef}
+      />
+    );
+
+    const refSpy = jest.spyOn(inputRef.current, 'focus');
+
+    // Trigger input.focus()
+    wrapper.find('form').simulate('reset');
+
+    expect(refSpy).toHaveBeenCalled();
+    expect(inputRef.current.tagName).toEqual('INPUT');
+  });
+
+  it('should return a ref when given a callback', () => {
     let inputRef;
     const wrapper = mount(
       <SearchBox

--- a/packages/react-instantsearch-dom/src/components/__tests__/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/SearchBox.js
@@ -174,7 +174,7 @@ describe('SearchBox', () => {
       <SearchBox
         refine={() => null}
         focusShortcuts={['s', 84]}
-        __inputRef={node => {
+        inputRef={node => {
           input = node;
         }}
       />
@@ -294,5 +294,25 @@ describe('SearchBox', () => {
     expect(refine).toHaveBeenCalledWith('');
     expect(wrapper.instance().input.focus).toHaveBeenCalled();
     expect(wrapper.state()).toEqual({ query: '' });
+  });
+
+  it('should provide a ref to its input element', () => {
+    let inputRef;
+    const wrapper = mount(
+      <SearchBox
+        refine={() => null}
+        inputRef={ref => {
+          inputRef = ref;
+        }}
+      />
+    );
+
+    const refSpy = jest.spyOn(inputRef, 'focus');
+
+    // Trigger input.focus()
+    wrapper.find('form').simulate('reset');
+
+    expect(refSpy).toHaveBeenCalled();
+    expect(inputRef.tagName).toEqual('INPUT');
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This makes it clear that `inputRef` is part of the api, so it can be used to get a React ref to the search input.  Closes #2910

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

```jsx
<SearchBox
     inputRef={input => {this.input = input;}}
/>

focusSearch() {
  if(this.input) this.input.focus();
}
```

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
