### PR TITLE
feat(facets): add a new option "facetOrdering" to Menu, RefinementList & HierarchicalMenu

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
@@ -1,4 +1,4 @@
-import { SearchParameters } from 'algoliasearch-helper';
+import { SearchResults, SearchParameters } from 'algoliasearch-helper';
 import connect from '../connectHierarchicalMenu';
 
 jest.mock('../../core/createConnector', () => x => x);
@@ -172,6 +172,158 @@ describe('connectHierarchicalMenu', () => {
         },
       ]);
       expect(props.items).toEqual(['items']);
+    });
+
+    it('facetValues results uses facetOrdering by default', () => {
+      const props = {
+        ...connect.defaultProps,
+        attributes: ['lvl0', 'lvl1'],
+        contextValue,
+      };
+      const searchState = { hierarchicalMenu: { lvl0: 'wat' } };
+      const state = connect.getSearchParameters(
+        new SearchParameters(),
+        props,
+        searchState
+      );
+      const results = new SearchResults(state, [
+        {
+          hits: [],
+          renderingContent: {
+            facetOrdering: {
+              values: {
+                lvl0: {
+                  order: ['wat'],
+                },
+                lvl1: {
+                  order: ['wat > wut'],
+                },
+              },
+            },
+          },
+          facets: {
+            lvl0: {
+              wat: 20,
+              oy: 10,
+            },
+            lvl1: {
+              'wat > wot': 15,
+              'wat > wut': 5,
+            },
+          },
+        },
+      ]);
+
+      const providedProps = connect.getProvidedProps(props, searchState, {
+        results,
+      });
+      expect(providedProps.items).toEqual([
+        {
+          label: 'wat',
+          value: undefined,
+          count: 20,
+          isRefined: true,
+          items: [
+            {
+              label: 'wut',
+              value: 'wat > wut',
+              count: 5,
+              isRefined: false,
+              items: null,
+            },
+            {
+              label: 'wot',
+              value: 'wat > wot',
+              count: 15,
+              isRefined: false,
+              items: null,
+            },
+          ],
+        },
+        {
+          label: 'oy',
+          value: 'oy',
+          count: 10,
+          isRefined: false,
+          items: null,
+        },
+      ]);
+    });
+
+    it('facetValues results does not use facetOrdering if disabled', () => {
+      const props = {
+        attributes: ['lvl0', 'lvl1'],
+        facetOrdering: false,
+        contextValue,
+      };
+      const searchState = { hierarchicalMenu: { lvl0: 'wat' } };
+      const state = connect.getSearchParameters(
+        new SearchParameters(),
+        props,
+        searchState
+      );
+      const results = new SearchResults(state, [
+        {
+          hits: [],
+          renderingContent: {
+            facetOrdering: {
+              values: {
+                lvl0: {
+                  order: ['wat'],
+                },
+                lvl1: {
+                  order: ['wat > wut'],
+                },
+              },
+            },
+          },
+          facets: {
+            lvl0: {
+              wat: 20,
+              oy: 10,
+            },
+            lvl1: {
+              'wat > wot': 15,
+              'wat > wut': 5,
+            },
+          },
+        },
+      ]);
+
+      const providedProps = connect.getProvidedProps(props, searchState, {
+        results,
+      });
+      expect(providedProps.items).toEqual([
+        {
+          label: 'oy',
+          value: 'oy',
+          count: 10,
+          isRefined: false,
+          items: null,
+        },
+        {
+          label: 'wat',
+          value: undefined,
+          count: 20,
+          isRefined: true,
+          items: [
+            {
+              label: 'wot',
+              value: 'wat > wot',
+              count: 15,
+              isRefined: false,
+              items: null,
+            },
+            {
+              label: 'wut',
+              value: 'wat > wut',
+              count: 5,
+              isRefined: false,
+              items: null,
+            },
+          ],
+        },
+      ]);
     });
 
     it('shows the effect of showMoreLimit when there is no transformItems', () => {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
@@ -307,6 +307,7 @@ describe('connectHierarchicalMenu', () => {
           count: 20,
           isRefined: true,
           items: [
+            // default ordering: alphabetical
             {
               label: 'wot',
               value: 'wat > wot',

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
@@ -1,4 +1,4 @@
-import { SearchParameters } from 'algoliasearch-helper';
+import { SearchResults, SearchParameters } from 'algoliasearch-helper';
 import connect from '../connectRefinementList';
 
 jest.mock('../../core/createConnector', () => x => x);
@@ -239,6 +239,116 @@ describe('connectRefinementList', () => {
         },
       ]);
       expect(props.isFromSearch).toBe(true);
+    });
+
+    it('facetValues have facetOrdering by default', () => {
+      const userProps = {
+        ...connect.defaultProps,
+        attribute: 'ok',
+        contextValue,
+      };
+      const searchState = {
+        refinementList: { ok: ['wat'] },
+      };
+      const parameters = connect.getSearchParameters(
+        new SearchParameters(),
+        userProps,
+        searchState
+      );
+
+      const searchResults = new SearchResults(parameters, [
+        {
+          hits: [],
+          renderingContent: {
+            facetOrdering: {
+              values: {
+                ok: {
+                  order: ['lol'],
+                },
+              },
+            },
+          },
+          facets: {
+            ok: {
+              wat: 20,
+              lol: 2000,
+            },
+          },
+        },
+      ]);
+
+      const providedProps = connect.getProvidedProps(userProps, searchState, {
+        results: searchResults,
+      });
+
+      expect(providedProps.items).toEqual([
+        {
+          count: 2000,
+          isRefined: false,
+          label: 'lol',
+          value: ['wat', 'lol'],
+        },
+        {
+          count: 20,
+          isRefined: true,
+          label: 'wat',
+          value: [],
+        },
+      ]);
+      expect(providedProps.isFromSearch).toBe(false);
+    });
+
+    it('facetValues results does not use facetOrdering if disabled', () => {
+      const userProps = { attribute: 'ok', facetOrdering: false, contextValue };
+      const searchState = {
+        refinementList: { ok: ['wat'] },
+      };
+      const parameters = connect.getSearchParameters(
+        new SearchParameters(),
+        userProps,
+        searchState
+      );
+
+      const searchResults = new SearchResults(parameters, [
+        {
+          hits: [],
+          renderingContent: {
+            facetOrdering: {
+              values: {
+                ok: {
+                  order: ['lol'],
+                },
+              },
+            },
+          },
+          facets: {
+            ok: {
+              wat: 20,
+              lol: 2000,
+            },
+          },
+        },
+      ]);
+
+      const providedProps = connect.getProvidedProps(userProps, searchState, {
+        results: searchResults,
+      });
+
+      expect(providedProps.items).toEqual([
+        {
+          count: 20,
+          isRefined: true,
+          label: 'wat',
+          value: [],
+        },
+        {
+          count: 2000,
+          isRefined: false,
+          label: 'lol',
+          value: ['wat', 'lol'],
+        },
+      ]);
+      expect(providedProps.isFromSearch).toBe(false);
     });
 
     it("calling refine updates the widget's search state", () => {

--- a/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
@@ -161,6 +161,7 @@ export default createConnector({
     limit: PropTypes.number,
     showMoreLimit: PropTypes.number,
     transformItems: PropTypes.func,
+    facetOrdering: PropTypes.bool,
   },
 
   defaultProps: {
@@ -170,10 +171,11 @@ export default createConnector({
     separator: ' > ',
     rootPath: null,
     showParentLevel: true,
+    facetOrdering: true,
   },
 
   getProvidedProps(props, searchState, searchResults) {
-    const { showMore, limit, showMoreLimit } = props;
+    const { showMore, limit, showMoreLimit, facetOrdering } = props;
     const id = getId(props);
 
     const results = getResults(searchResults, {
@@ -194,7 +196,7 @@ export default createConnector({
       };
     }
     const itemsLimit = showMore ? showMoreLimit : limit;
-    const value = results.getFacetValues(id, { sortBy });
+    const value = results.getFacetValues(id, { sortBy, facetOrdering });
     const items = value.data
       ? transformValue(value.data, props, searchState, {
           ais: props.contextValue,

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -82,12 +82,14 @@ export default createConnector({
     defaultRefinement: PropTypes.string,
     transformItems: PropTypes.func,
     searchable: PropTypes.bool,
+    facetOrdering: PropTypes.bool,
   },
 
   defaultProps: {
     showMore: false,
     limit: 10,
     showMoreLimit: 20,
+    facetOrdering: true,
   },
 
   getProvidedProps(
@@ -97,7 +99,7 @@ export default createConnector({
     meta,
     searchForFacetValuesResults
   ) {
-    const { attribute, searchable, indexContextValue } = props;
+    const { attribute, searchable, indexContextValue, facetOrdering } = props;
     const results = getResults(searchResults, {
       ais: props.contextValue,
       multiIndexContext: props.indexContextValue,
@@ -149,6 +151,7 @@ export default createConnector({
       items = results
         .getFacetValues(attribute, {
           sortBy: searchable ? undefined : defaultSortBy,
+          facetOrdering,
         })
         .map(v => ({
           label: v.name,

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -104,6 +104,7 @@ export default createConnector({
     ),
     searchable: PropTypes.bool,
     transformItems: PropTypes.func,
+    facetOrdering: PropTypes.bool,
   },
 
   defaultProps: {
@@ -111,6 +112,7 @@ export default createConnector({
     showMore: false,
     limit: 10,
     showMoreLimit: 20,
+    facetOrdering: true,
   },
 
   getProvidedProps(
@@ -120,7 +122,7 @@ export default createConnector({
     metadata,
     searchForFacetValuesResults
   ) {
-    const { attribute, searchable, indexContextValue } = props;
+    const { attribute, searchable, indexContextValue, facetOrdering } = props;
     const results = getResults(searchResults, {
       ais: props.contextValue,
       multiIndexContext: props.indexContextValue,
@@ -167,7 +169,7 @@ export default createConnector({
           count: v.count,
           isRefined: v.isRefined,
         }))
-      : results.getFacetValues(attribute, { sortBy }).map(v => ({
+      : results.getFacetValues(attribute, { sortBy, facetOrdering }).map(v => ({
           label: v.name,
           value: getValue(v.name, props, searchState, {
             ais: props.contextValue,

--- a/packages/react-instantsearch-core/src/core/indexUtils.js
+++ b/packages/react-instantsearch-core/src/core/indexUtils.js
@@ -6,6 +6,9 @@ export function getIndexId(context) {
     : context.ais.mainTargetedIndex;
 }
 
+/**
+ * @returns {import('algoliasearch-helper').SearchResults} results
+ */
 export function getResults(searchResults, context) {
   if (searchResults.results) {
     if (searchResults.results.hits) {


### PR DESCRIPTION
If `facetOrdering` is enabled (the default behaviour), before the default sortBy is used, the result from renderingContent.facetOrdering.values is first checked. If that's present, it will be used to sort the items.

You can still change that ordering afterwards with the existing transformItems, so if you are sorting in transformItems, you actually override the sorting done by facet ordering, and won't see the effect. To use facetOrdering, you thus need to remove any sorting done in transformItems.

If there is a facetOrdering present in the index, but you don't want to use it for a certain widget, you need to explicitly pass `facetOrdering: false` to the widget or connector

References:
- [RFC 45](https://github.com/algolia/instantsearch-rfcs/blob/master/accepted/flexible-facet-values.md)
- https://github.com/algolia/instantsearch.js/pull/4784
- https://github.com/algolia/algoliasearch-helper-js/pull/822

