### PR TITLE
fix(core): appending successful index search results by returning new object reference

### DIFF
--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -262,7 +262,7 @@ export default function createInstantSearchManager({
       results = !isDerivedHelpersEmpty && results.getFacetByName ? {} : results;
 
       if (!isDerivedHelpersEmpty) {
-        results[indexId] = event.results;
+        results = { ...results, [indexId]: event.results };
       } else {
         results = event.results;
       }


### PR DESCRIPTION
Fix https://github.com/algolia/react-instantsearch/issues/2875

So basically,

The index search results are from the `store` and because the new search result added by mutating the results object.

At the `createConnector.tsx`

https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-core/src/core/createConnector.tsx#L342

The `providedProps.allSearchResults` spread into the `Composed` component but since the object `providedProps. allSearchResults` reference did not change. React did not trigger re-render the `Composed` Component.