### PR TITLE
fix(RefinementList): prevent searchable component to refine on empty list

### DIFF
--- a/packages/react-instantsearch-dom/src/components/List.js
+++ b/packages/react-instantsearch-dom/src/components/List.js
@@ -131,7 +131,7 @@ class List extends Component {
           onSubmit={e => {
             e.preventDefault();
             e.stopPropagation();
-            if (isFromSearch) {
+            if (isFromSearch && items.length > 0) {
               selectItem(items[0], this.resetQuery);
             }
           }}

--- a/packages/react-instantsearch-dom/src/components/__tests__/RefinementList.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/RefinementList.js
@@ -330,5 +330,34 @@ describe('RefinementList', () => {
 
       wrapper.unmount();
     });
+
+    it('hit enter on an empty search values results list should do nothing', () => {
+      const emptyRefinementList = (
+        <RefinementList
+          refine={refine}
+          searchable
+          searchForItems={searchForItems}
+          createURL={() => '#'}
+          items={[]}
+          isFromSearch={true}
+          canRefine={true}
+        />
+      );
+
+      refine.mockClear();
+      const wrapper = mount(emptyRefinementList);
+      const input = wrapper.find('input[type="search"]');
+      input.props().value = 'white';
+
+      wrapper.find('form').simulate('submit');
+
+      expect(refine.mock.calls).toHaveLength(0);
+      expect(input.props().value).toBe('white');
+
+      const selectedRefinements = wrapper.find('li');
+      expect(selectedRefinements).toHaveLength(0);
+
+      wrapper.unmount();
+    });
   });
 });


### PR DESCRIPTION
**Summary**

Prevent the `RefinementList` component to refine when no items are in the list.

**Reproduction**
- Go to https://react-instantsearch.netlify.app/storybook/iframe.html?id=refinementlist--with-search-inside-items
- Search for anything that renders the `noResults` component
- Press <kbd>enter</kbd>

The component tries to refine even though the list is empty (`Cannot read property 'value' of undefined`), forcing the user to type again to make the facets reappear.

**Result**

Pressing <kbd>enter</kbd> when the list is empty won't do anything.

**Test**

_Following [this comment](https://github.com/algolia/react-instantsearch/pull/3045#issuecomment-855806807), it seems that our storybook don't pick local changes, so you need to change the import in the story._

`yarn storybook`