### PR TITLE
fix(createBoundingBoxFromHits): include check in the hit property "_geoloc"

### DIFF
--- a/packages/react-instantsearch-dom-maps/src/Provider.js
+++ b/packages/react-instantsearch-dom-maps/src/Provider.js
@@ -62,15 +62,9 @@ class Provider extends Component {
     const { google } = this.props;
 
     const latLngBounds = hits.reduce((acc, hit) => {
-      if (
-        !hit._geoloc ||
-        (Array.isArray(hit._geoloc) && hit._geoloc.lenght === 0)
-      ) {
-        return acc.extend({});
-      }
+      const geoLocs = Array.isArray(hit._geoloc) ? hit._geoloc : [hit._geoloc];
 
-      const _geoloc = Array.isArray(hit._geoloc) ? hit._geoloc[0] : hit._geoloc;
-      return acc.extend(_geoloc);
+      return geoLocs.reduce((bounds, current) => bounds.extend(current), acc);
     }, new google.maps.LatLngBounds());
 
     return {

--- a/packages/react-instantsearch-dom-maps/src/Provider.js
+++ b/packages/react-instantsearch-dom-maps/src/Provider.js
@@ -62,7 +62,12 @@ class Provider extends Component {
     const { google } = this.props;
 
     const latLngBounds = hits.reduce(
-      (acc, hit) => acc.extend(hit._geoloc),
+      (acc, hit) => {
+        if (!hit._geoloc || (Array.isArray(hit._geoloc) && hit._geoloc.lenght === 0) return acc;
+
+        const _geoloc = Array.isArray(hit._geoloc) ? hit._geoloc[0] : hit._geoloc;
+        return acc.extend(_geoloc);
+      },
       new google.maps.LatLngBounds()
     );
 

--- a/packages/react-instantsearch-dom-maps/src/Provider.js
+++ b/packages/react-instantsearch-dom-maps/src/Provider.js
@@ -61,15 +61,17 @@ class Provider extends Component {
   createBoundingBoxFromHits(hits) {
     const { google } = this.props;
 
-    const latLngBounds = hits.reduce(
-      (acc, hit) => {
-        if (!hit._geoloc || (Array.isArray(hit._geoloc) && hit._geoloc.lenght === 0) return acc;
+    const latLngBounds = hits.reduce((acc, hit) => {
+      if (
+        !hit._geoloc ||
+        (Array.isArray(hit._geoloc) && hit._geoloc.lenght === 0)
+      ) {
+        return acc.extend({});
+      }
 
-        const _geoloc = Array.isArray(hit._geoloc) ? hit._geoloc[0] : hit._geoloc;
-        return acc.extend(_geoloc);
-      },
-      new google.maps.LatLngBounds()
-    );
+      const _geoloc = Array.isArray(hit._geoloc) ? hit._geoloc[0] : hit._geoloc;
+      return acc.extend(_geoloc);
+    }, new google.maps.LatLngBounds());
 
     return {
       northEast: latLngBounds.getNorthEast().toJSON(),


### PR DESCRIPTION
fix createBoundingBoxFromHits
i included a check in the createBoundingBoxFromHits function when lists hits has one his or many hits with property "_geoloc" as array.
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
