### PR TITLE
fix(server side rendering): return a value from mock currentRefinement/metadata

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -388,7 +388,7 @@ describe('createInstantSearchManager', () => {
   });
 
   describe('metadata hydration', () => {
-    test.only('replaces value with a function returning empty search state', () => {
+    test('replaces value with a function returning empty search state', () => {
       const ism = createInstantSearchManager({
         indexName: 'index',
         searchClient: createSearchClient(),

--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.js
@@ -319,7 +319,7 @@ describe('createInstantSearchManager', () => {
     });
   });
 
-  describe('results hydratation', () => {
+  describe('results hydration', () => {
     it('initializes the manager with a single index hydrated results', () => {
       const ism = createInstantSearchManager({
         indexName: 'index',
@@ -384,6 +384,55 @@ describe('createInstantSearchManager', () => {
       expect(ism.store.getState().results.index1).toBeInstanceOf(SearchResults);
       expect(ism.store.getState().results.index2.query).toBe('query2');
       expect(ism.store.getState().results.index2).toBeInstanceOf(SearchResults);
+    });
+  });
+
+  describe('metadata hydration', () => {
+    test.only('replaces value with a function returning empty search state', () => {
+      const ism = createInstantSearchManager({
+        indexName: 'index',
+        searchClient: createSearchClient(),
+        resultsState: {
+          metadata: [
+            { stuff: 1, items: [{ stuff: 2, items: [{ stuff: 3 }] }] },
+          ],
+          rawResults: [
+            {
+              index: 'indexName',
+              query: 'query',
+            },
+          ],
+          state: {
+            index: 'indexName',
+            query: 'query',
+          },
+        },
+      });
+
+      const hydratedMetadata = ism.store.getState().metadata;
+
+      expect(hydratedMetadata).toEqual([
+        {
+          value: expect.any(Function),
+          stuff: 1,
+          items: [
+            {
+              value: expect.any(Function),
+              stuff: 2,
+              items: [
+                {
+                  value: expect.any(Function),
+                  stuff: 3,
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      expect(hydratedMetadata[0].value()).toEqual({});
+      expect(hydratedMetadata[0].items[0].value()).toEqual({});
+      expect(hydratedMetadata[0].items[0].items[0].value()).toEqual({});
     });
   });
 

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -618,17 +618,17 @@ function hydrateMetadata(resultsState) {
 
   // add a value noop, which gets replaced once the widgets are mounted
   return resultsState.metadata.map(datum => ({
-    value() {},
+    value: () => ({}),
     ...datum,
     items:
       datum.items &&
       datum.items.map(item => ({
-        value() {},
+        value: () => ({}),
         ...item,
         items:
           item.items &&
           item.items.map(nestedItem => ({
-            value() {},
+            value: () => ({}),
             ...nestedItem,
           })),
       })),


### PR DESCRIPTION
This is required, as transitionState gets called with the return of value in a createURL. 

Without this fix, an error happens if there is:
-  dynamic configure
- currentRefinements + createURL
- something is refined
- SSR
- first client render

The error is `TypeError: Cannot read properties of undefined (reading 'configure')` as the transitionState argument is given the result of createURL/currentRefinements, but that's undefined instead of an object. The state isn't actually transitioned, so an empty object works as a solution.

Here's a sandbox showing the existing state: https://codesandbox.io/s/charming-williamson-bifbf?file=/components/app.js:1158-1167
And that same sandbox fixed in this PR: https://codesandbox.io/s/bold-brook-gdyri