### PR TITLE
feat(DynamicWidgets): add fallbackComponent

### DIFF
--- a/packages/react-instantsearch-core/src/widgets/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-core/src/widgets/DynamicWidgets.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactChild, ReactNode } from 'react';
+import React, { Fragment, ReactChild, ComponentType, ReactNode } from 'react';
 import { getDisplayName } from '../core/utils';
 import connectDynamicWidgets from '../connectors/connectDynamicWidgets';
 
@@ -23,9 +23,14 @@ function getAttribute(component: ReactChild): string | undefined {
 type DynamicWidgetsProps = {
   children: ReactNode;
   attributesToRender: string[];
+  fallbackWidget?: ComponentType<{ attribute: string }>;
 };
 
-function DynamicWidgets({ children, attributesToRender }: DynamicWidgetsProps) {
+function DynamicWidgets({
+  children,
+  attributesToRender,
+  fallbackWidget: Fallback = () => null,
+}: DynamicWidgetsProps) {
   const widgets: Map<string, ReactChild> = new Map();
 
   React.Children.forEach(children, child => {
@@ -43,7 +48,9 @@ function DynamicWidgets({ children, attributesToRender }: DynamicWidgetsProps) {
   return (
     <>
       {attributesToRender.map(attribute => (
-        <Fragment key={attribute}>{widgets.get(attribute)}</Fragment>
+        <Fragment key={attribute}>
+          {widgets.get(attribute) || <Fallback attribute={attribute} />}
+        </Fragment>
       ))}
     </>
   );

--- a/packages/react-instantsearch-core/src/widgets/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-core/src/widgets/DynamicWidgets.tsx
@@ -23,13 +23,13 @@ function getAttribute(component: ReactChild): string | undefined {
 type DynamicWidgetsProps = {
   children: ReactNode;
   attributesToRender: string[];
-  fallbackWidget?: ComponentType<{ attribute: string }>;
+  fallbackComponent?: ComponentType<{ attribute: string }>;
 };
 
 function DynamicWidgets({
   children,
   attributesToRender,
-  fallbackWidget: Fallback = () => null,
+  fallbackComponent: Fallback = () => null,
 }: DynamicWidgetsProps) {
   const widgets: Map<string, ReactChild> = new Map();
 

--- a/packages/react-instantsearch-core/src/widgets/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-core/src/widgets/__tests__/DynamicWidgets.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import {
   connectHierarchicalMenu,
+  connectMenu,
   connectPagination,
   connectRefinementList,
 } from '../..';
@@ -39,7 +40,12 @@ const RefinementList = connectRefinementList(
 );
 
 const HierarchicalMenu = connectHierarchicalMenu(
-  ({ attributes }) => `HierarchicalMenu(${attributes.join(',')})`
+  ({ attributes }) => `HierarchicalMenu([${attributes.join(', ')}])`
+);
+
+const Menu = connectMenu(
+  ({ attribute, otherProp }) =>
+    `Menu(${attribute})${otherProp ? ` ${JSON.stringify({ otherProp })}` : ''}`
 );
 
 const Pagination = connectPagination(() => {
@@ -184,7 +190,7 @@ describe('DynamicWidgets', () => {
         expect(container).toMatchInlineSnapshot(`
           <div>
             RefinementList(test1)
-            HierarchicalMenu(test2,test3)
+            HierarchicalMenu([test2, test3])
           </div>
         `);
       }
@@ -198,7 +204,7 @@ describe('DynamicWidgets', () => {
 
         expect(container).toMatchInlineSnapshot(`
           <div>
-            HierarchicalMenu(test2,test3)
+            HierarchicalMenu([test2, test3])
             RefinementList(test1)
           </div>
         `);
@@ -229,7 +235,7 @@ describe('DynamicWidgets', () => {
           // @ts-ignore resultsState in InstantSearch is typed wrongly to deal with multi-index
           resultsState={resultsState}
         >
-          <DynamicWidgets transformItems={() => ['test1', 'test3']}>
+          <DynamicWidgets transformItems={() => ['test1', 'test3', 'test5']}>
             <RefinementList attribute="test1" />
             <RefinementList attribute="test2" />
             <Panel>
@@ -237,6 +243,12 @@ describe('DynamicWidgets', () => {
             </Panel>
             <Panel>
               <RefinementList attribute="test4" />
+            </Panel>
+            <Panel>
+              <HierarchicalMenu attributes={['test5', 'test5.1']} />
+            </Panel>
+            <Panel>
+              <HierarchicalMenu attributes={['test6', 'test6.1']} />
             </Panel>
           </DynamicWidgets>
         </InstantSearch>
@@ -252,6 +264,15 @@ describe('DynamicWidgets', () => {
               class="ais-Panel-body"
             >
               RefinementList(test3)
+            </div>
+          </div>
+          <div
+            class="ais-Panel"
+          >
+            <div
+              class="ais-Panel-body"
+            >
+              HierarchicalMenu([test5, test5.1])
             </div>
           </div>
         </div>
@@ -326,6 +347,87 @@ describe('DynamicWidgets', () => {
       ).toMatchInlineSnapshot(
         `[Error: Could not find "attribute" prop for UnknownComponent.]`
       );
+    });
+
+    test('does not render attributes without widget by default', () => {
+      const searchClient = createSearchClient();
+
+      const { container } = render(
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="test"
+          // @ts-ignore resultsState in InstantSearch is typed wrongly to deal with multi-index
+          resultsState={resultsState}
+        >
+          <DynamicWidgets transformItems={() => ['test1', 'test2', 'test3']}>
+            <RefinementList attribute="test1" />
+          </DynamicWidgets>
+        </InstantSearch>
+      );
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          RefinementList(test1)
+        </div>
+      `);
+    });
+
+    test("uses fallbackWidget component to create widgets that aren't explicitly declared", () => {
+      const searchClient = createSearchClient();
+
+      const { container } = render(
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="test"
+          // @ts-ignore resultsState in InstantSearch is typed wrongly to deal with multi-index
+          resultsState={resultsState}
+        >
+          <DynamicWidgets
+            transformItems={() => ['test1', 'test2', 'test3']}
+            fallbackWidget={Menu}
+          >
+            <RefinementList attribute="test1" />
+          </DynamicWidgets>
+        </InstantSearch>
+      );
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          RefinementList(test1)
+          Menu(test2)
+          Menu(test3)
+        </div>
+      `);
+    });
+
+    test("uses fallbackWidget callback to create widgets that aren't explicitly declared", () => {
+      const searchClient = createSearchClient();
+
+      const { container } = render(
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="test"
+          // @ts-ignore resultsState in InstantSearch is typed wrongly to deal with multi-index
+          resultsState={resultsState}
+        >
+          <DynamicWidgets
+            transformItems={() => ['test1', 'test2', 'test3']}
+            fallbackWidget={({ attribute }) => (
+              <Menu attribute={attribute} otherProp />
+            )}
+          >
+            <RefinementList attribute="test1" />
+          </DynamicWidgets>
+        </InstantSearch>
+      );
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          RefinementList(test1)
+          Menu(test2) {"otherProp":true}
+          Menu(test3) {"otherProp":true}
+        </div>
+      `);
     });
   });
 });

--- a/packages/react-instantsearch-core/src/widgets/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-core/src/widgets/__tests__/DynamicWidgets.test.tsx
@@ -372,7 +372,7 @@ describe('DynamicWidgets', () => {
       `);
     });
 
-    test("uses fallbackWidget component to create widgets that aren't explicitly declared", () => {
+    test("uses fallbackComponent component to create widgets that aren't explicitly declared", () => {
       const searchClient = createSearchClient();
 
       const { container } = render(
@@ -384,7 +384,7 @@ describe('DynamicWidgets', () => {
         >
           <DynamicWidgets
             transformItems={() => ['test1', 'test2', 'test3']}
-            fallbackWidget={Menu}
+            fallbackComponent={Menu}
           >
             <RefinementList attribute="test1" />
           </DynamicWidgets>
@@ -400,7 +400,7 @@ describe('DynamicWidgets', () => {
       `);
     });
 
-    test("uses fallbackWidget callback to create widgets that aren't explicitly declared", () => {
+    test("uses fallbackComponent callback to create widgets that aren't explicitly declared", () => {
       const searchClient = createSearchClient();
 
       const { container } = render(
@@ -412,7 +412,7 @@ describe('DynamicWidgets', () => {
         >
           <DynamicWidgets
             transformItems={() => ['test1', 'test2', 'test3']}
-            fallbackWidget={({ attribute }) => (
+            fallbackComponent={({ attribute }) => (
               <Menu attribute={attribute} otherProp />
             )}
           >


### PR DESCRIPTION
This was brought up by @Shipow as a possible use case: you want to have dynamic widgets, but don't know what the facets could be in advance.

The fallbackWidget prop caters for this use case, allowing you to special-case some widgets (like hierarchical for example), but use the same widget for the rest.

```jsx
const Defaults = () => (
  <ExperimentalDynamicWidgets fallbackComponent={RefinementList}>
    <HierarchicalMenu attributes={['hierarchy', 'subHierarchy']} />
  </ExperimentalDynamicWidgets>
);

const Custom = () => (
  <ExperimentalDynamicWidgets
    fallback fallbackComponent={({ attribute }) => <CustomWidget facet={attribute} />}
  >
    <HierarchicalMenu attributes={['hierarchy', 'subHierarchy']} />
  </ExperimentalDynamicWidgets>
);
```

## Alternatives

1. fallback
2. fallbackWidget
2. fallbackComponent
3. function as a child
4. widgetComponent
5. component
6. itemComponent
7. attributeComponent