### PR TITLE
docs(storybook): fix links to story source

### DIFF
--- a/stories/3rdPartyIntegrations.stories.js
+++ b/stories/3rdPartyIntegrations.stories.js
@@ -8,7 +8,7 @@ import { WrapWithHits } from './util';
 const stories = storiesOf('Integration With Other Libraries', module);
 
 stories.add('Airbnb Rheostat', () => (
-  <WrapWithHits linkedStoryGroup="3rdPartyIntegrations">
+  <WrapWithHits linkedStoryGroup="3rdPartyIntegrations.stories.js">
     <h3 style={{ marginBottom: 50, textAlign: 'center' }}>
       ⚠️ This example only works with the version 2.x of Rheostat ️️⚠️
     </h3>

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -15,7 +15,10 @@ const VirtualHierarchicalMenu = connectHierarchicalMenu(() => null);
 stories
   .add('default', () => (
     <div>
-      <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb">
+      <WrapWithHits
+        hasPlayground={true}
+        linkedStoryGroup="Breadcrumb.stories.js"
+      >
         <Breadcrumb
           attributes={[
             'hierarchicalCategories.lvl0',
@@ -38,7 +41,7 @@ stories
     </div>
   ))
   .add('with custom component', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb.stories.js">
       <Breadcrumb
         attributes={[
           'hierarchicalCategories.lvl0',
@@ -59,7 +62,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb.stories.js">
       <Breadcrumb
         attributes={[
           'hierarchicalCategories.lvl0',
@@ -82,7 +85,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb.stories.js">
       <Panel header="Breadcrumb" footer="footer">
         <Breadcrumb
           attributes={[
@@ -104,7 +107,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel but no refinement', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Breadcrumb.stories.js">
       <Panel header="Breadcrumb" footer="footer">
         <Breadcrumb
           attributes={[

--- a/stories/ClearRefinements.stories.js
+++ b/stories/ClearRefinements.stories.js
@@ -11,7 +11,7 @@ const stories = storiesOf('ClearRefinements', module);
 
 stories
   .add('with refinements to clear', () => (
-    <WrapWithHits linkedStoryGroup="ClearRefinements">
+    <WrapWithHits linkedStoryGroup="ClearRefinements.stories.js">
       <div>
         <ClearRefinements />
         <div style={{ display: 'none' }}>
@@ -21,12 +21,12 @@ stories
     </WrapWithHits>
   ))
   .add('nothing to clear', () => (
-    <WrapWithHits linkedStoryGroup="ClearRefinements">
+    <WrapWithHits linkedStoryGroup="ClearRefinements.stories.js">
       <ClearRefinements />
     </WrapWithHits>
   ))
   .add('clear all refinements and the query', () => (
-    <WrapWithHits linkedStoryGroup="ClearRefinements">
+    <WrapWithHits linkedStoryGroup="ClearRefinements.stories.js">
       <ClearRefinements
         clearsQuery
         translations={{ reset: 'Clear refinements and query' }}
@@ -35,7 +35,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="ClearRefinements">
+    <WrapWithHits linkedStoryGroup="ClearRefinements.stories.js">
       <Panel header="Clear refinements" footer="Footer">
         <ClearRefinements />
       </Panel>
@@ -46,7 +46,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel but no refinement', () => (
-    <WrapWithHits linkedStoryGroup="ClearRefinements">
+    <WrapWithHits linkedStoryGroup="ClearRefinements.stories.js">
       <Panel header="Clear refinements" footer="Footer">
         <ClearRefinements />
       </Panel>

--- a/stories/Conditional.stories.js
+++ b/stories/Conditional.stories.js
@@ -15,7 +15,7 @@ stories
       )
     );
     return (
-      <WrapWithHits linkedStoryGroup="Conditional">
+      <WrapWithHits linkedStoryGroup="Conditional.stories.js">
         <Content />
       </WrapWithHits>
     );
@@ -29,7 +29,7 @@ stories
       )
     );
     return (
-      <WrapWithHits linkedStoryGroup="Conditional">
+      <WrapWithHits linkedStoryGroup="Conditional.stories.js">
         <Content />
       </WrapWithHits>
     );
@@ -39,7 +39,7 @@ stories
       searching ? <div>searching</div> : <div>No searching</div>
     );
     return (
-      <WrapWithHits linkedStoryGroup="Conditional">
+      <WrapWithHits linkedStoryGroup="Conditional.stories.js">
         <Content />
       </WrapWithHits>
     );

--- a/stories/Configure.stories.js
+++ b/stories/Configure.stories.js
@@ -20,7 +20,7 @@ class ConfigureExample extends React.Component {
 
   render() {
     return (
-      <WrapWithHits linkedStoryGroup="Configure">
+      <WrapWithHits linkedStoryGroup="Configure.stories.js">
         <Configure hitsPerPage={this.state.hitsPerPage} />
         <button onClick={this.onClick}>Toggle HitsPerPage</button>
       </WrapWithHits>

--- a/stories/ConfigureRelatedItems.stories.tsx
+++ b/stories/ConfigureRelatedItems.stories.tsx
@@ -79,7 +79,7 @@ function ConfigureRelatedItemsExample() {
   );
 
   return (
-    <WrapWithHits linkedStoryGroup="ConfigureRelatedItems">
+    <WrapWithHits linkedStoryGroup="ConfigureRelatedItems.stories.tsx">
       <Index indexName="instant_search" indexId="mainIndex">
         <Configure hitsPerPage={1} />
 

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -16,7 +16,7 @@ const stories = storiesOf('CurrentRefinements', module);
 
 stories
   .add('with RefinementList', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
+    <WrapWithHits linkedStoryGroup="CurrentRefinements.stories.js">
       <CurrentRefinements />
       <hr />
       <RefinementList
@@ -26,14 +26,14 @@ stories
     </WrapWithHits>
   ))
   .add('with Menu', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
+    <WrapWithHits linkedStoryGroup="CurrentRefinements.stories.js">
       <CurrentRefinements />
       <hr />
       <Menu attribute="brand" defaultRefinement="Apple" />
     </WrapWithHits>
   ))
   .add('with HierarchicalMenu', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
+    <WrapWithHits linkedStoryGroup="CurrentRefinements.stories.js">
       <CurrentRefinements />
       <hr />
       <HierarchicalMenu
@@ -47,7 +47,7 @@ stories
     </WrapWithHits>
   ))
   .add('with ToggleRefinement', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
+    <WrapWithHits linkedStoryGroup="CurrentRefinements.stories.js">
       <CurrentRefinements />
       <hr />
       <ToggleRefinement
@@ -58,7 +58,7 @@ stories
     </WrapWithHits>
   ))
   .add('with NumericMenu', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
+    <WrapWithHits linkedStoryGroup="CurrentRefinements.stories.js">
       <CurrentRefinements />
       <hr />
       <NumericMenu
@@ -74,14 +74,14 @@ stories
     </WrapWithHits>
   ))
   .add('with RangeInput', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
+    <WrapWithHits linkedStoryGroup="CurrentRefinements.stories.js">
       <CurrentRefinements />
       <hr />
       <RangeInput attribute="price" defaultRefinement={{ min: 30, max: 500 }} />
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
+    <WrapWithHits linkedStoryGroup="CurrentRefinements.stories.js">
       <Panel header="Current refinements" footer="Footer">
         <CurrentRefinements />
       </Panel>
@@ -92,7 +92,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel but no refinements', () => (
-    <WrapWithHits linkedStoryGroup="CurrentRefinements">
+    <WrapWithHits linkedStoryGroup="CurrentRefinements.stories.js">
       <Panel header="Current refinements" footer="Footer">
         <CurrentRefinements />
       </Panel>

--- a/stories/GeoSearch.stories.js
+++ b/stories/GeoSearch.stories.js
@@ -34,7 +34,7 @@ const initialPosition = {
 
 stories
   .add('default', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -55,7 +55,7 @@ stories
     </WrapWithHits>
   ))
   .add('with default refinement', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -88,7 +88,7 @@ stories
     </WrapWithHits>
   ))
   .add('with refine disabled', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -117,7 +117,7 @@ stories
 // Only UI
 stories
   .add('with zoom & center', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -142,7 +142,7 @@ stories
     </WrapWithHits>
   ))
   .add('with map options', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -163,7 +163,7 @@ stories
     </WrapWithHits>
   ))
   .add('with <Marker> options', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -189,7 +189,7 @@ stories
     </WrapWithHits>
   ))
   .add('with <Marker> events', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -214,7 +214,7 @@ stories
     </WrapWithHits>
   ))
   .add('with <Redo> component', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -237,7 +237,7 @@ stories
     </WrapWithHits>
   ))
   .add('with <Control> component', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -260,7 +260,7 @@ stories
     </WrapWithHits>
   ))
   .add('with <Control> component disabled', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -283,7 +283,7 @@ stories
     </WrapWithHits>
   ))
   .add('with <CustomMarker>', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -314,7 +314,7 @@ stories
     </WrapWithHits>
   ))
   .add('with <CustomMarker> events', () => (
-    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+    <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
       <Configure aroundLatLngViaIP hitsPerPage={20} />
 
       <Container>
@@ -348,7 +348,7 @@ stories
 
 // With Places
 stories.add('with Places', () => (
-  <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+  <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch.stories.js">
     <Configure hitsPerPage={20} aroundRadius={5000} />
 
     <Places
@@ -414,7 +414,10 @@ stories.add('with InfoWindow', () => {
       const { google } = this.props;
 
       return (
-        <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <WrapWithHits
+          indexName="airbnb"
+          linkedStoryGroup="GeoSearch.stories.js"
+        >
           <Configure aroundLatLngViaIP hitsPerPage={20} />
 
           <Container>
@@ -506,7 +509,7 @@ stories.add('with hits communication (custom)', () => {
       return (
         <WrapWithHits
           indexName="airbnb"
-          linkedStoryGroup="GeoSearch"
+          linkedStoryGroup="GeoSearch.stories.js"
           hitsElement={
             <CustomHits selectedHit={selectedHit} onHitOver={this.onHitOver} />
           }
@@ -547,7 +550,10 @@ stories.add('with unmount', () => {
       const { visible } = this.state;
 
       return (
-        <WrapWithHits indexName="airbnb" linkedStoryGroup="GeoSearch">
+        <WrapWithHits
+          indexName="airbnb"
+          linkedStoryGroup="GeoSearch.stories.js"
+        >
           <Configure aroundLatLngViaIP hitsPerPage={20} />
 
           <button onClick={this.onToggle} style={{ marginBottom: 15 }}>

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -8,7 +8,10 @@ const stories = storiesOf('HierarchicalMenu', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="HierarchicalMenu.stories.js"
+    >
       <HierarchicalMenu
         attributes={[
           'hierarchicalCategories.lvl0',
@@ -19,7 +22,10 @@ stories
     </WrapWithHits>
   ))
   .add('with default selected item', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="HierarchicalMenu.stories.js"
+    >
       <HierarchicalMenu
         attributes={[
           'hierarchicalCategories.lvl0',
@@ -31,7 +37,10 @@ stories
     </WrapWithHits>
   ))
   .add('with show more', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="HierarchicalMenu.stories.js"
+    >
       <HierarchicalMenu
         attributes={[
           'hierarchicalCategories.lvl0',
@@ -45,7 +54,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="HierarchicalMenu">
+    <WrapWithHits linkedStoryGroup="HierarchicalMenu.stories.js">
       <HierarchicalMenu
         attributes={[
           'hierarchicalCategories.lvl0',
@@ -60,7 +69,10 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="HierarchicalMenu.stories.js"
+    >
       <Panel header="Hierarchical Menu" footer="Footer">
         <HierarchicalMenu
           attributes={[
@@ -76,7 +88,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="HierarchicalMenu"
+      linkedStoryGroup="HierarchicalMenu.stories.js"
     >
       <Panel header="Hierarchical Menu" footer="Footer">
         <HierarchicalMenu

--- a/stories/Highlight.stories.js
+++ b/stories/Highlight.stories.js
@@ -47,12 +47,12 @@ StrongHits.propTypes = {
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Highlight">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Highlight.stories.js">
       <Hits hitComponent={Default} />
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="Highlight">
+    <WrapWithHits linkedStoryGroup="Highlight.stories.js">
       <Hits hitComponent={StrongHits} />
     </WrapWithHits>
   ));

--- a/stories/Hits.stories.js
+++ b/stories/Hits.stories.js
@@ -16,7 +16,7 @@ const stories = storiesOf('Hits', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits linkedStoryGroup="Hits">
+    <WrapWithHits linkedStoryGroup="Hits.stories.js">
       <Hits />
     </WrapWithHits>
   ))
@@ -38,13 +38,13 @@ stories
       hit: PropTypes.object.isRequired,
     };
     return (
-      <WrapWithHits linkedStoryGroup="Hits">
+      <WrapWithHits linkedStoryGroup="Hits.stories.js">
         <Hits hitComponent={Product} />
       </WrapWithHits>
     );
   })
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="Hits">
+    <WrapWithHits linkedStoryGroup="Hits.stories.js">
       <Panel header="Hits" footer="Footer">
         <Hits />
       </Panel>
@@ -75,7 +75,7 @@ stories
       insights: PropTypes.func.isRequired,
     };
     return (
-      <WrapWithHits linkedStoryGroup="Hits">
+      <WrapWithHits linkedStoryGroup="Hits.stories.js">
         <Configure clickAnalytics />
         <Hits hitComponent={ProductWithInsights} />
       </WrapWithHits>

--- a/stories/HitsPerPage.stories.js
+++ b/stories/HitsPerPage.stories.js
@@ -8,7 +8,10 @@ const stories = storiesOf('HitsPerPage', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="HitsPerPage.stories.js"
+    >
       <HitsPerPage
         defaultRefinement={4}
         items={[
@@ -21,7 +24,10 @@ stories
     </WrapWithHits>
   ))
   .add('without label', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="HitsPerPage.stories.js"
+    >
       <HitsPerPage
         defaultRefinement={4}
         items={[{ value: 2 }, { value: 4 }, { value: 6 }, { value: 8 }]}
@@ -29,7 +35,10 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="HitsPerPage">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="HitsPerPage.stories.js"
+    >
       <Panel header="Hits per page" footer="Footer">
         <HitsPerPage
           defaultRefinement={4}
@@ -44,7 +53,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="HitsPerPage">
+    <WrapWithHits linkedStoryGroup="HitsPerPage.stories.js">
       <HitsPerPage
         defaultRefinement={number('default hits per page', 4)}
         items={[

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -18,7 +18,7 @@ const stories = storiesOf('InfiniteHits', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits linkedStoryGroup="InfiniteHits" pagination={false}>
+    <WrapWithHits linkedStoryGroup="InfiniteHits.stories.js" pagination={false}>
       <InfiniteHits />
     </WrapWithHits>
   ))
@@ -26,7 +26,7 @@ stories
     const urlLogger = action('Routing state');
     return (
       <WrapWithHits
-        linkedStoryGroup="InfiniteHits"
+        linkedStoryGroup="InfiniteHits.stories.js"
         pagination={false}
         initialSearchState={{ page: 3 }}
         onSearchStateChange={({ configure, ...searchState }) => {
@@ -74,7 +74,7 @@ stories
 
     return (
       <WrapWithHits
-        linkedStoryGroup="InfiniteHits"
+        linkedStoryGroup="InfiniteHits.stories.js"
         pagination={false}
         initialSearchState={{ page: 3 }}
         onSearchStateChange={({ configure, ...searchState }) => {
@@ -105,13 +105,13 @@ stories
     };
 
     return (
-      <WrapWithHits linkedStoryGroup="InfiniteHits">
+      <WrapWithHits linkedStoryGroup="InfiniteHits.stories.js">
         <InfiniteHits hitComponent={Product} />
       </WrapWithHits>
     );
   })
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="InfiniteHits" pagination={false}>
+    <WrapWithHits linkedStoryGroup="InfiniteHits.stories.js" pagination={false}>
       <Panel header="Infinite hits" footer="Footer">
         <InfiniteHits />
       </Panel>
@@ -143,7 +143,7 @@ stories
       insights: PropTypes.func.isRequired,
     };
     return (
-      <WrapWithHits linkedStoryGroup="Hits">
+      <WrapWithHits linkedStoryGroup="Hits.stories.js">
         <Configure clickAnalytics />
         <InfiniteHits hitComponent={ProductWithInsights} />
       </WrapWithHits>
@@ -166,7 +166,7 @@ stories
     };
 
     return (
-      <WrapWithHits linkedStoryGroup="InfiniteHits">
+      <WrapWithHits linkedStoryGroup="InfiniteHits.stories.js">
         <Configure hitsPerPage={16} />
         <InfiniteHits
           hitComponent={Product}

--- a/stories/InstantSearch.stories.js
+++ b/stories/InstantSearch.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import algoliasearch from 'algoliasearch/lite';
 import { storiesOf } from '@storybook/react';
 import { InstantSearch, SearchBox, Hits } from 'react-instantsearch-dom';
+import { Content } from './util';
 
 const stories = storiesOf('<InstantSearch>', module);
 
@@ -12,23 +13,27 @@ const searchClient = algoliasearch(
 
 stories
   .add('default', () => (
-    <InstantSearch searchClient={searchClient} indexName="instant_search">
-      <SearchBox />
-      <Hits />
-    </InstantSearch>
+    <Content linkedStoryGroup="InstantSearch.stories.js">
+      <InstantSearch searchClient={searchClient} indexName="instant_search">
+        <SearchBox />
+        <Hits />
+      </InstantSearch>
+    </Content>
   ))
   .add('with custom search client', () => (
-    <InstantSearch
-      indexName="instant_search"
-      searchClient={{
-        search() {
-          return Promise.resolve({
-            results: [{ hits: [{ name: 'Fake result' }] }],
-          });
-        },
-      }}
-    >
-      <SearchBox />
-      <Hits />
-    </InstantSearch>
+    <Content linkedStoryGroup="InstantSearch.stories.js">
+      <InstantSearch
+        indexName="instant_search"
+        searchClient={{
+          search() {
+            return Promise.resolve({
+              results: [{ hits: [{ name: 'Fake result' }] }],
+            });
+          },
+        }}
+      >
+        <SearchBox />
+        <Hits />
+      </InstantSearch>
+    </Content>
   ));

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -9,22 +9,22 @@ const stories = storiesOf('Menu', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu.stories.js">
       <Menu attribute="brand" />
     </WrapWithHits>
   ))
   .add('with default selected item', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu.stories.js">
       <Menu attribute="brand" defaultRefinement="Apple" />
     </WrapWithHits>
   ))
   .add('with show more', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu.stories.js">
       <Menu attribute="brand" limit={2} showMoreLimit={5} showMore={true} />
     </WrapWithHits>
   ))
   .add('with search inside items', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu.stories.js">
       <Menu
         attribute="brand"
         searchable
@@ -39,7 +39,7 @@ stories
     </WrapWithHits>
   ))
   .add('with the sort strategy changed', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu.stories.js">
       <Menu
         attribute="brand"
         transformItems={items =>
@@ -49,7 +49,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Menu.stories.js">
       <Panel header="Menu" footer="Footer">
         <Menu attribute="brand" />
       </Panel>
@@ -59,7 +59,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="Menu"
+      linkedStoryGroup="Menu.stories.js"
     >
       <Panel header="Menu" footer="Footer">
         <Menu attribute="brand" />
@@ -71,7 +71,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="Menu">
+    <WrapWithHits linkedStoryGroup="Menu.stories.js">
       <Menu
         attribute="brand"
         defaultRefinement={text('defaultSelectedItem', 'Apple')}

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -9,17 +9,17 @@ const stories = storiesOf('MenuSelect', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect.stories.js">
       <MenuSelect attribute="brand" />
     </WrapWithHits>
   ))
   .add('with default selected item', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect.stories.js">
       <MenuSelect attribute="brand" defaultRefinement="Apple" />
     </WrapWithHits>
   ))
   .add('with the sort strategy changed', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect.stories.js">
       <MenuSelect
         attribute="brand"
         transformItems={items =>
@@ -29,7 +29,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="MenuSelect">
+    <WrapWithHits linkedStoryGroup="MenuSelect.stories.js">
       <MenuSelect
         attribute="brand"
         defaultRefinement={text('defaultSelectedItem', 'Apple')}
@@ -37,7 +37,7 @@ stories
     </WrapWithHits>
   ))
   .add('with localized count', () => (
-    <WrapWithHits linkedStoryGroup="MenuSelect">
+    <WrapWithHits linkedStoryGroup="MenuSelect.stories.js">
       <MenuSelect
         attribute="brand"
         defaultRefinement={text('defaultSelectedItem', 'Apple')}
@@ -51,7 +51,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="MenuSelect.stories.js">
       <Panel header="Menu select" footer="Footer">
         <MenuSelect attribute="brand" />
       </Panel>
@@ -61,7 +61,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="MenuSelect"
+      linkedStoryGroup="MenuSelect.stories.js"
     >
       <Panel header="Menu select" footer="Footer">
         <MenuSelect attribute="brand" />

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -15,6 +15,7 @@ import {
   connectAutoComplete,
   connectStateResults,
 } from 'react-instantsearch-dom';
+import { Content as StoryWrapper } from './util';
 
 const searchClient = algoliasearch(
   'latency',
@@ -25,150 +26,160 @@ const stories = storiesOf('<Index>', module);
 
 stories
   .add('MultiHits', () => (
-    <InstantSearch searchClient={searchClient} indexName="instant_search">
-      <SearchBox />
+    <StoryWrapper linkedStoryGroup="MultiIndex.stories.js">
+      <InstantSearch searchClient={searchClient} indexName="instant_search">
+        <SearchBox />
 
-      <Index indexName="bestbuy">
-        <h3>
-          index: <code>bestbuy</code>
-        </h3>
-        <Configure hitsPerPage={3} />
-        <CustomCategoriesOrBrands />
-      </Index>
+        <Index indexName="bestbuy">
+          <h3>
+            index: <code>bestbuy</code>
+          </h3>
+          <Configure hitsPerPage={3} />
+          <CustomCategoriesOrBrands />
+        </Index>
 
-      <Index indexName="instant_search">
-        <h3>
-          index: <code>instant_search</code>
-        </h3>
-        <Configure hitsPerPage={3} />
-        <CustomCategoriesOrBrands />
-      </Index>
+        <Index indexName="instant_search">
+          <h3>
+            index: <code>instant_search</code>
+          </h3>
+          <Configure hitsPerPage={3} />
+          <CustomCategoriesOrBrands />
+        </Index>
 
-      <Index indexId="instant_search_apple" indexName="instant_search">
-        <h3>
-          index: <code>instant_search</code> with <code>brand:Apple</code>
-        </h3>
-        <Configure hitsPerPage={3} filters="brand:Apple" />
-        <CustomCategoriesOrBrands />
-      </Index>
+        <Index indexId="instant_search_apple" indexName="instant_search">
+          <h3>
+            index: <code>instant_search</code> with <code>brand:Apple</code>
+          </h3>
+          <Configure hitsPerPage={3} filters="brand:Apple" />
+          <CustomCategoriesOrBrands />
+        </Index>
 
-      <Index indexId="instant_search_samsung" indexName="instant_search">
-        <h3>
-          index: <code>instant_search</code> with <code>brand:Samsung</code>
-        </h3>
-        <Configure hitsPerPage={3} filters="brand:Samsung" />
-        <CustomCategoriesOrBrands />
-      </Index>
+        <Index indexId="instant_search_samsung" indexName="instant_search">
+          <h3>
+            index: <code>instant_search</code> with <code>brand:Samsung</code>
+          </h3>
+          <Configure hitsPerPage={3} filters="brand:Samsung" />
+          <CustomCategoriesOrBrands />
+        </Index>
 
-      <Index indexId="instant_search_microsoft" indexName="instant_search">
-        <h3>
-          index: <code>instant_search</code> with <code>brand:Microsoft</code>
-        </h3>
-        <Configure hitsPerPage={3} filters="brand:Microsoft" />
-        <CustomCategoriesOrBrands />
-      </Index>
-    </InstantSearch>
+        <Index indexId="instant_search_microsoft" indexName="instant_search">
+          <h3>
+            index: <code>instant_search</code> with <code>brand:Microsoft</code>
+          </h3>
+          <Configure hitsPerPage={3} filters="brand:Microsoft" />
+          <CustomCategoriesOrBrands />
+        </Index>
+      </InstantSearch>
+    </StoryWrapper>
   ))
   .add('AutoComplete', () => (
-    <InstantSearch searchClient={searchClient} indexName="categories">
-      <Configure hitsPerPage={3} />
-      <Index indexName="brands" />
-      <Index indexName="products">
-        <Configure hitsPerPage={5} />
-      </Index>
-      <AutoComplete />
-    </InstantSearch>
+    <StoryWrapper linkedStoryGroup="MultiIndex.stories.js">
+      <InstantSearch searchClient={searchClient} indexName="categories">
+        <Configure hitsPerPage={3} />
+        <Index indexName="brands" />
+        <Index indexName="products">
+          <Configure hitsPerPage={5} />
+        </Index>
+        <AutoComplete />
+      </InstantSearch>
+    </StoryWrapper>
   ))
   .add('with SortBy nested in same Index as Root', () => (
-    <InstantSearch searchClient={searchClient} indexName="categories">
-      <SearchBox />
+    <StoryWrapper linkedStoryGroup="MultiIndex.stories.js">
+      <InstantSearch searchClient={searchClient} indexName="categories">
+        <SearchBox />
 
-      <div className="multi-index_content">
-        <div className="multi-index_categories-or-brands">
-          <Index indexName="categories">
-            <Configure hitsPerPage={3} />
-
-            <SortBy
-              defaultRefinement="categories"
-              items={[
-                { value: 'categories', label: 'Categories' },
-                { value: 'bestbuy', label: 'Best buy' },
-              ]}
-            />
-
-            <CustomCategoriesOrBrands />
-          </Index>
-
-          <Index indexName="products">
-            <Configure hitsPerPage={3} />
-
-            <SortBy
-              defaultRefinement="products"
-              items={[
-                { value: 'products', label: 'Products' },
-                { value: 'brands', label: 'Brands' },
-              ]}
-            />
-
-            <CustomCategoriesOrBrands />
-          </Index>
-        </div>
-      </div>
-    </InstantSearch>
-  ))
-  .add('with conditional rendering', () => (
-    <InstantSearch searchClient={searchClient} indexName="categories">
-      <SearchBox />
-      <Results>
         <div className="multi-index_content">
           <div className="multi-index_categories-or-brands">
             <Index indexName="categories">
-              <Content>
-                <div>
-                  <div>Categories: </div>
-                  <Configure hitsPerPage={3} />
-                  <CustomCategoriesOrBrands />
-                </div>
-              </Content>
+              <Configure hitsPerPage={3} />
+
+              <SortBy
+                defaultRefinement="categories"
+                items={[
+                  { value: 'categories', label: 'Categories' },
+                  { value: 'bestbuy', label: 'Best buy' },
+                ]}
+              />
+
+              <CustomCategoriesOrBrands />
             </Index>
-            <Index indexName="brands">
-              <Content>
-                <div>
-                  <div>Brand: </div>
-                  <Configure hitsPerPage={3} />
-                  <CustomCategoriesOrBrands />
-                </div>
-              </Content>
-            </Index>
-          </div>
-          <div className="multi-index_products">
+
             <Index indexName="products">
-              <Content>
-                <div>
-                  <div>Products: </div>
-                  <Configure hitsPerPage={5} />
-                  <CustomProducts />
-                </div>
-              </Content>
+              <Configure hitsPerPage={3} />
+
+              <SortBy
+                defaultRefinement="products"
+                items={[
+                  { value: 'products', label: 'Products' },
+                  { value: 'brands', label: 'Brands' },
+                ]}
+              />
+
+              <CustomCategoriesOrBrands />
             </Index>
           </div>
         </div>
-      </Results>
-    </InstantSearch>
+      </InstantSearch>
+    </StoryWrapper>
+  ))
+  .add('with conditional rendering', () => (
+    <StoryWrapper linkedStoryGroup="MultiIndex.stories.js">
+      <InstantSearch searchClient={searchClient} indexName="categories">
+        <SearchBox />
+        <Results>
+          <div className="multi-index_content">
+            <div className="multi-index_categories-or-brands">
+              <Index indexName="categories">
+                <Content>
+                  <div>
+                    <div>Categories: </div>
+                    <Configure hitsPerPage={3} />
+                    <CustomCategoriesOrBrands />
+                  </div>
+                </Content>
+              </Index>
+              <Index indexName="brands">
+                <Content>
+                  <div>
+                    <div>Brand: </div>
+                    <Configure hitsPerPage={3} />
+                    <CustomCategoriesOrBrands />
+                  </div>
+                </Content>
+              </Index>
+            </div>
+            <div className="multi-index_products">
+              <Index indexName="products">
+                <Content>
+                  <div>
+                    <div>Products: </div>
+                    <Configure hitsPerPage={5} />
+                    <CustomProducts />
+                  </div>
+                </Content>
+              </Index>
+            </div>
+          </div>
+        </Results>
+      </InstantSearch>
+    </StoryWrapper>
   ))
   .add('with Hits & Configure', () => (
-    <InstantSearch searchClient={searchClient} indexName="brands">
-      <Configure hitsPerPage={5} />
-      <SearchBox />
+    <StoryWrapper linkedStoryGroup="MultiIndex.stories.js">
+      <InstantSearch searchClient={searchClient} indexName="brands">
+        <Configure hitsPerPage={5} />
+        <SearchBox />
 
-      <CustomCategoriesOrBrands />
-      <Pagination />
-
-      <Index indexName="products">
-        <CustomProducts />
+        <CustomCategoriesOrBrands />
         <Pagination />
-      </Index>
-    </InstantSearch>
+
+        <Index indexName="products">
+          <CustomProducts />
+          <Pagination />
+        </Index>
+      </InstantSearch>
+    </StoryWrapper>
   ));
 
 const AutoComplete = connectAutoComplete(

--- a/stories/NumericMenu.stories.js
+++ b/stories/NumericMenu.stories.js
@@ -7,7 +7,7 @@ const stories = storiesOf('NumericMenu', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits linkedStoryGroup="NumericMenu">
+    <WrapWithHits linkedStoryGroup="NumericMenu.stories.js">
       <NumericMenu
         attribute="price"
         items={[
@@ -20,7 +20,7 @@ stories
     </WrapWithHits>
   ))
   .add('with a default range selected', () => (
-    <WrapWithHits linkedStoryGroup="NumericMenu">
+    <WrapWithHits linkedStoryGroup="NumericMenu.stories.js">
       <NumericMenu
         attribute="price"
         items={[
@@ -34,7 +34,7 @@ stories
     </WrapWithHits>
   ))
   .add('with some non selectable ranges', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="NumericMenu">
+    <WrapWithHits searchBox={false} linkedStoryGroup="NumericMenu.stories.js">
       <NumericMenu
         attribute="price"
         items={[
@@ -47,7 +47,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="NumericMenu">
+    <WrapWithHits linkedStoryGroup="NumericMenu.stories.js">
       <Panel header="Numeric Menu" footer="Footer">
         <NumericMenu
           attribute="price"
@@ -62,7 +62,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel but no refinement', () => (
-    <WrapWithHits linkedStoryGroup="NumericMenu">
+    <WrapWithHits linkedStoryGroup="NumericMenu.stories.js">
       <Configure filters="price>200000" />
 
       <Panel header="Numeric Menu" footer="Footer">

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -8,12 +8,12 @@ const stories = storiesOf('Pagination', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination.stories.js">
       <Pagination />
     </WrapWithHits>
   ))
   .add('with all props', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination.stories.js">
       <Pagination
         showFirst={true}
         showLast={true}
@@ -25,7 +25,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="Pagination">
+    <WrapWithHits linkedStoryGroup="Pagination.stories.js">
       <Pagination
         showFirst={boolean('show First', true)}
         showLast={boolean('show Last', true)}
@@ -37,7 +37,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Pagination.stories.js">
       <Panel header="Pagination" footer="Footer">
         <Pagination />
       </Panel>
@@ -47,7 +47,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="Pagination"
+      linkedStoryGroup="Pagination.stories.js"
     >
       <Panel header="Pagination" footer="Footer">
         <Pagination header="Pagination" />

--- a/stories/PoweredBy.stories.js
+++ b/stories/PoweredBy.stories.js
@@ -6,7 +6,7 @@ import { WrapWithHits } from './util';
 const stories = storiesOf('PoweredBy', module);
 
 stories.add('default', () => (
-  <WrapWithHits linkedStoryGroup="PoweredBy">
+  <WrapWithHits linkedStoryGroup="PoweredBy.stories.js">
     <PoweredBy />
   </WrapWithHits>
 ));

--- a/stories/QueryRuleContext.stories.tsx
+++ b/stories/QueryRuleContext.stories.tsx
@@ -49,7 +49,7 @@ const storyProps = {
   appId: 'latency',
   apiKey: 'af044fb0788d6bb15f807e4420592bc5',
   indexName: 'instant_search_movies',
-  linkedStoryGroup: 'QueryRuleCustomData',
+  linkedStoryGroup: 'QueryRuleCustomData.stories.tsx',
   hitsElement: <StoryHits />,
 };
 

--- a/stories/QueryRuleCustomData.stories.tsx
+++ b/stories/QueryRuleCustomData.stories.tsx
@@ -44,7 +44,7 @@ const storyProps = {
   appId: 'latency',
   apiKey: 'af044fb0788d6bb15f807e4420592bc5',
   indexName: 'instant_search_movies',
-  linkedStoryGroup: 'QueryRuleCustomData',
+  linkedStoryGroup: 'QueryRuleCustomData.stories.tsx',
   hitsElement: <StoryHits />,
 };
 

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -8,12 +8,12 @@ const stories = storiesOf('RangeInput', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <RangeInput attribute="price" />
     </WrapWithHits>
   ))
   .add('visible without refinement', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput">
+    <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput.stories.js">
       <RangeInput attribute="price" header="Range Input" />
 
       <div style={{ display: 'none' }}>
@@ -22,7 +22,7 @@ stories
     </WrapWithHits>
   ))
   .add('with no refinement', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput">
+    <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput.stories.js">
       <RangeInput attribute="price" />
       <div style={{ display: 'none' }}>
         <SearchBox defaultRefinement="ds" />
@@ -30,37 +30,37 @@ stories
     </WrapWithHits>
   ))
   .add('with precision of 2', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <RangeInput attribute="price" precision={2} />
     </WrapWithHits>
   ))
   .add('with default value', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <RangeInput attribute="price" defaultRefinement={{ min: 50 }} />
     </WrapWithHits>
   ))
   .add('with default values', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <RangeInput attribute="price" defaultRefinement={{ min: 50, max: 200 }} />
     </WrapWithHits>
   ))
   .add('with min boundaries', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <RangeInput attribute="price" min={30} />
     </WrapWithHits>
   ))
   .add('with max boundaries', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <RangeInput attribute="price" max={500} />
     </WrapWithHits>
   ))
   .add('with min / max boundaries', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <RangeInput attribute="price" min={30} max={500} />
     </WrapWithHits>
   ))
   .add('with boundaries and default value', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <RangeInput
         attribute="price"
         min={30}
@@ -70,7 +70,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <RangeInput
         attribute="price"
         min={number('min', 0)}
@@ -85,14 +85,14 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="RangeInput">
+    <WrapWithHits linkedStoryGroup="RangeInput.stories.js">
       <Panel header="Range Input" footer="Footer">
         <RangeInput attribute="price" />
       </Panel>
     </WrapWithHits>
   ))
   .add('with Panel but no refinement', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput">
+    <WrapWithHits searchBox={false} linkedStoryGroup="RangeInput.stories.js">
       <Panel header="Range Input" footer="Footer">
         <RangeInput attribute="price" />
       </Panel>

--- a/stories/RangeSlider.stories.js
+++ b/stories/RangeSlider.stories.js
@@ -15,25 +15,37 @@ const Warning = () => (
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="RangeSlider.stories.js"
+    >
       <Warning />
       <Range attribute="price" />
     </WrapWithHits>
   ))
   .add('providing default value', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="RangeSlider.stories.js"
+    >
       <Warning />
       <Range attribute="price" defaultRefinement={{ min: 50, max: 200 }} />
     </WrapWithHits>
   ))
   .add('custom min/max bounds', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="RangeSlider.stories.js"
+    >
       <Warning />
       <Range attribute="price" min={30} max={100} />
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RangeSlider">
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="RangeSlider.stories.js"
+    >
       <Warning />
       <Panel header="Range Slider" footer="Footer">
         <Range attribute="price" />
@@ -41,7 +53,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="RangeSlider">
+    <WrapWithHits linkedStoryGroup="RangeSlider.stories.js">
       <Warning />
       <Range
         attribute="price"

--- a/stories/RatingMenu.stories.js
+++ b/stories/RatingMenu.stories.js
@@ -13,41 +13,41 @@ const stories = storiesOf('RatingMenu', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu.stories.js">
       <RatingMenu attribute="rating" />
     </WrapWithHits>
   ))
   .add('with min', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu.stories.js">
       <RatingMenu attribute="rating" min={3} />
     </WrapWithHits>
   ))
   .add('with max', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu.stories.js">
       <RatingMenu attribute="rating" max={3} />
     </WrapWithHits>
   ))
   .add('with min & max', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu.stories.js">
       <RatingMenu attribute="rating" min={2} max={4} />
     </WrapWithHits>
   ))
   .add('with only one value available', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu.stories.js">
       <Configure filters="rating>=4" />
 
       <RatingMenu attribute="rating" />
     </WrapWithHits>
   ))
   .add('with only one value available & min & max', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu.stories.js">
       <Configure filters="rating>=4" />
 
       <RatingMenu attribute="rating" min={1} max={5} />
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="RatingMenu.stories.js">
       <Panel header="Ratings">
         <RatingMenu attribute="rating" />
       </Panel>
@@ -57,7 +57,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="RatingMenu"
+      linkedStoryGroup="RatingMenu.stories.js"
     >
       <Panel header="Ratings">
         <RatingMenu attribute="rating" />
@@ -72,7 +72,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="RatingMenu"
+      linkedStoryGroup="RatingMenu.stories.js"
     >
       <Panel header="Ratings">
         <RatingMenu attribute="rating" min={1} max={5} />
@@ -84,7 +84,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="RatingMenu">
+    <WrapWithHits linkedStoryGroup="RatingMenu.stories.js">
       <RatingMenu
         attribute="rating"
         min={number('min', 1)}

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -9,17 +9,26 @@ const stories = storiesOf('RefinementList', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+    <WrapWithHits
+      linkedStoryGroup="RefinementList.stories.js"
+      hasPlayground={true}
+    >
       <RefinementList attribute="brand" />
     </WrapWithHits>
   ))
   .add('with selected item', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+    <WrapWithHits
+      linkedStoryGroup="RefinementList.stories.js"
+      hasPlayground={true}
+    >
       <RefinementList attribute="brand" defaultRefinement={['Apple']} />
     </WrapWithHits>
   ))
   .add('with show more', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+    <WrapWithHits
+      linkedStoryGroup="RefinementList.stories.js"
+      hasPlayground={true}
+    >
       <RefinementList
         attribute="brand"
         limit={2}
@@ -29,12 +38,18 @@ stories
     </WrapWithHits>
   ))
   .add('with search inside items', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+    <WrapWithHits
+      linkedStoryGroup="RefinementList.stories.js"
+      hasPlayground={true}
+    >
       <RefinementList attribute="brand" searchable />
     </WrapWithHits>
   ))
   .add('with the sort strategy changed', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+    <WrapWithHits
+      linkedStoryGroup="RefinementList.stories.js"
+      hasPlayground={true}
+    >
       <RefinementList
         attribute="brand"
         transformItems={items =>
@@ -44,7 +59,10 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList" hasPlayground={true}>
+    <WrapWithHits
+      linkedStoryGroup="RefinementList.stories.js"
+      hasPlayground={true}
+    >
       <Panel header="Refinement List" footer="Footer">
         <RefinementList attribute="brand" />
       </Panel>
@@ -53,7 +71,7 @@ stories
   .add('with Panel but no refinement', () => (
     <WrapWithHits
       searchBox={false}
-      linkedStoryGroup="RefinementList"
+      linkedStoryGroup="RefinementList.stories.js"
       hasPlayground={true}
     >
       <Panel header="Refinement List" footer="Footer">
@@ -66,7 +84,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="RefinementList">
+    <WrapWithHits linkedStoryGroup="RefinementList.stories.js">
       <RefinementList
         attribute="brand"
         defaultRefinement={array('defaultSelectedItem', ['Apple', 'Samsung'])}

--- a/stories/RefreshCache.stories.js
+++ b/stories/RefreshCache.stories.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import algoliasearch from 'algoliasearch/lite';
 import { InstantSearch, SearchBox, Configure } from 'react-instantsearch-dom';
-import { CustomHits } from './util';
+import { CustomHits, Content } from './util';
 
 const stories = storiesOf('RefreshCache', module);
 
@@ -111,7 +111,11 @@ class AppWithRefresh extends Component {
   }
 }
 
-stories.add('with a refresh button', () => <AppWithRefresh />);
+stories.add('with a refresh button', () => (
+  <Content linkedStoryGroup="RefreshCache.stories.js">
+    <AppWithRefresh />
+  </Content>
+));
 
 class App extends Component {
   state = {
@@ -164,4 +168,8 @@ class App extends Component {
   }
 }
 
-stories.add('with setInterval', () => <App />);
+stories.add('with setInterval', () => (
+  <Content linkedStoryGroup="RefreshCache.stories.js">
+    <App />
+  </Content>
+));

--- a/stories/ScrollTo.stories.js
+++ b/stories/ScrollTo.stories.js
@@ -6,7 +6,7 @@ import { WrapWithHits } from './util';
 const stories = storiesOf('ScrollTo', module);
 
 stories.add('default', () => (
-  <WrapWithHits linkedStoryGroup="ScrollTo">
+  <WrapWithHits linkedStoryGroup="ScrollTo.stories.js">
     <Configure hitsPerPage={5} />
     <ScrollTo>
       <Hits />

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -12,7 +12,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="SearchBox"
+      linkedStoryGroup="SearchBox.stories.js"
     >
       <SearchBox showLoadingIndicator={boolean('showLoadingIndicator', true)} />
     </WrapWithHits>
@@ -21,7 +21,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="SearchBox"
+      linkedStoryGroup="SearchBox.stories.js"
     >
       <SearchBox defaultRefinement="battery" />
     </WrapWithHits>
@@ -30,7 +30,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="SearchBox"
+      linkedStoryGroup="SearchBox.stories.js"
     >
       <SearchBox
         submit={<span>🔍</span>}
@@ -43,7 +43,7 @@ stories
     </WrapWithHits>
   ))
   .add('Display feedback when search is stalled (custom component)', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox">
+    <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox.stories.js">
       <SearchBox
         showLoadingIndicator={true}
         loadingIndicator={<span>✨</span>}
@@ -51,7 +51,7 @@ stories
     </WrapWithHits>
   ))
   .add('without search as you type', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox">
+    <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox.stories.js">
       <SearchBox searchAsYouType={false} />
     </WrapWithHits>
   ))
@@ -59,7 +59,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="SearchBox"
+      linkedStoryGroup="SearchBox.stories.js"
     >
       <Panel header="SearchBox" footer="Footer">
         <SearchBox />
@@ -67,7 +67,7 @@ stories
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox">
+    <WrapWithHits searchBox={false} linkedStoryGroup="SearchBox.stories.js">
       <SearchBox
         focusShortcuts={['s']}
         searchAsYouType={true}
@@ -126,7 +126,7 @@ class SearchBoxContainer extends Component {
       <WrapWithHits
         searchBox={false}
         hasPlayground={true}
-        linkedStoryGroup="SearchBox"
+        linkedStoryGroup="SearchBox.stories.js"
       >
         <div
           style={{

--- a/stories/Snippet.stories.js
+++ b/stories/Snippet.stories.js
@@ -47,13 +47,13 @@ StrongHits.propTypes = {
 
 stories
   .add('default', () => (
-    <WrapWithHits hasPlayground={true} linkedStoryGroup="Snippet">
+    <WrapWithHits hasPlayground={true} linkedStoryGroup="Snippet.stories.js">
       <Configure attributesToSnippet={['name', 'description']} />
       <Hits hitComponent={Default} />
     </WrapWithHits>
   ))
   .add('playground', () => (
-    <WrapWithHits linkedStoryGroup="Snippet">
+    <WrapWithHits linkedStoryGroup="Snippet.stories.js">
       <Configure attributesToSnippet={['name', 'description']} />
       <Hits hitComponent={StrongHits} />
     </WrapWithHits>

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -7,7 +7,7 @@ const stories = storiesOf('SortBy', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits linkedStoryGroup="SortBy">
+    <WrapWithHits linkedStoryGroup="SortBy.stories.js">
       <SortBy
         items={[
           { value: 'instant_search', label: 'Featured' },
@@ -19,7 +19,7 @@ stories
     </WrapWithHits>
   ))
   .add('without label', () => (
-    <WrapWithHits linkedStoryGroup="SortBy">
+    <WrapWithHits linkedStoryGroup="SortBy.stories.js">
       <SortBy
         items={[
           { value: 'instant_search' },
@@ -31,7 +31,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="SortBy">
+    <WrapWithHits linkedStoryGroup="SortBy.stories.js">
       <Panel header="Sort By" footer="Footer">
         <SortBy
           items={[

--- a/stories/Stats.stories.js
+++ b/stories/Stats.stories.js
@@ -7,14 +7,14 @@ const stories = storiesOf('Stats', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits linkedStoryGroup="Stats">
+    <WrapWithHits linkedStoryGroup="Stats.stories.js">
       <div>
         <Stats />
       </div>
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="Stats">
+    <WrapWithHits linkedStoryGroup="Stats.stories.js">
       <Panel header="Stats" footer="Footer">
         <Stats />
       </Panel>

--- a/stories/ToggleRefinement.stories.js
+++ b/stories/ToggleRefinement.stories.js
@@ -7,7 +7,7 @@ const stories = storiesOf('ToggleRefinement', module);
 
 stories
   .add('default', () => (
-    <WrapWithHits linkedStoryGroup="ToggleRefinement">
+    <WrapWithHits linkedStoryGroup="ToggleRefinement.stories.js">
       <ToggleRefinement
         attribute="free_shipping"
         label="Free shipping"
@@ -16,7 +16,7 @@ stories
     </WrapWithHits>
   ))
   .add('checked by default', () => (
-    <WrapWithHits linkedStoryGroup="ToggleRefinement">
+    <WrapWithHits linkedStoryGroup="ToggleRefinement.stories.js">
       <ToggleRefinement
         attribute="free_shipping"
         label="Free shipping"
@@ -26,7 +26,7 @@ stories
     </WrapWithHits>
   ))
   .add('with Panel', () => (
-    <WrapWithHits linkedStoryGroup="ToggleRefinement">
+    <WrapWithHits linkedStoryGroup="ToggleRefinement.stories.js">
       <Panel header="Toggle Refinement" footer="Footer">
         <ToggleRefinement
           attribute="free_shipping"

--- a/stories/VoiceSearch.stories.tsx
+++ b/stories/VoiceSearch.stories.tsx
@@ -11,7 +11,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="VoiceSearch"
+      linkedStoryGroup="VoiceSearch.stories.tsx"
     >
       <p style={{ color: '#999', fontStyle: 'italic' }}>
         To see this button disabled, test it on unsupported browsers like
@@ -24,7 +24,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="VoiceSearch"
+      linkedStoryGroup="VoiceSearch.stories.tsx"
     >
       <VoiceSearch statusComponent={() => null} />
     </WrapWithHits>
@@ -33,7 +33,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="VoiceSearch"
+      linkedStoryGroup="VoiceSearch.stories.tsx"
     >
       <VoiceSearch />
       <SearchBox />
@@ -43,7 +43,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="VoiceSearch"
+      linkedStoryGroup="VoiceSearch.stories.tsx"
     >
       <div className="custom-button-story">
         <VoiceSearch
@@ -77,7 +77,7 @@ stories
       <WrapWithHits
         searchBox={false}
         hasPlayground={true}
-        linkedStoryGroup="VoiceSearch"
+        linkedStoryGroup="VoiceSearch.stories.tsx"
       >
         <VoiceSearch statusComponent={Status} />
       </WrapWithHits>
@@ -107,7 +107,7 @@ stories
       <WrapWithHits
         searchBox={false}
         hasPlayground={true}
-        linkedStoryGroup="VoiceSearch"
+        linkedStoryGroup="VoiceSearch.stories.tsx"
       >
         <VoiceSearch searchAsYouSpeak={true} statusComponent={Status} />
       </WrapWithHits>
@@ -126,7 +126,7 @@ stories
       <WrapWithHits
         searchBox={false}
         hasPlayground={true}
-        linkedStoryGroup="VoiceSearch"
+        linkedStoryGroup="VoiceSearch.stories.tsx"
       >
         <div className="custom-ui">
           <VoiceSearch statusComponent={Status} />
@@ -139,7 +139,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="VoiceSearch"
+      linkedStoryGroup="VoiceSearch.stories.tsx"
     >
       <VoiceSearch additionalQueryParameters={() => {}} />
       <SearchBox />
@@ -149,7 +149,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="VoiceSearch"
+      linkedStoryGroup="VoiceSearch.stories.tsx"
     >
       <VoiceSearch language="fr-FR" additionalQueryParameters={() => {}} />
     </WrapWithHits>
@@ -158,7 +158,7 @@ stories
     <WrapWithHits
       searchBox={false}
       hasPlayground={true}
-      linkedStoryGroup="VoiceSearch"
+      linkedStoryGroup="VoiceSearch.stories.tsx"
     >
       <VoiceSearch
         language="fr-FR"

--- a/stories/util.js
+++ b/stories/util.js
@@ -52,7 +52,7 @@ export function Content({
   hasPlayground,
   linkedStoryGroup,
   children,
-  defaultView,
+  resultsView,
 }) {
   const sourceCodeUrl = `https://github.com/algolia/react-instantsearch/tree/master/stories/${linkedStoryGroup}`;
   const playgroundLink = hasPlayground ? (
@@ -78,12 +78,12 @@ export function Content({
     </div>
   ) : null;
 
-  const results = defaultView ? (
+  const results = resultsView ? (
     <div
       style={linkedStoryGroup ? {} : { borderRadius: '0px 0px 5px 5px' }}
       className="container hits-container"
     >
-      {defaultView}
+      {resultsView}
     </div>
   ) : null;
 
@@ -100,7 +100,7 @@ Content.propTypes = {
   linkedStoryGroup: PropTypes.string,
   hasPlayground: PropTypes.bool,
   children: PropTypes.node,
-  defaultView: PropTypes.node,
+  resultsView: PropTypes.node,
 };
 
 export function WrapWithHits({
@@ -146,7 +146,7 @@ export function WrapWithHits({
       <Content
         linkedStoryGroup={linkedStoryGroup}
         hasPlayground={hasPlayground}
-        defaultView={
+        resultsView={
           <div>
             <div className="hit-actions">
               {searchBox ? (

--- a/stories/util.js
+++ b/stories/util.js
@@ -48,25 +48,13 @@ Hits.propTypes = {
 
 export const CustomHits = connectHits(Hits);
 
-export const WrapWithHits = ({
-  searchParameters: askedSearchParameters = {},
-  children,
-  searchBox = true,
-  hasPlayground = false,
+export function Content({
+  hasPlayground,
   linkedStoryGroup,
-  pagination = true,
-  appId,
-  apiKey,
-  indexName,
-  hitsElement,
-  initialSearchState,
-  onSearchStateChange,
-}) => {
-  const searchClient = useMemo(() => {
-    return algoliasearch(appId, apiKey);
-  }, [appId, apiKey]);
-
-  const sourceCodeUrl = `https://github.com/algolia/react-instantsearch/tree/master/stories/${linkedStoryGroup}.stories.js`;
+  children,
+  defaultView,
+}) {
+  const sourceCodeUrl = `https://github.com/algolia/react-instantsearch/tree/master/stories/${linkedStoryGroup}`;
   const playgroundLink = hasPlayground ? (
     <button
       onClick={linkTo(linkedStoryGroup, 'playground')}
@@ -90,6 +78,49 @@ export const WrapWithHits = ({
     </div>
   ) : null;
 
+  const results = defaultView ? (
+    <div
+      style={linkedStoryGroup ? {} : { borderRadius: '0px 0px 5px 5px' }}
+      className="container hits-container"
+    >
+      {defaultView}
+    </div>
+  ) : null;
+
+  return (
+    <div>
+      <div className="container widget-container">{children}</div>
+      {results}
+      {footer}
+    </div>
+  );
+}
+
+Content.propTypes = {
+  linkedStoryGroup: PropTypes.string,
+  hasPlayground: PropTypes.bool,
+  children: PropTypes.node,
+  defaultView: PropTypes.node,
+};
+
+export function WrapWithHits({
+  searchParameters: askedSearchParameters = {},
+  children,
+  searchBox = true,
+  hasPlayground = false,
+  linkedStoryGroup,
+  pagination = true,
+  hitsElement,
+  appId,
+  apiKey,
+  indexName,
+  initialSearchState,
+  onSearchStateChange,
+}) {
+  const searchClient = useMemo(() => {
+    return algoliasearch(appId, apiKey);
+  }, [appId, apiKey]);
+
   const hits = hitsElement || <CustomHits />;
 
   const searchParameters = {
@@ -112,13 +143,11 @@ export const WrapWithHits = ({
       onSearchStateChange={setNextSearchState}
     >
       <Configure {...searchParameters} />
-      <div>
-        <div className="container widget-container">{children}</div>
-        <div>
-          <div
-            style={linkedStoryGroup ? {} : { borderRadius: '0px 0px 5px 5px' }}
-            className="container hits-container"
-          >
+      <Content
+        linkedStoryGroup={linkedStoryGroup}
+        hasPlayground={hasPlayground}
+        defaultView={
+          <div>
             <div className="hit-actions">
               {searchBox ? (
                 <SearchBox
@@ -134,12 +163,13 @@ export const WrapWithHits = ({
               {pagination ? <Pagination showLast={true} /> : null}
             </div>
           </div>
-          {footer}
-        </div>
-      </div>
+        }
+      >
+        {children}
+      </Content>
     </InstantSearch>
   );
-};
+}
 
 WrapWithHits.propTypes = {
   appId: PropTypes.string,
@@ -162,5 +192,5 @@ WrapWithHits.defaultProps = {
   apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
   indexName: 'instant_search',
   initialSearchState: {},
-  onSearchStateChange: () => {},
+  onSearchStateChange: searchState => searchState,
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

storybook was assuming all stories ended in `.stories.js`, which is no longer the case

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

fixes #2968

- made the `linkedStoryGroup` param take the full file name `xxx.stories.js` instead of the widget name (`xxx`)
- split up the rendering of WrapWithHits to export the inner component for stories which render their own InstantSearch (refresh, `<Index />` & `<InstantSearch />`)

example fixed links:
- https://deploy-preview-2969--react-instantsearch.netlify.app/storybook/?path=/story/instantsearch--default
- https://deploy-preview-2969--react-instantsearch.netlify.app/storybook/?path=/story/queryrulecustomdata--default
