### PR TITLE
fix(SearchBox): Adds `inputId` prop to `SearchBox`

### DIFF
--- a/packages/react-instantsearch-dom/src/components/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/SearchBox.js
@@ -86,6 +86,7 @@ class SearchBox extends Component {
       PropTypes.func,
       PropTypes.exact({ current: PropTypes.object }),
     ]),
+    inputId: PropTypes.string,
   };
 
   static defaultProps = {
@@ -221,6 +222,7 @@ class SearchBox extends Component {
   render() {
     const {
       className,
+      inputId,
       translate,
       autoFocus,
       loadingIndicator,
@@ -257,6 +259,7 @@ class SearchBox extends Component {
         >
           <input
             ref={this.onInputMount}
+            id={inputId}
             type="search"
             placeholder={translate('placeholder')}
             autoFocus={autoFocus}

--- a/packages/react-instantsearch-dom/src/components/__tests__/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/components/__tests__/SearchBox.js
@@ -25,6 +25,14 @@ describe('SearchBox', () => {
     instance.unmount();
   });
 
+  it('applies its default props with custom inputId', () => {
+    const inputId = 'search-box';
+    const wrapper = mount(<SearchBox inputId={inputId} refine={() => null} />);
+
+    const input = wrapper.find('input').getDOMNode();
+    expect(input.getAttribute('id')).toEqual(inputId);
+  });
+
   it('transfers the autoFocus prop to the underlying input element', () => {
     const instance = renderer.create(
       <SearchBox refine={() => null} autoFocus />

--- a/packages/react-instantsearch-dom/src/widgets/SearchBox.js
+++ b/packages/react-instantsearch-dom/src/widgets/SearchBox.js
@@ -15,6 +15,7 @@ import SearchBox from '../components/SearchBox';
  * @propType {node} [reset] - Change the apparence of the default reset button (cross).
  * @propType {node} [loadingIndicator] - Change the apparence of the default loading indicator (spinning circle).
  * @propType {string} [defaultRefinement] - Provide default refinement value when component is mounted.
+ * @propType {string} [inputId] - The id of the search input
  * @propType {boolean} [showLoadingIndicator=false] - Display that the search is loading. This only happens after a certain amount of time to avoid a blinking effect. This timer can be configured with `stalledSearchDelay` props on <InstantSearch>. By default, the value is 200ms.
  * @themeKey ais-SearchBox - the root div of the widget
  * @themeKey ais-SearchBox-form - the wrapping form


### PR DESCRIPTION
**Summary**

This PR adds an `inputId` prop to the `SearchBox` component, in order to associate the element with a `label`

This PR is a continuation of the work from #3068 

**Result**

1. Ran `npm link` in `packages/react-instantsearch-dom` and root directory to sync package update
2. Added an `inputId` to the default `SearchBox` Storybook story
3. Confirmed the `inputId` prop appears in DOM as an `id` attribute on `input`

<img width="1065" alt="Screen Shot 2021-06-30 at 9 12 42 AM" src="https://user-images.githubusercontent.com/17488657/123966335-554d3b00-d983-11eb-8dc2-fa950cc6c60a.png">
