### PR TITLE
fix(ConfigureRelatedItems): support nested attributes

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigureRelatedItems.ts
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectConfigureRelatedItems.ts
@@ -81,6 +81,32 @@ describe('connectConfigure', () => {
       );
     });
 
+    it('sets the optionalFilters search parameter based on matchingPatterns with nested attributes', () => {
+      const searchParameters = connect.getSearchParameters.call(
+        { contextValue },
+        new SearchParameters(),
+        {
+          ...defaultProps,
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            'hierarchicalCategories.lvl0': { score: 2 },
+          },
+        }
+      );
+
+      expect(searchParameters).toEqual(
+        expect.objectContaining({
+          facetFilters: ['objectID:-1'],
+          sumOrFiltersScores: true,
+          optionalFilters: [
+            'brand:Amazon<score=3>',
+            'hierarchicalCategories.lvl0:TV & Home Theater<score=2>',
+          ],
+        })
+      );
+    });
+
     it('sets transformed search parameters based on transformSearchParameters', () => {
       const searchParameters = connect.getSearchParameters.call(
         { contextValue },

--- a/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectConfigureRelatedItems.ts
@@ -6,6 +6,7 @@ import createConnector, { ConnectedProps } from '../core/createConnector';
 import {
   omit,
   getObjectType,
+  getPropertyByPath,
   removeEmptyKey,
   removeEmptyArraysFromObject,
 } from '../core/utils';
@@ -73,7 +74,7 @@ function getSearchParametersFromProps(
     Array<string | string[]>
   >((acc, attributeName) => {
     const attributePattern = props.matchingPatterns[attributeName];
-    const attributeValue = props.hit[attributeName];
+    const attributeValue = getPropertyByPath(props.hit, attributeName);
     const attributeScore = attributePattern.score;
 
     if (Array.isArray(attributeValue)) {


### PR DESCRIPTION
This brings support for nested attributes in the [`configureRelatedItems`](https://www.algolia.com/doc/api-reference/widgets/configure-related-items/js/) widget.

## Description

Previously, an attribute like `hierarchicalCategories.lvl0` was considered as non-existant because we were accessing it as `hit[hierarchicalCategories.lvl0]`. We now access it with our `getPropertyByPath` util which correctly picks up the attribute.

## Related

- [Slack message](https://algolia.slack.com/archives/C2XP6HBKQ/p1597715211006100)
- Fix in InstantSearch.js: algolia/instantsearch.js#4480