### PR TITLE
poc: add hooks

### DIFF
--- a/packages/react-instantsearch-core/src/core/context.ts
+++ b/packages/react-instantsearch-core/src/core/context.ts
@@ -12,10 +12,7 @@ export type InstantSearchContext = {
   mainTargetedIndex: string;
 };
 
-export const {
-  Consumer: InstantSearchConsumer,
-  Provider: InstantSearchProvider,
-} = createContext<InstantSearchContext>({
+export const InstantSearchContext = createContext<InstantSearchContext>({
   onInternalStateUpdate: () => undefined,
   createHrefForState: () => '#',
   onSearchForFacetValues: () => undefined,
@@ -25,6 +22,11 @@ export const {
   widgetsManager: {},
   mainTargetedIndex: '',
 });
+
+export const {
+  Consumer: InstantSearchConsumer,
+  Provider: InstantSearchProvider,
+} = InstantSearchContext;
 
 export type IndexContext =
   | {

--- a/packages/react-instantsearch-core/src/core/createConnector.tsx
+++ b/packages/react-instantsearch-core/src/core/createConnector.tsx
@@ -95,6 +95,7 @@ export function createConnectorWithoutContext(
       unregisterWidget?: () => void;
 
       isUnmounting = false;
+      name = Connector.displayName;
 
       state: ConnectorState = {
         providedProps: this.getProvidedProps(this.props),

--- a/packages/react-instantsearch-core/src/index.ts
+++ b/packages/react-instantsearch-core/src/index.ts
@@ -6,6 +6,12 @@ export { HIGHLIGHT_TAGS } from './core/highlight';
 export { default as version } from './core/version';
 export { default as translatable } from './core/translatable';
 
+export {
+  InstantSearchContext,
+  InstantSearchConsumer,
+  InstantSearchProvider,
+} from './core/context';
+
 // Widgets
 export { default as Configure } from './widgets/Configure';
 export {

--- a/packages/react-instantsearch-dom/src/hooks.js
+++ b/packages/react-instantsearch-dom/src/hooks.js
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+import { InstantSearchContext } from 'react-instantsearch-core';
+
+export function useSearch() {
+  const { store, widgetsManager } = useContext(InstantSearchContext);
+  const getResults = () => store.getState().results;
+  const searchBox = widgetsManager
+    .getWidgets()
+    .find(widget => widget.name.startsWith('AlgoliaSearchBox'));
+  const setQuery = query => searchBox && searchBox.refine(query);
+
+  return {
+    getResults,
+    setQuery,
+  };
+}

--- a/packages/react-instantsearch-dom/src/index.js
+++ b/packages/react-instantsearch-dom/src/index.js
@@ -67,6 +67,9 @@ export { default as ToggleRefinement } from './widgets/ToggleRefinement';
 export { default as VoiceSearch } from './widgets/VoiceSearch';
 export { default as QueryRuleCustomData } from './widgets/QueryRuleCustomData';
 
+// Hooks
+export { useSearch } from './hooks';
+
 // Utils
 export { createClassNames } from './core/utils';
 

--- a/stories/Hooks.stories.js
+++ b/stories/Hooks.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { useSearch } from 'react-instantsearch-dom';
+import { WrapWithHits } from './util';
+
+const stories = storiesOf('Hooks', module);
+
+function HookPlayground() {
+  const { getResults, setQuery } = useSearch();
+
+  return (
+    <div>
+      <button type="button" onClick={() => setQuery('Amazon')}>
+        Search for 'Amazon'
+      </button>
+      <pre>{JSON.stringify(getResults(), null, 2)}</pre>
+    </div>
+  );
+}
+
+stories.add('default', function() {
+  return (
+    <WrapWithHits linkedStoryGroup="Hits.stories.js">
+      <HookPlayground />
+    </WrapWithHits>
+  );
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This is a dirty PoC just to play with hooks.

This doesn't even work as intended.
`useSearch()` returns an outdated things, but I'm not intending to dig into that, at least for now.

To try this,

- open [this storybook](https://5f7dba6c2a449700073c7f6f--react-instantsearch.netlify.app/storybook/?path=/story/hooks--default).
- type any character in the search box, then you will see `results` displayed.
- if you click the `Search for 'Amazon'` button, it will refine with `amazon` query.