### PR TITLE
chore(release): remove afterPublish script

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -46,16 +46,16 @@ module.exports = {
   pullRequestTeamReviewers: ['instantsearch-for-websites'],
   buildCommand: ({ version }) =>
     `NODE_ENV=production VERSION=${version} yarn build`,
-  afterPublish: async ({ exec, version }) => {
-    await waitUntil(() => {
-      return (
-        exec(`npm view react-instantsearch@${version}`)
-          .toString()
-          .trim() !== ''
-      );
-    });
-    exec('node scripts/update-examples.js');
-  },
+  // afterPublish: async ({ exec, version }) => {
+  //   await waitUntil(() => {
+  //     return (
+  //       exec(`npm view react-instantsearch@${version}`)
+  //         .toString()
+  //         .trim() !== ''
+  //     );
+  //   });
+  //   exec('node scripts/update-examples.js');
+  // },
   slack: {
     // disable slack notification for `prepared` lifecycle.
     // Ship.js will send slack message only for `releaseSuccess`.
@@ -96,13 +96,13 @@ module.exports = {
   },
 };
 
-function waitUntil(checkFn) {
-  return new Promise(resolve => {
-    const intervalId = setInterval(async () => {
-      if (await checkFn()) {
-        clearInterval(intervalId);
-        resolve();
-      }
-    }, 3000);
-  });
-}
+// function waitUntil(checkFn) {
+//   return new Promise(resolve => {
+//     const intervalId = setInterval(async () => {
+//       if (await checkFn()) {
+//         clearInterval(intervalId);
+//         resolve();
+//       }
+//     }, 3000);
+//   });
+// }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR removes `afterPublish` lifecycle hook in the release process because it's not working at the moment. I will create another PR later with working version.

With this script failiing, shipjs also failed to push git tags to the remote (except for that, everything else worked, though).