### PR TITLE
fix(HitsPerPage): Adds `id` prop to `HitsPerPage`, `Select` components

### DIFF
--- a/packages/react-instantsearch-dom/src/components/HitsPerPage.js
+++ b/packages/react-instantsearch-dom/src/components/HitsPerPage.js
@@ -8,6 +8,7 @@ const cx = createClassNames('HitsPerPage');
 
 class HitsPerPage extends Component {
   static propTypes = {
+    id: PropTypes.string,
     items: PropTypes.arrayOf(
       PropTypes.shape({
         value: PropTypes.number.isRequired,
@@ -24,11 +25,12 @@ class HitsPerPage extends Component {
   };
 
   render() {
-    const { items, currentRefinement, refine, className } = this.props;
+    const { id, items, currentRefinement, refine, className } = this.props;
 
     return (
       <div className={classNames(cx(''), className)}>
         <Select
+          id={id}
           onSelect={refine}
           selectedItem={currentRefinement}
           items={items}

--- a/packages/react-instantsearch-dom/src/components/Select.js
+++ b/packages/react-instantsearch-dom/src/components/Select.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 export default class Select extends Component {
   static propTypes = {
     cx: PropTypes.func.isRequired,
+    id: PropTypes.string,
     onSelect: PropTypes.func.isRequired,
     items: PropTypes.arrayOf(
       PropTypes.shape({
@@ -24,10 +25,11 @@ export default class Select extends Component {
   };
 
   render() {
-    const { cx, items, selectedItem } = this.props;
+    const { cx, id, items, selectedItem } = this.props;
 
     return (
       <select
+        id={id}
         className={cx('select')}
         value={selectedItem}
         onChange={this.onChange}

--- a/packages/react-instantsearch-dom/src/components/__tests__/HitsPerPage.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/HitsPerPage.js
@@ -52,6 +52,27 @@ describe('HitsPerPage', () => {
         .toJSON()
     ).toMatchSnapshot());
 
+  it('should forward the id to Select', () => {
+    const id = 'ais-select';
+    const wrapper = mount(
+      <HitsPerPage
+        id={id}
+        createURL={() => '#'}
+        items={[
+          { value: 2, label: '2 hits per page' },
+          { value: 4, label: '4 hits per page' },
+          { value: 6, label: '6 hits per page' },
+          { value: 8, label: '8 hits per page' },
+        ]}
+        refine={() => null}
+        currentRefinement={2}
+      />
+    );
+
+    const selectedValue = wrapper.find('select').getDOMNode();
+    expect(selectedValue.getAttribute('id')).toEqual(id);
+  });
+
   it('refines its value on change', () => {
     const refine = jest.fn();
     const wrapper = mount(

--- a/packages/react-instantsearch-dom/src/widgets/HitsPerPage.js
+++ b/packages/react-instantsearch-dom/src/widgets/HitsPerPage.js
@@ -10,6 +10,7 @@ import HitsPerPage from '../components/HitsPerPage';
  *
  * @name HitsPerPage
  * @kind widget
+ * @propType {string} id - The id of the select input
  * @propType {{value: number, label: string}[]} items - List of available options.
  * @propType {number} defaultRefinement - The number of items selected by default
  * @propType {function} [transformItems] - Function to modify the items being displayed, e.g. for filtering or sorting them. Takes an items as parameter and expects it back in return.


### PR DESCRIPTION
**Summary**

This PR adds an `id` prop to the `HitsPerPage` component, in order to associate the element with a `label`. To accomplish this, the PR also adds an `id` prop to the `Select` component

This PR is a continuation of the work from #3068 

**Result**

1. Ran `npm link` in `packages/react-instantsearch-dom` and root directory to sync package update
2. Added an `id` to the default `HitsPerPage` Storybook story
3. Confirmed the `id` prop appears in DOM

<img width="955" alt="Screen Shot 2021-06-30 at 9 07 09 AM" src="https://user-images.githubusercontent.com/17488657/123965570-93962a80-d982-11eb-99dd-a102a39c50d1.png">
