### PR TITLE
fix(SmartSort): make `textComponent` and `buttonTextComponent` optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "38.40 kB"
+      "maxSize": "38.41 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",

--- a/packages/react-instantsearch-dom/src/components/SmartSort.tsx
+++ b/packages/react-instantsearch-dom/src/components/SmartSort.tsx
@@ -21,7 +21,7 @@ export type SmartSortProps = {
 const DefaultButtonTextComponent = ({
   isSmartSorted,
 }: SmartSortComponentProps) => (
-  <div>{isSmartSorted ? 'See all results' : 'See relevant results'}</div>
+  <span>{isSmartSorted ? 'See all results' : 'See relevant results'}</span>
 );
 
 const SmartSort: React.FC<SmartSortProps> = ({

--- a/packages/react-instantsearch-dom/src/components/SmartSort.tsx
+++ b/packages/react-instantsearch-dom/src/components/SmartSort.tsx
@@ -13,23 +13,29 @@ export type SmartSortProps = {
   className?: string;
   isVirtualReplica: boolean;
   isSmartSorted: boolean;
-  buttonTextComponent: React.FunctionComponent<SmartSortComponentProps>;
-  textComponent: React.FunctionComponent<SmartSortComponentProps>;
+  buttonTextComponent?: React.FunctionComponent<SmartSortComponentProps>;
+  textComponent?: React.FunctionComponent<SmartSortComponentProps>;
   refine(relevancyStrictness: number | undefined): void;
 };
+
+const DefaultButtonTextComponent = ({
+  isSmartSorted,
+}: SmartSortComponentProps) => (
+  <div>{isSmartSorted ? 'See all results' : 'See relevant results'}</div>
+);
 
 const SmartSort: React.FC<SmartSortProps> = ({
   className = '',
   isVirtualReplica,
   isSmartSorted,
-  buttonTextComponent: ButtonTextComponent,
+  buttonTextComponent: ButtonTextComponent = DefaultButtonTextComponent,
   textComponent: TextComponent,
   refine,
 }) =>
   !isVirtualReplica ? null : (
     <div className={classNames(cx(''), className)}>
       <div className={cx('text')}>
-        <TextComponent isSmartSorted={isSmartSorted} />
+        {TextComponent && <TextComponent isSmartSorted={isSmartSorted} />}
       </div>
       <button
         className={cx('button')}
@@ -41,12 +47,12 @@ const SmartSort: React.FC<SmartSortProps> = ({
   );
 
 SmartSort.propTypes = {
-  buttonTextComponent: PropTypes.func.isRequired,
+  buttonTextComponent: PropTypes.func,
   className: PropTypes.string,
   isVirtualReplica: PropTypes.bool.isRequired,
   isSmartSorted: PropTypes.bool.isRequired,
   refine: PropTypes.func.isRequired,
-  textComponent: PropTypes.func.isRequired,
+  textComponent: PropTypes.func,
 };
 
 export default SmartSort;

--- a/packages/react-instantsearch-dom/src/components/__tests__/SmartSort.tsx
+++ b/packages/react-instantsearch-dom/src/components/__tests__/SmartSort.tsx
@@ -2,27 +2,13 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import SmartSort, { SmartSortComponentProps } from '../SmartSort';
 
-const TextComponent = ({ isSmartSorted }: SmartSortComponentProps) => (
-  <div>
-    {isSmartSorted
-      ? 'We removed some search results to show you the most relevant ones'
-      : 'Currently showing all results'}
-  </div>
-);
-
-const ButtonTextComponent = ({ isSmartSorted }: SmartSortComponentProps) => (
-  <div>{isSmartSorted ? 'See all results' : 'See relevant results'}</div>
-);
-
 describe('SmartSort', () => {
   it("returns null if it's not a virtual replica", () => {
     const tree = renderer.create(
       <SmartSort
-        buttonTextComponent={ButtonTextComponent}
         isVirtualReplica={false}
         isSmartSorted={false}
         refine={() => {}}
-        textComponent={TextComponent}
       />
     );
 
@@ -32,12 +18,10 @@ describe('SmartSort', () => {
   it('accepts a custom className', () => {
     const tree = renderer.create(
       <SmartSort
-        buttonTextComponent={ButtonTextComponent}
         className="MyCustomSmartSort"
         isVirtualReplica={true}
         isSmartSorted={false}
         refine={() => {}}
-        textComponent={TextComponent}
       />
     );
 
@@ -71,5 +55,133 @@ describe('SmartSort', () => {
       },
       {}
     );
+  });
+
+  it('renders with the default ButtonTextComponent', () => {
+    const tree = renderer.create(
+      <SmartSort
+        isVirtualReplica={true}
+        isSmartSorted={true}
+        refine={() => {}}
+      />
+    );
+
+    expect(tree.toJSON()).toMatchInlineSnapshot(`
+      <div
+        className="ais-SmartSort"
+      >
+        <div
+          className="ais-SmartSort-text"
+        />
+        <button
+          className="ais-SmartSort-button"
+          onClick={[Function]}
+        >
+          <div>
+            See all results
+          </div>
+        </button>
+      </div>
+    `);
+  });
+
+  it('renders with a custom ButtonTextComponent', () => {
+    const tree = renderer.create(
+      <SmartSort
+        buttonTextComponent={({ isSmartSorted }: SmartSortComponentProps) => (
+          <div>
+            {isSmartSorted ? 'See all results' : 'See relevant results'}
+          </div>
+        )}
+        isVirtualReplica={true}
+        isSmartSorted={true}
+        refine={() => {}}
+      />
+    );
+
+    expect(tree.toJSON()).toMatchInlineSnapshot(`
+      <div
+        className="ais-SmartSort"
+      >
+        <div
+          className="ais-SmartSort-text"
+        />
+        <button
+          className="ais-SmartSort-button"
+          onClick={[Function]}
+        >
+          <div>
+            See all results
+          </div>
+        </button>
+      </div>
+    `);
+  });
+
+  it('renders without a textComponent', () => {
+    const tree = renderer.create(
+      <SmartSort
+        isVirtualReplica={true}
+        isSmartSorted={false}
+        refine={() => {}}
+      />
+    );
+
+    expect(tree.toJSON()).toMatchInlineSnapshot(`
+      <div
+        className="ais-SmartSort"
+      >
+        <div
+          className="ais-SmartSort-text"
+        />
+        <button
+          className="ais-SmartSort-button"
+          onClick={[Function]}
+        >
+          <div>
+            See relevant results
+          </div>
+        </button>
+      </div>
+    `);
+  });
+
+  it('renders with a custom textComponent', () => {
+    const tree = renderer.create(
+      <SmartSort
+        isVirtualReplica={true}
+        isSmartSorted={false}
+        refine={() => {}}
+        textComponent={({ isSmartSorted }: SmartSortComponentProps) => (
+          <div>
+            {isSmartSorted
+              ? 'We removed some search results to show you the most relevant ones'
+              : 'Currently showing all results'}
+          </div>
+        )}
+      />
+    );
+
+    expect(tree.toJSON()).toMatchInlineSnapshot(`
+      <div
+        className="ais-SmartSort"
+      >
+        <div
+          className="ais-SmartSort-text"
+        >
+          <div>
+            Currently showing all results
+          </div>
+        </div>
+        <button
+          className="ais-SmartSort-button"
+          onClick={[Function]}
+        >
+          <div>
+            See relevant results
+          </div>
+        </button>
+      </div>
+    `);
   });
 });

--- a/packages/react-instantsearch-dom/src/components/__tests__/SmartSort.tsx
+++ b/packages/react-instantsearch-dom/src/components/__tests__/SmartSort.tsx
@@ -77,9 +77,9 @@ describe('SmartSort', () => {
           className="ais-SmartSort-button"
           onClick={[Function]}
         >
-          <div>
+          <span>
             See all results
-          </div>
+          </span>
         </button>
       </div>
     `);
@@ -89,9 +89,9 @@ describe('SmartSort', () => {
     const tree = renderer.create(
       <SmartSort
         buttonTextComponent={({ isSmartSorted }: SmartSortComponentProps) => (
-          <div>
+          <span>
             {isSmartSorted ? 'See all results' : 'See relevant results'}
-          </div>
+          </span>
         )}
         isVirtualReplica={true}
         isSmartSorted={true}
@@ -110,9 +110,9 @@ describe('SmartSort', () => {
           className="ais-SmartSort-button"
           onClick={[Function]}
         >
-          <div>
+          <span>
             See all results
-          </div>
+          </span>
         </button>
       </div>
     `);
@@ -138,9 +138,9 @@ describe('SmartSort', () => {
           className="ais-SmartSort-button"
           onClick={[Function]}
         >
-          <div>
+          <span>
             See relevant results
-          </div>
+          </span>
         </button>
       </div>
     `);
@@ -153,11 +153,11 @@ describe('SmartSort', () => {
         isSmartSorted={false}
         refine={() => {}}
         textComponent={({ isSmartSorted }: SmartSortComponentProps) => (
-          <div>
+          <p>
             {isSmartSorted
               ? 'We removed some search results to show you the most relevant ones'
               : 'Currently showing all results'}
-          </div>
+          </p>
         )}
       />
     );
@@ -169,17 +169,17 @@ describe('SmartSort', () => {
         <div
           className="ais-SmartSort-text"
         >
-          <div>
+          <p>
             Currently showing all results
-          </div>
+          </p>
         </div>
         <button
           className="ais-SmartSort-button"
           onClick={[Function]}
         >
-          <div>
+          <span>
             See relevant results
-          </div>
+          </span>
         </button>
       </div>
     `);


### PR DESCRIPTION
**Summary**

To match the `InstantSearch.js` implementation (https://github.com/algolia/instantsearch.js/pull/4648), we made the `textComponent` and `buttonTextComponent` props optional and provided a default `ButtonTextComponent`