### PR TITLE
feat(connectNumericMenu): add support for floating point values

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectNumericMenu.js
@@ -25,6 +25,7 @@ describe('connectNumericMenu', () => {
         {},
         { results }
       );
+
       expect(props).toEqual({
         items: [
           { label: 'All', value: '', isRefined: true, noRefinement: false },
@@ -112,6 +113,37 @@ describe('connectNumericMenu', () => {
           {
             label: 'Maybe ok?',
             value: '100:200',
+            isRefined: false,
+            noRefinement: false,
+          },
+          { label: 'All', value: '', isRefined: true, noRefinement: false },
+        ],
+        currentRefinement: '',
+        canRefine: true,
+      });
+
+      props = connect.getProvidedProps(
+        {
+          items: [
+            { label: 'is 0', start: 0, end: 0 },
+            { label: 'in 0..0.5', start: 0, end: 0.5 },
+          ],
+          contextValue,
+        },
+        {},
+        { results }
+      );
+      expect(props).toEqual({
+        items: [
+          {
+            label: 'is 0',
+            value: '0:0',
+            isRefined: false,
+            noRefinement: false,
+          },
+          {
+            label: 'in 0..0.5',
+            value: '0:0.5',
             isRefined: false,
             noRefinement: false,
           },
@@ -337,6 +369,16 @@ describe('connectNumericMenu', () => {
       expect(params.getNumericRefinements('facet')).toEqual({
         '>=': [0],
         '<=': [0],
+      });
+
+      params = connect.getSearchParameters(
+        initSP,
+        { attribute: 'facet', contextValue },
+        { multiRange: { facet: '0:0.5' } }
+      );
+      expect(params.getNumericRefinements('facet')).toEqual({
+        '>=': [0],
+        '<=': [0.5],
       });
     });
 

--- a/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
@@ -24,8 +24,8 @@ function parseItem(value) {
   }
   const [startStr, endStr] = value.split(':');
   return {
-    start: startStr.length > 0 ? parseInt(startStr, 10) : null,
-    end: endStr.length > 0 ? parseInt(endStr, 10) : null,
+    start: startStr.length > 0 ? parseFloat(startStr) : null,
+    end: endStr.length > 0 ? parseFloat(endStr) : null,
   };
 }
 


### PR DESCRIPTION
**Summary**

I was trying to figure out why our numeric menu with statically defined percentages could not filter on <= 0.5%, which it couldn't.

**Result**

Valid searches not showing up after filtering -> nowhere in the docs is it specified that numeric menu is INTEGER only. 

Simple fix: parseInt -> parseFloat. I'm not missing the radix argument, I doubt others will have different numeric bases than 10. 
