### PR TITLE
fix: add missing dependencies

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -44,6 +44,7 @@
     "react-fast-compare": "^3.0.0"
   },
   "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 5",
     "react": ">= 16.3.0 < 17"
   }
 }

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -44,7 +44,8 @@
     "algoliasearch-helper": "^3.1.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.10",
-    "react-instantsearch-core": "^6.7.0"
+    "react-instantsearch-core": "^6.7.0",
+    "react-fast-compare": "^3.0.0"
   },
   "peerDependencies": {
     "react": ">= 16.3.0 < 17",


### PR DESCRIPTION
**Summary**

Added `react-fast-compare` as a dependency to `react-instantsearch-dom` because it's using it without declaring it and `algoliasearch` as a peer dependency to `react-instantsearch-core` because it inherits it from `algoliasearch-helper` so it needs to be declared

**Result**

Building using Yarn 2's PnP mode succeeds.
Been declared like this for months in https://github.com/yarnpkg/berry/blob/9e5ea238cf4363dd95c43111494db8bfbdb06ccd/.yarnrc.yml#L60-L66