### PR TITLE
fix(types): fix type errors regarding SpeechRecognition

### DIFF
--- a/packages/react-instantsearch-dom/src/components/VoiceSearch.tsx
+++ b/packages/react-instantsearch-dom/src/components/VoiceSearch.tsx
@@ -5,6 +5,7 @@ import createVoiceSearchHelper, {
   VoiceSearchHelper,
   VoiceListeningState,
   Status,
+  SpeechRecognitionErrorCode,
 } from '../lib/voiceSearchHelper';
 const cx = createClassNames('VoiceSearch');
 

--- a/packages/react-instantsearch-dom/src/lib/voiceSearchHelper/__tests__/index.ts
+++ b/packages/react-instantsearch-dom/src/lib/voiceSearchHelper/__tests__/index.ts
@@ -30,6 +30,7 @@ const createFakeSpeechRecognition = (): jest.Mock => {
 describe('VoiceSearchHelper', () => {
   afterEach(() => {
     delete window.webkitSpeechRecognition;
+    // @ts-ignore: not sure why TS says that `window.SpeechRecognition` isn't optional.
     delete window.SpeechRecognition;
   });
 

--- a/packages/react-instantsearch-dom/src/lib/voiceSearchHelper/index.ts
+++ b/packages/react-instantsearch-dom/src/lib/voiceSearchHelper/index.ts
@@ -1,5 +1,24 @@
 // copied from https://github.com/algolia/instantsearch.js/blob/688e36a67bb4c63d008d8abc02257a7b7c04e513/src/lib/voiceSearchHelper/index.ts
 
+// begin - wrong SpeechRecognition-related types
+// This is not released in typescript yet, so we're copy&pasting the type definition from
+// https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/924
+export type SpeechRecognitionErrorCode =
+  | 'aborted'
+  | 'audio-capture'
+  | 'bad-grammar'
+  | 'language-not-supported'
+  | 'network'
+  | 'no-speech'
+  | 'not-allowed'
+  | 'service-not-allowed';
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: SpeechRecognitionErrorCode;
+  readonly message: string;
+}
+// end - wrong SpeechRecognition-related types
+
 export type VoiceSearchHelperParams = {
   searchAsYouSpeak: boolean;
   language?: string;
@@ -74,7 +93,7 @@ export default function createVoiceSearchHelper({
     });
   };
 
-  const onError = (event: SpeechRecognitionError): void => {
+  const onError = (event: SpeechRecognitionErrorEvent): void => {
     setState({ status: 'error', errorCode: event.error });
   };
 
@@ -113,6 +132,7 @@ export default function createVoiceSearchHelper({
       recognition.lang = language;
     }
     recognition.addEventListener('start', onStart);
+    // @ts-ignore: refer to the top `wrong SpeechRecognition-related types` comments
     recognition.addEventListener('error', onError);
     recognition.addEventListener('result', onResult);
     recognition.addEventListener('end', onEnd);
@@ -125,6 +145,7 @@ export default function createVoiceSearchHelper({
     }
     recognition.stop();
     recognition.removeEventListener('start', onStart);
+    // @ts-ignore: refer to the top `wrong SpeechRecognition-related types` comments
     recognition.removeEventListener('error', onError);
     recognition.removeEventListener('result', onResult);
     recognition.removeEventListener('end', onEnd);

--- a/packages/react-instantsearch-dom/src/lib/voiceSearchHelper/index.ts
+++ b/packages/react-instantsearch-dom/src/lib/voiceSearchHelper/index.ts
@@ -1,6 +1,6 @@
 // copied from https://github.com/algolia/instantsearch.js/blob/688e36a67bb4c63d008d8abc02257a7b7c04e513/src/lib/voiceSearchHelper/index.ts
 
-// begin - wrong SpeechRecognition-related types
+// #region wrong SpeechRecognition-related types
 // This is not released in typescript yet, so we're copy&pasting the type definition from
 // https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/924
 export type SpeechRecognitionErrorCode =
@@ -17,7 +17,7 @@ interface SpeechRecognitionErrorEvent extends Event {
   readonly error: SpeechRecognitionErrorCode;
   readonly message: string;
 }
-// end - wrong SpeechRecognition-related types
+// #endregion wrong SpeechRecognition-related types
 
 export type VoiceSearchHelperParams = {
   searchAsYouSpeak: boolean;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Since the module `typescript` has been upgraded to `3.8.3` from #2996, it started to throw new errors regarding SpeechRecognition.
However the correct types are not released yet (https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/924), so this PR copies and pastes the related type and adds some `@ts-ignore` comments to pass the `yarn type-check`.