### PR TITLE
chore: add codesandbox ci

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,3 @@
+{
+  "packages": ["packages/*"]
+}

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,6 @@
 {
-  "packages": ["packages/*"]
+  "packages": ["packages/*"],
+  "sandboxes": [
+    "github/algolia/create-instantsearch-app/tree/templates/react-instantsearch"
+  ]
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR configures [CodeSandbox CI app](https://github.com/apps/codesandbox). 

When a PR is created, the app prepares a sandbox with the build from the branch.
![image](https://user-images.githubusercontent.com/499898/82207812-ba260d00-990a-11ea-9f0f-c39abde105fd.png)
The comment gets updated with the new url as the PR is updated.

![image](https://user-images.githubusercontent.com/499898/82207670-834ff700-990a-11ea-9b2e-475d6cccc738.png)

This app doesn't give us a way to install the temporary build on other environments whereas Pika CI does.

![image](https://user-images.githubusercontent.com/499898/82208051-230d8500-990b-11ea-8b56-b2a7648b6390.png)

In my opinion, we heavily use CodeSandbox and might not need to `yarn install` out of CodeSandbox.

What do you think? If you want to see Pika CI in action, I can open another PR to demonstrate it. Or, if you all are satisfied with CodeSandbox CI, then we can merge this PR 🙂 