### PR TITLE
fix(ssr): cleaner result for multi-index

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -121,35 +121,37 @@ describe('createInstantSearchManager', () => {
         return;
       }
 
-      const resultsState = [
-        {
-          metadata: [],
-          _internalIndexId: 'index1',
-          rawResults: [
-            {
+      const resultsState = {
+        metadata: [],
+        results: [
+          {
+            _internalIndexId: 'index1',
+            rawResults: [
+              {
+                index: 'index1',
+                query: 'query1',
+              },
+            ],
+            state: {
               index: 'index1',
               query: 'query1',
             },
-          ],
-          state: {
-            index: 'index1',
-            query: 'query1',
           },
-        },
-        {
-          _internalIndexId: 'index2',
-          rawResults: [
-            {
+          {
+            _internalIndexId: 'index2',
+            rawResults: [
+              {
+                index: 'index2',
+                query: 'query2',
+              },
+            ],
+            state: {
               index: 'index2',
               query: 'query2',
             },
-          ],
-          state: {
-            index: 'index2',
-            query: 'query2',
           },
-        },
-      ];
+        ],
+      };
 
       expect(Object.keys(searchClient.cache)).toHaveLength(0);
 
@@ -345,35 +347,37 @@ describe('createInstantSearchManager', () => {
       const ism = createInstantSearchManager({
         indexName: 'index',
         searchClient: createSearchClient(),
-        resultsState: [
-          {
-            metadata: [],
-            _internalIndexId: 'index1',
-            rawResults: [
-              {
+        resultsState: {
+          metadata: [],
+          results: [
+            {
+              _internalIndexId: 'index1',
+              rawResults: [
+                {
+                  index: 'index1',
+                  query: 'query1',
+                },
+              ],
+              state: {
                 index: 'index1',
                 query: 'query1',
               },
-            ],
-            state: {
-              index: 'index1',
-              query: 'query1',
             },
-          },
-          {
-            _internalIndexId: 'index2',
-            rawResults: [
-              {
+            {
+              _internalIndexId: 'index2',
+              rawResults: [
+                {
+                  index: 'index2',
+                  query: 'query2',
+                },
+              ],
+              state: {
                 index: 'index2',
                 query: 'query2',
               },
-            ],
-            state: {
-              index: 'index2',
-              query: 'query2',
             },
-          },
-        ],
+          ],
+        },
       });
 
       expect(ism.store.getState().results.index1.query).toBe('query1');

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -364,8 +364,8 @@ export default function createInstantSearchManager({
       };
     }
 
-    if (Array.isArray(results)) {
-      hydrateSearchClientWithMultiIndexRequest(client, results);
+    if (Array.isArray(results.results)) {
+      hydrateSearchClientWithMultiIndexRequest(client, results.results);
       return;
     }
 
@@ -478,8 +478,8 @@ export default function createInstantSearchManager({
       return null;
     }
 
-    if (Array.isArray(results)) {
-      return results.reduce(
+    if (Array.isArray(results.results)) {
+      return results.results.reduce(
         (acc, result) => ({
           ...acc,
           [result._internalIndexId]: new algoliasearchHelper.SearchResults(
@@ -611,18 +611,12 @@ export default function createInstantSearchManager({
   };
 }
 
-function extractMetadata(resultsState) {
+function hydrateMetadata(resultsState) {
   if (!resultsState) {
     return [];
   }
-  if (Array.isArray(resultsState)) {
-    return resultsState[0].metadata;
-  }
-  return resultsState.metadata;
-}
 
-function hydrateMetadata(resultsState) {
-  return extractMetadata(resultsState).map(datum => ({
+  return resultsState.metadata.map(datum => ({
     ...datum,
     // add a value noop, which gets replaced once the widgets are mounted
     value() {},

--- a/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
@@ -521,7 +521,7 @@ describe('findResultsState', () => {
         ...requiredProps,
       };
 
-      const results = await findResultsState(App, props);
+      const { results } = await findResultsState(App, props);
 
       results.forEach(result => {
         expect(result.state).toBeInstanceOf(SearchParameters);
@@ -579,15 +579,17 @@ describe('findResultsState', () => {
 
       const data = await findResultsState(App, props);
 
-      expect(data).toHaveLength(2);
+      expect(data.results).toHaveLength(2);
 
-      const [first, second] = data;
+      const { metadata, results } = data;
+      const [first, second] = results;
+
+      expect(metadata).toEqual([
+        expect.objectContaining({ id: 'cool' }),
+        expect.objectContaining({ id: 'cool' }),
+      ]);
 
       expect(first).toEqual({
-        metadata: [
-          expect.objectContaining({ id: 'cool' }),
-          expect.objectContaining({ id: 'cool' }),
-        ],
         _internalIndexId: 'index1',
         state: expect.objectContaining({ index: 'index1', query: 'Apple' }),
         rawResults: [
@@ -621,17 +623,18 @@ describe('findResultsState', () => {
         indexName: 'index1',
       };
 
-      const data = await findResultsState(App, props);
+      const { results, metadata } = await findResultsState(App, props);
 
-      expect(data).toHaveLength(2);
+      expect(metadata).toEqual([
+        expect.objectContaining({ id: 'cool' }),
+        expect.objectContaining({ id: 'cool' }),
+      ]);
 
-      const [first, second] = data;
+      expect(results).toHaveLength(2);
+
+      const [first, second] = results;
 
       expect(first).toEqual({
-        metadata: [
-          expect.objectContaining({ id: 'cool' }),
-          expect.objectContaining({ id: 'cool' }),
-        ],
         _internalIndexId: 'index1',
         state: expect.objectContaining({ index: 'index1', query: 'Apple' }),
         rawResults: [
@@ -665,17 +668,18 @@ describe('findResultsState', () => {
         indexName: 'index1',
       };
 
-      const data = await findResultsState(App, props);
+      const { results, metadata } = await findResultsState(App, props);
 
-      expect(data).toHaveLength(2);
+      expect(metadata).toEqual([
+        expect.objectContaining({ id: 'cool' }),
+        expect.objectContaining({ id: 'cool' }),
+      ]);
 
-      const [first, second] = data;
+      expect(results).toHaveLength(2);
+
+      const [first, second] = results;
 
       expect(first).toEqual({
-        metadata: [
-          expect.objectContaining({ id: 'cool' }),
-          expect.objectContaining({ id: 'cool' }),
-        ],
         _internalIndexId: 'index1',
         state: expect.objectContaining({ index: 'index1', query: 'Apple' }),
         rawResults: [
@@ -721,17 +725,18 @@ describe('findResultsState', () => {
         },
       };
 
-      const data = await findResultsState(App, props);
+      const { results, metadata } = await findResultsState(App, props);
 
-      expect(data).toHaveLength(2);
+      expect(metadata).toEqual([
+        expect.objectContaining({ id: 'cool' }),
+        expect.objectContaining({ id: 'cool' }),
+      ]);
 
-      const [first, second] = data;
+      expect(results).toHaveLength(2);
+
+      const [first, second] = results;
 
       expect(first).toEqual({
-        metadata: [
-          expect.objectContaining({ id: 'cool' }),
-          expect.objectContaining({ id: 'cool' }),
-        ],
         _internalIndexId: 'index1',
         state: expect.objectContaining({ index: 'index1', query: 'iPhone' }),
         rawResults: [
@@ -773,17 +778,18 @@ describe('findResultsState', () => {
         },
       };
 
-      const data = await findResultsState(App, props);
+      const { results, metadata } = await findResultsState(App, props);
 
-      expect(data).toHaveLength(2);
+      expect(metadata).toEqual([
+        expect.objectContaining({ id: 'cool' }),
+        expect.objectContaining({ id: 'cool' }),
+      ]);
 
-      const [first, second] = data;
+      expect(results).toHaveLength(2);
+
+      const [first, second] = results;
 
       expect(first).toEqual({
-        metadata: [
-          expect.objectContaining({ id: 'cool' }),
-          expect.objectContaining({ id: 'cool' }),
-        ],
         _internalIndexId: 'index1',
         state: expect.objectContaining({ index: 'index1', query: 'iPhone' }),
         rawResults: [
@@ -825,17 +831,18 @@ describe('findResultsState', () => {
         },
       };
 
-      const data = await findResultsState(App, props);
+      const { results, metadata } = await findResultsState(App, props);
 
-      expect(data).toHaveLength(2);
+      expect(metadata).toEqual([
+        expect.objectContaining({ id: 'cool' }),
+        expect.objectContaining({ id: 'cool' }),
+      ]);
 
-      const [first, second] = data;
+      expect(results).toHaveLength(2);
+
+      const [first, second] = results;
 
       expect(first).toEqual({
-        metadata: [
-          expect.objectContaining({ id: 'cool' }),
-          expect.objectContaining({ id: 'cool' }),
-        ],
         _internalIndexId: 'index1',
         state: expect.objectContaining({ index: 'index1', query: 'iPhone' }),
         rawResults: [
@@ -878,25 +885,26 @@ describe('findResultsState', () => {
         searchState,
       };
 
-      const data = await findResultsState(App, props);
+      const { results, metadata } = await findResultsState(App, props);
 
-      expect(data).toHaveLength(2);
+      expect(metadata).toEqual([
+        {
+          id: 'cool',
+          searchState,
+          props: expect.objectContaining({ prop: 'value1' }),
+        },
+        {
+          id: 'cool',
+          searchState,
+          props: expect.objectContaining({ prop: 'value2' }),
+        },
+      ]);
 
-      const [first, second] = data;
+      expect(results).toHaveLength(2);
+
+      const [first, second] = results;
 
       expect(first).toEqual({
-        metadata: [
-          {
-            id: 'cool',
-            searchState,
-            props: expect.objectContaining({ prop: 'value1' }),
-          },
-          {
-            id: 'cool',
-            searchState,
-            props: expect.objectContaining({ prop: 'value2' }),
-          },
-        ],
         _internalIndexId: 'index1',
         state: expect.objectContaining({ index: 'index1', query: 'iPhone' }),
         rawResults: [
@@ -938,11 +946,11 @@ describe('findResultsState', () => {
           },
         };
 
-        const data = await findResultsState(App, props);
+        const { results } = await findResultsState(App, props);
 
-        expect(data).toHaveLength(2);
+        expect(results).toHaveLength(2);
 
-        const [first, second] = data;
+        const [first, second] = results;
 
         expect(first.rawResults[0].params).toMatchInlineSnapshot(
           `"query=iPhone"`
@@ -981,11 +989,11 @@ describe('findResultsState', () => {
           },
         };
 
-        const data = await findResultsState(App, props);
+        const { results } = await findResultsState(App, props);
 
-        expect(data).toHaveLength(2);
+        expect(results).toHaveLength(2);
 
-        const [first, second] = data;
+        const [first, second] = results;
 
         expect(first.rawResults[0].params).toBeUndefined();
         expect(second.rawResults[0].params).toBeUndefined();
@@ -1019,11 +1027,11 @@ describe('findResultsState', () => {
           },
         };
 
-        const data = await findResultsState(App, props);
+        const { results } = await findResultsState(App, props);
 
-        expect(data).toHaveLength(2);
+        expect(results).toHaveLength(2);
 
-        const [first, second] = data;
+        const [first, second] = results;
 
         expect(first.rawResults[0].params).toMatchInlineSnapshot(
           `"query=iPhone"`

--- a/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js
@@ -202,7 +202,6 @@ export const findResultsState = function(App, props) {
     sharedParameters,
     derivedParameters
   ).then(results => {
-    results[0].metadata = metadata;
-    return results;
+    return { metadata, results };
   });
 };

--- a/packages/react-instantsearch-dom/src/widgets/__tests__/InstantSearch.tsx
+++ b/packages/react-instantsearch-dom/src/widgets/__tests__/InstantSearch.tsx
@@ -109,28 +109,30 @@ describe('InstantSearch', () => {
         }
       );
 
-      const resultsState = [
-        {
-          metadata: [],
-          rawResults: EMPTY_RESPONSE.results,
-          state: {
-            index: 'instant_search',
-            query: '',
-          },
-        },
-        {
-          rawResults: [
-            {
-              ...EMPTY_RESPONSE.results[0],
-              index: 'instant_search2',
+      const resultsState = {
+        metadata: [],
+        results: [
+          {
+            rawResults: EMPTY_RESPONSE.results,
+            state: {
+              index: 'instant_search',
+              query: '',
             },
-          ],
-          state: {
-            index: 'instant_search2',
-            query: '',
           },
-        },
-      ];
+          {
+            rawResults: [
+              {
+                ...EMPTY_RESPONSE.results[0],
+                index: 'instant_search2',
+              },
+            ],
+            state: {
+              index: 'instant_search2',
+              query: '',
+            },
+          },
+        ],
+      };
 
       render(
         <InstantSearch


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

storing metadata in the first result is confusing, so we change the shape to always be an object; be it multi-index or single index

stacked PR on top of #2973

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

result of findResultsState is now an object with the keys `{ metadata, results }` instead of `results` and metadata being in the first element
