### PR TITLE
fix(maps): leave zoom in place if the bounds did not change

### DIFF
--- a/packages/react-instantsearch-dom-maps/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-maps/src/GoogleMaps.js
@@ -68,13 +68,23 @@ class GoogleMaps extends Component {
 
     if (boundingBox) {
       this.lockUserInteration(() => {
-        this.instance.fitBounds(
-          new google.maps.LatLngBounds(
-            boundingBox.southWest,
-            boundingBox.northEast
-          ),
-          boundingBoxPadding
+        const oldBounds = this.instance.getBounds();
+        const newBounds = new google.maps.LatLngBounds(
+          boundingBox.southWest,
+          boundingBox.northEast
         );
+
+        if (
+          !oldBounds ||
+          !oldBounds.Ua ||
+          !oldBounds.La ||
+          oldBounds.Ua.g !== newBounds.Ua.g ||
+          oldBounds.Ua.i !== newBounds.Ua.i ||
+          oldBounds.La.g !== newBounds.La.g ||
+          oldBounds.La.i !== newBounds.La.i
+        ) {
+          this.instance.fitBounds(newBounds, boundingBoxPadding);
+        }
       });
     } else {
       this.lockUserInteration(() => {

--- a/packages/react-instantsearch-dom-maps/src/GoogleMaps.js
+++ b/packages/react-instantsearch-dom-maps/src/GoogleMaps.js
@@ -67,27 +67,21 @@ class GoogleMaps extends Component {
     }
 
     if (boundingBox) {
-      this.lockUserInteration(() => {
+      this.lockUserInteraction(() => {
         const oldBounds = this.instance.getBounds();
+
+        // south west and north east are swapped
         const newBounds = new google.maps.LatLngBounds(
           boundingBox.southWest,
           boundingBox.northEast
         );
 
-        if (
-          !oldBounds ||
-          !oldBounds.Ua ||
-          !oldBounds.La ||
-          oldBounds.Ua.g !== newBounds.Ua.g ||
-          oldBounds.Ua.i !== newBounds.Ua.i ||
-          oldBounds.La.g !== newBounds.La.g ||
-          oldBounds.La.i !== newBounds.La.i
-        ) {
+        if (!newBounds.equals(oldBounds)) {
           this.instance.fitBounds(newBounds, boundingBoxPadding);
         }
       });
     } else {
-      this.lockUserInteration(() => {
+      this.lockUserInteraction(() => {
         this.instance.setZoom(initialZoom);
         this.instance.setCenter(initialPosition);
       });
@@ -134,7 +128,7 @@ class GoogleMaps extends Component {
     );
   };
 
-  lockUserInteration(functionThatAltersTheMapPosition) {
+  lockUserInteraction(functionThatAltersTheMapPosition) {
     this.isUserInteraction = false;
     functionThatAltersTheMapPosition();
     this.isUserInteraction = true;

--- a/packages/react-instantsearch-dom-maps/test/mockGoogleMaps.js
+++ b/packages/react-instantsearch-dom-maps/test/mockGoogleMaps.js
@@ -15,6 +15,22 @@ export class FakeOverlayView {
   }));
 }
 
+export const MockLatLngBounds = jest.fn((ne, sw) => ({
+  northEast: ne,
+  southWest: sw,
+  equals(oldBounds) {
+    if (!oldBounds) {
+      return false;
+    }
+    return (
+      oldBounds.northEast.lat === this.northEast.lat &&
+      oldBounds.northEast.lng === this.northEast.lng &&
+      oldBounds.southWest.lat === this.southWest.lat &&
+      oldBounds.southWest.lng === this.southWest.lng
+    );
+  },
+}));
+
 export const createFakeMapInstance = () => ({
   addListener: jest.fn(() => ({
     remove: jest.fn(),
@@ -23,10 +39,9 @@ export const createFakeMapInstance = () => ({
   setCenter: jest.fn(),
   getZoom: jest.fn(),
   setZoom: jest.fn(),
-  getBounds: jest.fn(() => ({
-    getNorthEast: jest.fn(),
-    getSouthWest: jest.fn(),
-  })),
+  getBounds: jest.fn(
+    () => new MockLatLngBounds({ lat: 0, lng: 0 }, { lat: 0, lng: 0 })
+  ),
   getProjection: jest.fn(() => ({
     fromPointToLatLng: jest.fn(() => ({
       lat: jest.fn(),
@@ -58,9 +73,7 @@ export const createFakeGoogleReference = ({
 } = {}) => ({
   maps: {
     LatLng: jest.fn(x => x),
-    LatLngBounds: jest.fn(() => ({
-      extend: jest.fn().mockReturnThis(),
-    })),
+    LatLngBounds: MockLatLngBounds,
     Map: jest.fn(() => mapInstance),
     Marker: jest.fn(() => markerInstance),
     ControlPosition: {


### PR DESCRIPTION
Fix map-zoom after browser-zoom

**Summary**

We encountered an issue with a map and connected list of hits. When browser zoom is set to 125% (or any other value really) and we tried to zoom in the map (with a "+" button), map did zoom in, but immediately zoomed out again. This issue happened on almost (but not every) press of the "+" button in map controls. And it happens in Chrome 90.0.4430.93 on Mac OS X, but was also reported by colleagues on Windows with the same Chrome version.


**Result**

After debugging I figured out that fitBounds() is being called multiple times after "+" button is pressed. Some of these calls were setting bounds to the same value that was already set. By adding a condition around fitBounds() to not execute it unless bounds are different from the current bounds, problem with zooming-out immediately after zooming-in is solved.

Please note that there are no additional tests for this fix.

**Guess of what the root cause is**

My guess is that the issue is related to "refine" functionality and perhaps timing.

I can imagine the scenario where first fitBounds() call with original wider bounds (before zooming in) generates a call to "refine" which in turn sends a request (1) to fetch data. Immediately after that another fitBounds() call with narrower area is executed, which in turn executes "refine" functionality again and that sends another request (2) to fetch data.

Now, because request(2) will probably have less data, it could finish earlier than request(1). So then bounds could be reset to the area before zooming-in.

This is a wild guess though and I'll let poeple who are more familiar with react-instantsearch code than me to perhaps investigate further.