### PR TITLE
feat. request: expose some utilities in createInstantSearchServer for wider SSR-usage

### DIFF
--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -10,7 +10,7 @@ const getIndexId = context =>
     ? context.multiIndexContext.targetedIndex
     : context.ais.mainTargetedIndex;
 
-const createSearchParametersCollector = accumulator => {
+export const createSearchParametersCollector = accumulator => {
   return (getWidgetSearchParameters, context, props, searchState) => {
     accumulator.push({
       getSearchParameters: getWidgetSearchParameters,
@@ -129,6 +129,31 @@ const multiIndexSearch = (
   );
 };
 
+export const getResultsStateFromSearchParameters = function(indexName, searchClient, searchParameters) {
+  const { sharedParameters, derivedParameters } = getSearchParameters(
+    indexName,
+    searchParameters
+  );
+
+  const helper = algoliasearchHelper(searchClient, sharedParameters.index);
+
+  if (typeof searchClient.addAlgoliaAgent === 'function') {
+    searchClient.addAlgoliaAgent(`react-instantsearch-server (${version})`);
+  }
+
+  if (Object.keys(derivedParameters).length === 0) {
+    return singleIndexSearch(helper, sharedParameters);
+  }
+
+  return multiIndexSearch(
+    indexName,
+    searchClient,
+    helper,
+    sharedParameters,
+    derivedParameters
+  );
+}
+
 export const findResultsState = function(App, props) {
   if (!props) {
     throw new Error(
@@ -159,26 +184,5 @@ export const findResultsState = function(App, props) {
     />
   );
 
-  const { sharedParameters, derivedParameters } = getSearchParameters(
-    indexName,
-    searchParameters
-  );
-
-  const helper = algoliasearchHelper(searchClient, sharedParameters.index);
-
-  if (typeof searchClient.addAlgoliaAgent === 'function') {
-    searchClient.addAlgoliaAgent(`react-instantsearch-server (${version})`);
-  }
-
-  if (Object.keys(derivedParameters).length === 0) {
-    return singleIndexSearch(helper, sharedParameters);
-  }
-
-  return multiIndexSearch(
-    indexName,
-    searchClient,
-    helper,
-    sharedParameters,
-    derivedParameters
-  );
+  return getResultsStateFromSearchParameters(indexName, searchClient, searchParameters);
 };


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
This is more like a feature request than finalized PR.

Currently findResultsState can be used only by giving it a component tree to render. Often you already have similar kind of server-side rendering logic to gather data for hydration. For example, with Apollo Client you might be using getDataFromTree to extract cache.

By exposing these functions you can get the results state at the same time with other such renderings.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
```
const searchParams = [];
const searchParamsCollector = createSearchParametersCollector(acc);
const data = await getDataFromTree(
  <App
    {...appProps}
    searchParamsCollector={searchParamsCollector}
    Component={Component}
    apolloState={apolloState}
    apollo={apollo}
  />
 );
algoliaResultsState = await getResultsStateFromSearchParams(
  indexName,
  client,
  searchParams
);
```