### PR TITLE
fix(core): fix maximum call stack size exceeded

### DIFF
--- a/examples/server-side-rendering/src/createApp.js
+++ b/examples/server-side-rendering/src/createApp.js
@@ -1,13 +1,16 @@
 import algoliasearch from 'algoliasearch/lite';
+// import { createInMemoryCache } from '@algolia/cache-in-memory';
 import App from './App';
-
-export const createApp = () => {
-  const indexName = 'instant_search';
   const searchClient = algoliasearch(
     'latency',
-    '6be0576ff61c053d5f9a3225e2a90f76'
+    '6be0576ff61c053d5f9a3225e2a90f76',
+    { // For testing with cache, uncomment cache related lines:
+          // responsesCache: createInMemoryCache(),
+          // requestsCache: createInMemoryCache({ serializable: false })
+    }
   );
-
+export const createApp = () => {
+  const indexName = 'instant_search';
   const props = {
     indexName,
     searchClient,

--- a/examples/server-side-rendering/src/createApp.js
+++ b/examples/server-side-rendering/src/createApp.js
@@ -1,14 +1,15 @@
 import algoliasearch from 'algoliasearch/lite';
 // import { createInMemoryCache } from '@algolia/cache-in-memory';
 import App from './App';
-  const searchClient = algoliasearch(
-    'latency',
-    '6be0576ff61c053d5f9a3225e2a90f76',
-    { // For testing with cache, uncomment cache related lines:
-          // responsesCache: createInMemoryCache(),
-          // requestsCache: createInMemoryCache({ serializable: false })
-    }
-  );
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76',
+  {
+    // For testing with cache, uncomment cache related lines:
+    // responsesCache: createInMemoryCache(),
+    // requestsCache: createInMemoryCache({ serializable: false })
+  }
+);
 export const createApp = () => {
   const indexName = 'instant_search';
   const props = {

--- a/examples/server-side-rendering/src/createApp.js
+++ b/examples/server-side-rendering/src/createApp.js
@@ -1,15 +1,12 @@
 import algoliasearch from 'algoliasearch/lite';
-// import { createInMemoryCache } from '@algolia/cache-in-memory';
+
 import App from './App';
+
 const searchClient = algoliasearch(
   'latency',
-  '6be0576ff61c053d5f9a3225e2a90f76',
-  {
-    // For testing with cache, uncomment cache related lines:
-    // responsesCache: createInMemoryCache(),
-    // requestsCache: createInMemoryCache({ serializable: false })
-  }
+  '6be0576ff61c053d5f9a3225e2a90f76'
 );
+
 export const createApp = () => {
   const indexName = 'instant_search';
   const props = {

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -264,6 +264,51 @@ describe('createInstantSearchManager', () => {
 
       expect(Object.keys(searchClient.cache)).toHaveLength(0);
     });
+
+    it('when using algoliasearch@v4, it overrides search only once', () => {
+      const searchClient = algoliasearch('appId', 'apiKey', {
+        _cache: true,
+      });
+
+      // Skip this test with Algoliasearch API Client < v4, as
+      // search does not need to be overridden.
+      if (!searchClient.transporter) {
+        return;
+      }
+
+      const resultsState = {
+        rawResults: [
+          {
+            index: 'indexName',
+            query: 'query',
+          },
+        ],
+        state: {
+          index: 'indexName',
+          query: 'query',
+        },
+      };
+
+      const originalSearch = algoliasearch.search;
+
+      createInstantSearchManager({
+        indexName: 'index',
+        searchClient,
+        resultsState,
+      });
+
+      expect(searchClient.search).not.toBe(originalSearch);
+
+      searchClient.search = 'already-overridden';
+
+      createInstantSearchManager({
+        indexName: 'index',
+        searchClient,
+        resultsState,
+      });
+
+      expect(searchClient.search).toEqual('already-overridden');
+    });
   });
 
   describe('results hydratation', () => {

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -299,7 +299,8 @@ describe('createInstantSearchManager', () => {
 
       expect(searchClient.search).not.toBe(originalSearch);
 
-      searchClient.search = 'already-overridden';
+      const alreadyOverridden = jest.fn();
+      searchClient.search = alreadyOverridden;
 
       createInstantSearchManager({
         indexName: 'index',
@@ -307,7 +308,7 @@ describe('createInstantSearchManager', () => {
         resultsState,
       });
 
-      expect(searchClient.search).toEqual('already-overridden');
+      expect(searchClient.search).toBe(alreadyOverridden);
     });
   });
 

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -328,7 +328,7 @@ export default function createInstantSearchManager({
     // - Algoliasearch API Client < v4 with cache disabled
     // - Third party clients (detected by the `addAlgoliaAgent` function missing)
     if (
-      !client.transporter &&
+      (!client.transporter || client._cacheHydrated) &&
       (!client._useCache || typeof client.addAlgoliaAgent !== 'function')
     ) {
       return;
@@ -342,6 +342,8 @@ export default function createInstantSearchManager({
     // to populate it on a custom key and override the `search` method to
     // search on it first.
     if (client.transporter) {
+      client._cacheHydrated = true;
+
       const baseMethod = client.search;
       client.search = (requests, ...methodArgs) => {
         const requestsWithSerializedParams = requests.map(request => ({

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -327,6 +327,7 @@ export default function createInstantSearchManager({
     // Disable cache hydration on:
     // - Algoliasearch API Client < v4 with cache disabled
     // - Third party clients (detected by the `addAlgoliaAgent` function missing)
+
     if (
       (!client.transporter || client._cacheHydrated) &&
       (!client._useCache || typeof client.addAlgoliaAgent !== 'function')
@@ -341,7 +342,7 @@ export default function createInstantSearchManager({
     // for us to compute the key the same way as `algoliasearch-client` we need
     // to populate it on a custom key and override the `search` method to
     // search on it first.
-    if (client.transporter) {
+    if (client.transporter && !client._cacheHydrated) {
       client._cacheHydrated = true;
 
       const baseMethod = client.search;


### PR DESCRIPTION
Fixes #2912 

This pull request addresses a bug that is impacting all the customers using React Instantsearch v6.4 with Algoliasearch v4, and having high traffic in their applications.

**Problem**: Internally, on the function `hydrateSearchClient`, the `search` method on the client was being overridden in every request by the previous version of it, eventually causing maximum call stack size exceeded.

**Solution**: This pull request adds a flag to the given client so his search doesn't get override more than once. As the cache as already hydrated before.

**Feedback about this**: The cache hydration system only works when customers are using ` responsesCache: createInMemoryCache(),`. Not sure if that is clear on the docs or for us.

Going to test this pull request a little bit in my side now, meanwhile, you guys can validate this.

Note: Also updated the demo server side rendering re-use the some client between requests.