### PR TITLE
fix(ssr): allow "params" to be optional in custom clients

### DIFF
--- a/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
@@ -262,6 +262,32 @@ describe('findResultsState', () => {
         );
       });
 
+      it('with custom client, without "params"', async () => {
+        const Connected = createWidget();
+
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient({
+            transformResponseParams() {
+              return undefined;
+            },
+          }),
+          searchState: {
+            query: 'iPhone',
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data.rawResults[0].params).toBeUndefined();
+      });
+
       it('with shadowing query', async () => {
         const Connected = createWidget();
 
@@ -777,6 +803,45 @@ describe('findResultsState', () => {
         expect(second.rawResults[0].params).toMatchInlineSnapshot(
           `"query=iPad%26query%3Dtest"`
         );
+      });
+
+      it('custom client without "params"', async () => {
+        const Connected = createWidget();
+        const App = props => (
+          <InstantSearch {...props}>
+            <Connected />
+            <Index indexId="index1WithRefinement" indexName="index1">
+              <Connected />
+            </Index>
+          </InstantSearch>
+        );
+
+        const props = {
+          ...requiredProps,
+          searchClient: createSearchClient({
+            transformResponseParams() {
+              return undefined;
+            },
+          }),
+          indexName: 'index1',
+          searchState: {
+            query: 'iPhone',
+            indices: {
+              index1WithRefinement: {
+                query: 'iPad&query=test',
+              },
+            },
+          },
+        };
+
+        const data = await findResultsState(App, props);
+
+        expect(data).toHaveLength(2);
+
+        const [first, second] = data;
+
+        expect(first.rawResults[0].params).toBeUndefined();
+        expect(second.rawResults[0].params).toBeUndefined();
       });
 
       it('server-side params', async () => {

--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -65,6 +65,9 @@ const getSearchParameters = (indexName, searchParameters) => {
  * only the first query (always the one from the parameters).
  */
 function removeDuplicateQuery(params) {
+  if (!params) {
+    return params;
+  }
   let hasFoundQuery = false;
   const queryParamRegex = /&?query=[^&]*/g;
   return params.replace(queryParamRegex, function replacer(match) {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

A custom client could _not_  return `params`. In this case we can keep `params` as-is instead of trying to `replace`.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

If `params`  is falsy, it doesn't get transformed. This will also add a  small boost for empty query, although a replace on empty string already probably was very fast.

fix #2958
