### PR TITLE
fix(ssr): remove second instance of "query" in the response "params" for SSR

### DIFF
--- a/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
@@ -13,11 +13,14 @@ import { findResultsState } from '../createInstantSearchServer';
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('findResultsState', () => {
-  const createSearchClient = () => ({
+  const createSearchClient = responseParams => ({
     search: requests =>
       Promise.resolve({
         results: requests.map(({ indexName, params: { query } }) => ({
           query,
+          params: responseParams
+            ? responseParams(query)
+            : `query=${encodeURIComponent(query)}`,
           index: indexName,
         })),
       }),
@@ -231,6 +234,179 @@ describe('findResultsState', () => {
           expect.objectContaining({ index: 'indexName', query: 'iPhone' }),
         ],
         state: expect.objectContaining({ index: 'indexName', query: 'iPhone' }),
+      });
+    });
+
+    describe('cleaning "params"', () => {
+      it('with one query', async () => {
+        const Connected = createWidget();
+
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient(),
+          searchState: {
+            query: 'iPhone',
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data.rawResults[0].params).toMatchInlineSnapshot(
+          `"query=iPhone"`
+        );
+      });
+
+      it('with shadowing query', async () => {
+        const Connected = createWidget();
+
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient(),
+          searchState: {
+            query: 'iPhone&query=iphone',
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data.rawResults[0].params).toMatchInlineSnapshot(
+          `"query=iPhone%26query%3Diphone"`
+        );
+      });
+
+      it('with modified query', async () => {
+        const Connected = createWidget();
+
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient(
+            query => `query=${encodeURIComponent(query)}&query=modified`
+          ),
+          searchState: {
+            query: 'iPhone',
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data.rawResults[0].params).toMatchInlineSnapshot(
+          `"query=iPhone"`
+        );
+      });
+
+      it('with shadowing query and modified query', async () => {
+        const Connected = createWidget();
+
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient(
+            query => `query=${encodeURIComponent(query)}&query=modified`
+          ),
+          searchState: {
+            query: 'iPhone&query=iphone',
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data.rawResults[0].params).toMatchInlineSnapshot(
+          `"query=iPhone%26query%3Diphone"`
+        );
+      });
+
+      it('with padded, modified query', async () => {
+        const Connected = createWidget();
+
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient(
+            query =>
+              `test=1&query=${encodeURIComponent(query)}&boo=ba&query=modified`
+          ),
+          searchState: {
+            query: 'iPhone&query=iphone',
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data.rawResults[0].params).toMatchInlineSnapshot(
+          `"test=1&query=iPhone%26query%3Diphone&boo=ba"`
+        );
+      });
+
+      it('with nothing returned', async () => {
+        const Connected = createWidget();
+
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient(() => ''),
+          searchState: {
+            query: 'iPhone&query=iphone',
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data.rawResults[0].params).toMatchInlineSnapshot(`""`);
+      });
+
+      it('with no query returned', async () => {
+        const Connected = createWidget();
+
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient(() => 'lol=lol'),
+          searchState: {
+            query: 'iPhone&query=iphone',
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data.rawResults[0].params).toMatchInlineSnapshot(`"lol=lol"`);
       });
     });
   });
@@ -554,6 +730,88 @@ describe('findResultsState', () => {
         rawResults: [
           expect.objectContaining({ index: 'index1', query: 'iPad' }),
         ],
+      });
+    });
+
+    describe('cleaning "params"', () => {
+      it('multiple queries', async () => {
+        const Connected = createWidget();
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+            <Index indexId="index1WithRefinement" indexName="index1">
+              <Connected />
+            </Index>
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient(),
+          indexName: 'index1',
+          searchState: {
+            query: 'iPhone',
+            indices: {
+              index1WithRefinement: {
+                query: 'iPad&query=test',
+              },
+            },
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data).toHaveLength(2);
+
+        const [first, second] = data;
+
+        expect(first.rawResults[0].params).toMatchInlineSnapshot(
+          `"query=iPhone"`
+        );
+        expect(second.rawResults[0].params).toMatchInlineSnapshot(
+          `"query=iPad%26query%3Dtest"`
+        );
+      });
+
+      it('server-side params', async () => {
+        const Connected = createWidget();
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+            <Index indexId="index1WithRefinement" indexName="index1">
+              <Connected />
+            </Index>
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient(
+            query => `query=${encodeURIComponent(query)}&query=modified`
+          ),
+          indexName: 'index1',
+          searchState: {
+            query: 'iPhone',
+            indices: {
+              index1WithRefinement: {
+                query: 'iPad&query=test',
+              },
+            },
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data).toHaveLength(2);
+
+        const [first, second] = data;
+
+        expect(first.rawResults[0].params).toMatchInlineSnapshot(
+          `"query=iPhone"`
+        );
+        expect(second.rawResults[0].params).toMatchInlineSnapshot(
+          `"query=iPad%26query%3Dtest"`
+        );
       });
     });
   });

