### PR TITLE
fix: upgrade prop-types dependency to 15.6+

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "algoliasearch-helper": "^3.1.0",
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.7.2",
     "react-fast-compare": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-dom-maps/package.json
+++ b/packages/react-instantsearch-dom-maps/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.7.2",
     "scriptjs": "^2.5.8"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.1.2",
     "algoliasearch-helper": "^3.1.0",
     "classnames": "^2.2.5",
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.7.2",
     "react-fast-compare": "^3.0.0",
     "react-instantsearch-core": "^6.8.2"
   },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

We ran into an issue using `react-instantsearch-dom@latest` during local development with regard to the `prop-types@15.5.10` package, which seems to cause the following runtime error:

> Uncaught TypeError: prop_types__WEBPACK_IMPORTED_MODULE_10___default.a.exact is not a function

It looks like the `exact` function was not added until `prop-types@15.6.0` according to the [CHANGELOG](https://github.com/facebook/prop-types/blob/master/CHANGELOG.md#1560), but the [`SearchBox` component of `react-instantsearch-dom` makes use of `PropTypes.exact`](https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-dom/src/components/SearchBox.js#L87) while remaining on `prop-types@15.5.10`.

This manifests as a runtime error during local development when using `react-instantsearch-dom` as seen above.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

By upgrading the `prop-types` package to v15.6+ (opting for `prop-types@latest` here), this error should no longer happen when we are trying to use `react-instantsearch-dom` during local development.
