### PR TITLE
feat(hooks): introduce `useConnector`

### DIFF
--- a/packages/react-instantsearch-core-next/package.json
+++ b/packages/react-instantsearch-core-next/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "algoliasearch-helper": "^3.5.3",
+    "dequal": "^2.0.0",
     "instantsearch.js": "^4.28.0"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-core-next/src/InstantSearch.tsx
+++ b/packages/react-instantsearch-core-next/src/InstantSearch.tsx
@@ -6,7 +6,7 @@ import { useInstantSearch } from './useInstantSearch';
 
 import type { UseInstantSearchProps } from './useInstantSearch';
 
-type InstantSearchProps = UseInstantSearchProps & {
+export type InstantSearchProps = UseInstantSearchProps & {
   children?: React.ReactNode;
 };
 

--- a/packages/react-instantsearch-core-next/src/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-core-next/src/__tests__/InstantSearch.test.tsx
@@ -81,7 +81,7 @@ describe('InstantSearch', () => {
 
     render(<InstantSearch indexName="indexName" searchClient={searchClient} />);
 
-    // @TODO once props are stable:
+    // @TODO: figure out why it's called 6 times instead of 3.
     // expect(searchClient.addAlgoliaAgent).toHaveBeenCalledTimes(3);
     expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
       `react (${ReactVersion})`

--- a/packages/react-instantsearch-core-next/src/__tests__/useConnector.test.tsx
+++ b/packages/react-instantsearch-core-next/src/__tests__/useConnector.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+
+import { createSearchClient } from '../../../../test/mock';
+import { InstantSearch } from '../InstantSearch';
+import { useConnector } from '../useConnector';
+import { noop } from '../utils';
+
+import type { Connector } from 'instantsearch.js';
+
+type CustomSearchBoxConnector = {
+  $$type: 'test.searchBox';
+  renderState: {
+    query: string;
+  };
+};
+
+const connectCustomSearchBox: Connector<
+  CustomSearchBoxConnector,
+  Record<string, never>
+> =
+  (renderFn, unmountFn = noop) =>
+  (widgetParams) => ({
+    $$type: 'test.searchBox',
+    init({ instantSearchInstance }) {
+      renderFn(
+        { query: 'query at init', instantSearchInstance, widgetParams },
+        true
+      );
+    },
+    render({ instantSearchInstance }) {
+      renderFn({ query: 'query', instantSearchInstance, widgetParams }, false);
+    },
+    dispose() {
+      unmountFn();
+    },
+  });
+
+describe('useConnector', () => {
+  test('returns the connector render state', async () => {
+    const searchClient = createSearchClient();
+    const wrapper = ({ children }) => (
+      <InstantSearch searchClient={searchClient} indexName="indexName">
+        {children}
+      </InstantSearch>
+    );
+    const { result, waitForNextUpdate } = renderHook(
+      () =>
+        useConnector(
+          connectCustomSearchBox,
+          {},
+          {
+            query: '',
+          }
+        ),
+      { wrapper }
+    );
+
+    // Initial render state
+    expect(result.current).toEqual({ query: '' });
+
+    await waitForNextUpdate();
+
+    // It should never be "query at init" because we skip the `init` step.
+    expect(result.current).not.toEqual({ query: 'query at init' });
+
+    // Render state provided by InstantSearch Core during `render`.
+    expect(result.current).toEqual({ query: 'query' });
+  });
+});

--- a/packages/react-instantsearch-core-next/src/index.ts
+++ b/packages/react-instantsearch-core-next/src/index.ts
@@ -1,3 +1,4 @@
 export { default as version } from './version';
 export * from './InstantSearch';
 export * from './SearchIndex';
+export * from './useConnector';

--- a/packages/react-instantsearch-core-next/src/useConnector.ts
+++ b/packages/react-instantsearch-core-next/src/useConnector.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+import { useIndexContext } from './useIndexContext';
+import { useStableValue } from './useStableValue';
+
+import type {
+  Connector,
+  WidgetDescription,
+  WidgetRenderState,
+} from 'instantsearch.js';
+
+type ConnectorState<TProps> = Omit<
+  WidgetRenderState<any, TProps>,
+  'widgetParams'
+>;
+
+export function useConnector<
+  TProps extends Record<string, unknown>,
+  TState extends ConnectorState<TProps>,
+  TDescription extends WidgetDescription
+>(
+  connector: Connector<TDescription, TProps>,
+  props: TProps = {} as TProps,
+  initialState: TState | (() => TState)
+) {
+  const parentIndex = useIndexContext();
+  const [state, setState] = useState(initialState);
+  const stableProps = useStableValue(props);
+
+  useEffect(() => {
+    const createWidget = connector((connectorState, isFirstRender) => {
+      // We skip the `init` widget render because:
+      // - We rely on a computed initial state before the InstantSearch Core lifecycle starts.
+      // - It prevents UI flashes when updating the widget props.
+      if (isFirstRender) {
+        return;
+      }
+
+      const { instantSearchInstance, widgetParams, ...renderState } =
+        connectorState;
+
+      setState(renderState as ConnectorState<TProps>);
+    });
+    const widget = createWidget(stableProps);
+
+    parentIndex.addWidgets([widget]);
+
+    return () => {
+      parentIndex.removeWidgets([widget]);
+    };
+  }, [connector, parentIndex, stableProps]);
+
+  return state;
+}

--- a/packages/react-instantsearch-core-next/src/useIndex.ts
+++ b/packages/react-instantsearch-core-next/src/useIndex.ts
@@ -2,6 +2,7 @@ import index from 'instantsearch.js/es/widgets/index/index';
 import { useEffect, useMemo } from 'react';
 
 import { useIndexContext } from './useIndexContext';
+import { useStableValue } from './useStableValue';
 
 import type { IndexWidgetParams } from 'instantsearch.js/es/widgets/index/index';
 
@@ -9,7 +10,8 @@ export type UseIndexProps = IndexWidgetParams;
 
 export function useIndex(props: UseIndexProps) {
   const parentIndex = useIndexContext();
-  const indexWidget = useMemo(() => index(props), [props]);
+  const stableProps = useStableValue(props);
+  const indexWidget = useMemo(() => index(stableProps), [stableProps]);
 
   useEffect(() => {
     parentIndex.addWidgets([indexWidget]);

--- a/packages/react-instantsearch-core-next/src/useInstantSearch.ts
+++ b/packages/react-instantsearch-core-next/src/useInstantSearch.ts
@@ -1,6 +1,7 @@
 import instantsearch from 'instantsearch.js';
 import { useEffect, useMemo, version as ReactVersion } from 'react';
 
+import { useStableValue } from './useStableValue';
 import version from './version';
 
 import type { InstantSearchOptions } from 'instantsearch.js';
@@ -8,17 +9,20 @@ import type { InstantSearchOptions } from 'instantsearch.js';
 export type UseInstantSearchProps = InstantSearchOptions;
 
 export function useInstantSearch(props: UseInstantSearchProps) {
-  const search = useMemo(() => instantsearch(props), [props]);
+  const stableProps = useStableValue(props);
+  const search = useMemo(() => instantsearch(stableProps), [stableProps]);
 
   useEffect(() => {
-    if (typeof props.searchClient.addAlgoliaAgent === 'function') {
-      props.searchClient.addAlgoliaAgent(`react (${ReactVersion})`);
-      props.searchClient.addAlgoliaAgent(`react-instantsearch (${version})`);
-      props.searchClient.addAlgoliaAgent(
+    if (typeof stableProps.searchClient.addAlgoliaAgent === 'function') {
+      stableProps.searchClient.addAlgoliaAgent(`react (${ReactVersion})`);
+      stableProps.searchClient.addAlgoliaAgent(
+        `react-instantsearch (${version})`
+      );
+      stableProps.searchClient.addAlgoliaAgent(
         `react-instantsearch-hooks (${version})`
       );
     }
-  }, [props.searchClient]);
+  }, [stableProps.searchClient]);
 
   useEffect(() => {
     search.start();

--- a/packages/react-instantsearch-core-next/src/useStableValue.ts
+++ b/packages/react-instantsearch-core-next/src/useStableValue.ts
@@ -1,0 +1,15 @@
+import { dequal } from 'dequal/lite';
+import { useEffect, useState } from 'react';
+
+export function useStableValue<TValue>(value: TValue) {
+  const [stableValue, setStableValue] = useState<TValue>(() => value);
+
+  useEffect(() => {
+    if (!dequal(stableValue, value)) {
+      setStableValue(value);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  return stableValue;
+}

--- a/packages/react-instantsearch-core-next/src/utils/index.ts
+++ b/packages/react-instantsearch-core-next/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './noop';

--- a/packages/react-instantsearch-core-next/src/utils/noop.ts
+++ b/packages/react-instantsearch-core-next/src/utils/noop.ts
@@ -1,0 +1,1 @@
+export const noop = (..._args: any[]) => {};

--- a/test/utils/createInstantSearchTestWrapper.tsx
+++ b/test/utils/createInstantSearchTestWrapper.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { InstantSearchProps } from '../../packages/react-instantsearch-core-next/src';
+import { InstantSearch } from '../../packages/react-instantsearch-core-next/src';
+
+import { createSearchClient } from '../mock';
+
+export function createInstantSearchTestWrapper(
+  props?: Partial<InstantSearchProps>
+) {
+  const searchClient = createSearchClient();
+  const wrapper = ({ children }) => (
+    <InstantSearch searchClient={searchClient} indexName="indexName" {...props}>
+      {children}
+    </InstantSearch>
+  );
+
+  return wrapper;
+}

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './createInstantSearchTestWrapper';
 export * from './runAllMicroTasks';
 export * from './wait';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7783,6 +7783,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dequal@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"


### PR DESCRIPTION
## Description

This introduces `useConnector` which creates the bridge between InstantSearch.js connectors and this new React InstantSearch version.

This is the bare minimum for users to start using this version.

## Usage

Here's a basic version of a `useSearchBox` hook, as we'll provide in next PRs:

```tsx
import connectSearchBox from 'instantsearch.js/es/connectors/search-box/connectSearchBox';
import { useConnector } from 'react-instantsearch-hooks';

function useSearchBox(props) {
  return useConnector(connectSearchBox, props, {
    query: '',
    refine: () => {},
    clear: () => {},
    isSearchStalled: false,
  });
}

function SearchBox(props) {
  const { query, refine, clear, isSearchStalled } = useSearchBox(props);

  return <div>{/* ... */}</div>;
}
```

In our implementation, we'll rely on the `helper` state to compute the initial state.