--- a/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
@@ -13,13 +13,13 @@ import { findResultsState } from '../createInstantSearchServer';
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('findResultsState', () => {
-  const createSearchClient = responseParams => ({
+  const createSearchClient = ({ transformResponseParams } = {}) => ({
     search: requests =>
       Promise.resolve({
         results: requests.map(({ indexName, params: { query } }) => ({
           query,
-          params: responseParams
-            ? responseParams(query)
+          params: transformResponseParams
+            ? transformResponseParams(query)
             : `query=${encodeURIComponent(query)}`,
           index: indexName,
         })),
@@ -297,9 +297,10 @@ describe('findResultsState', () => {
 
         const props = {
           ...requiredProps,
-          searchClient: createSearchClient(
-            query => `query=${encodeURIComponent(query)}&query=modified`
-          ),
+          searchClient: createSearchClient({
+            transformResponseParams: query =>
+              `query=${encodeURIComponent(query)}&query=modified`,
+          }),
           searchState: {
             query: 'iPhone',
           },
@@ -323,9 +324,10 @@ describe('findResultsState', () => {
 
         const props = {
           ...requiredProps,
-          searchClient: createSearchClient(
-            query => `query=${encodeURIComponent(query)}&query=modified`
-          ),
+          searchClient: createSearchClient({
+            transformResponseParams: query =>
+              `query=${encodeURIComponent(query)}&query=modified`,
+          }),
           searchState: {
             query: 'iPhone&query=iphone',
           },
@@ -349,10 +351,10 @@ describe('findResultsState', () => {
 
         const props = {
           ...requiredProps,
-          searchClient: createSearchClient(
-            query =>
-              `test=1&query=${encodeURIComponent(query)}&boo=ba&query=modified`
-          ),
+          searchClient: createSearchClient({
+            transformResponseParams: query =>
+              `test=1&query=${encodeURIComponent(query)}&boo=ba&query=modified`,
+          }),
           searchState: {
             query: 'iPhone&query=iphone',
           },
@@ -376,7 +378,9 @@ describe('findResultsState', () => {
 
         const props = {
           ...requiredProps,
-          searchClient: createSearchClient(() => ''),
+          searchClient: createSearchClient({
+            transformResponseParams: () => '',
+          }),
           searchState: {
             query: 'iPhone&query=iphone',
           },
@@ -398,7 +402,9 @@ describe('findResultsState', () => {
 
         const props = {
           ...requiredProps,
-          searchClient: createSearchClient(() => 'lol=lol'),
+          searchClient: createSearchClient({
+            transformResponseParams: () => 'lol=lol',
+          }),
           searchState: {
             query: 'iPhone&query=iphone',
           },
@@ -786,9 +792,10 @@ describe('findResultsState', () => {
 
         const props = {
           ...requiredProps,
-          searchClient: createSearchClient(
-            query => `query=${encodeURIComponent(query)}&query=modified`
-          ),
+          searchClient: createSearchClient({
+            transformResponseParams: query =>
+              `query=${encodeURIComponent(query)}&query=modified`,
+          }),
           indexName: 'index1',
           searchState: {
             query: 'iPhone',

--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -59,9 +59,36 @@ const getSearchParameters = (indexName, searchParameters) => {
   };
 };
 
+/**
+ * The engine can return params: "query=xxx&query=yyy" if e.g. a query rule modifies it.
+ * This however will cause us to miss the cache hydration, so we make sure to keep
+ * only the first query (always the one from the parameters).
+ */
+function removeDuplicateQuery(params) {
+  let previousIndex = undefined;
+  const queryParamRegex = /&?query=[^&]*/g;
+  return params.replace(queryParamRegex, function replacer(match, offset) {
+    if (previousIndex !== undefined && offset > previousIndex) {
+      previousIndex = offset;
+      return '';
+    }
+    previousIndex = offset;
+    return match;
+  });
+}
+
+function cleanRawResults(rawResults) {
+  return rawResults.map(res => {
+    return {
+      ...res,
+      params: removeDuplicateQuery(res.params),
+    };
+  });
+}
+
 const singleIndexSearch = (helper, parameters) =>
   helper.searchOnce(parameters).then(res => ({
-    rawResults: res.content._rawResults,
+    rawResults: cleanRawResults(res.content._rawResults),
     state: res.content._state,
   }));
 
@@ -93,7 +120,7 @@ const multiIndexSearch = (
   // may have multiple times the same index.
   return Promise.all(searches).then(results =>
     [indexName, ...indexIds].map((indexId, i) => ({
-      rawResults: results[i].content._rawResults,
+      rawResults: cleanRawResults(results[i].content._rawResults),
       state: results[i].content._state,
       _internalIndexId: indexId,
     }))

--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -65,14 +65,13 @@ const getSearchParameters = (indexName, searchParameters) => {
  * only the first query (always the one from the parameters).
  */
 function removeDuplicateQuery(params) {
-  let previousIndex = undefined;
+  let hasFoundQuery = false;
   const queryParamRegex = /&?query=[^&]*/g;
-  return params.replace(queryParamRegex, function replacer(match, offset) {
-    if (previousIndex !== undefined && offset > previousIndex) {
-      previousIndex = offset;
+  return params.replace(queryParamRegex, function replacer(match) {
+    if (hasFoundQuery) {
       return '';
     }
-    previousIndex = offset;
+    hasFoundQuery = true;
     return match;
   });
 }


### PR DESCRIPTION



<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

We use the `params` of the response given by the Algolia query to craft a cache key for the query done by server-side rendering. However, when the engine has e.g. a query rule which edits the query, this `params` won't be the same as the one actually queried. It will have `query=original...&query=edited`, which means that we should remove the second instance of the query to make the cache not miss

**Result**

When rendering a query which is edited by a query rule, no query gets done frontend. This can be tested by the query `edit_me` on the `instant_search` index.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

closes #2941
fixes #2940
