### PR TITLE
fix(SortBy): Adds `id` prop to `SortBy`, `Select` components

### DIFF
--- a/packages/react-instantsearch-dom/src/components/Select.js
+++ b/packages/react-instantsearch-dom/src/components/Select.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 export default class Select extends Component {
   static propTypes = {
     cx: PropTypes.func.isRequired,
+    id: PropTypes.string,
     onSelect: PropTypes.func.isRequired,
     items: PropTypes.arrayOf(
       PropTypes.shape({
@@ -24,10 +25,11 @@ export default class Select extends Component {
   };
 
   render() {
-    const { cx, items, selectedItem } = this.props;
+    const { cx, id, items, selectedItem } = this.props;
 
     return (
       <select
+        id={id}
         className={cx('select')}
         value={selectedItem}
         onChange={this.onChange}

--- a/packages/react-instantsearch-dom/src/components/SortBy.js
+++ b/packages/react-instantsearch-dom/src/components/SortBy.js
@@ -8,6 +8,7 @@ const cx = createClassNames('SortBy');
 
 class SortBy extends Component {
   static propTypes = {
+    id: PropTypes.string,
     items: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string,
@@ -24,11 +25,12 @@ class SortBy extends Component {
   };
 
   render() {
-    const { items, currentRefinement, refine, className } = this.props;
+    const { id, items, currentRefinement, refine, className } = this.props;
 
     return (
       <div className={classNames(cx(''), className)}>
         <Select
+          id={id}
           cx={cx}
           items={items}
           selectedItem={currentRefinement}

--- a/packages/react-instantsearch-dom/src/components/__tests__/SortBy.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/SortBy.js
@@ -25,6 +25,26 @@ describe('SortBy', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should forward the id to Select', () => {
+    const id = 'ais-select';
+    const wrapper = mount(
+      <SortBy
+        id={id}
+        items={[
+          { value: 'index1' },
+          { value: 'index2' },
+          { value: 'index3' },
+          { value: 'index4' },
+        ]}
+        currentRefinement={'index1'}
+        refine={() => null}
+      />
+    );
+
+    const select = wrapper.find('select').getDOMNode();
+    expect(select.getAttribute('id')).toEqual(id);
+  });
+
   it('refines its value on change', () => {
     const refine = jest.fn();
     const wrapper = mount(

--- a/packages/react-instantsearch-dom/src/widgets/SortBy.js
+++ b/packages/react-instantsearch-dom/src/widgets/SortBy.js
@@ -7,6 +7,7 @@ import SortBy from '../components/SortBy';
  * @requirements Algolia handles sorting by creating replica indices. [Read more about sorting](https://www.algolia.com/doc/guides/relevance/sorting/) on
  * the Algolia website.
  * @kind widget
+ * @propType {string} id - The id of the select input
  * @propType {{value: string, label: string}[]} items - The list of indexes to search in.
  * @propType {string} defaultRefinement - The default selected index.
  * @propType {function} [transformItems] - Function to modify the items being displayed, e.g. for filtering or sorting them. Takes an items as parameter and expects it back in return.

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -9,6 +9,7 @@ stories
   .add('default', () => (
     <WrapWithHits linkedStoryGroup="SortBy.stories.js">
       <SortBy
+        id="sort-by"
         items={[
           { value: 'instant_search', label: 'Featured' },
           { value: 'instant_search_price_asc', label: 'Price asc.' },

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -9,7 +9,6 @@ stories
   .add('default', () => (
     <WrapWithHits linkedStoryGroup="SortBy.stories.js">
       <SortBy
-        id="sort-by"
         items={[
           { value: 'instant_search', label: 'Featured' },
           { value: 'instant_search_price_asc', label: 'Price asc.' },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR adds an `id` prop to the `SortBy` component, in order to associate the element with a `label`. To accomplish this, the PR also adds an `id` prop to the `Select` component

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

1. Ran `npm link` in `packages/react-instantsearch-dom` and root directory to sync package update
     - Is there a better way to do this? `yarn watch` wasn't updating the component from the package
2. Added an `id` to the default `SortBy` Storybook story
3. Confirmed the `id` prop appears in DOM

<img width="1383" alt="Screen Shot 2021-06-25 at 2 11 47 PM" src="https://user-images.githubusercontent.com/17488657/123468086-4a7b5a80-d5bf-11eb-9cca-bdeb94c8247c.png">


<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

**Questions**

- Where do we update the documentation for `SortBy` on the Algolia website to include the new `id` prop?