### PR TITLE
feat(hooks): introduce `useRefinementList`

### DIFF
--- a/packages/react-instantsearch-hooks/src/__tests__/useRefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/useRefinementList.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { createInstantSearchTestWrapper } from '../../../../test/utils';
+import { useRefinementList } from '../useRefinementList';
+
+describe('useRefinementList', () => {
+  test('returns the connector render state', async () => {
+    const wrapper = createInstantSearchTestWrapper();
+    const { result, waitForNextUpdate } = renderHook(
+      () => useRefinementList({ attribute: 'attribute' }),
+      {
+        wrapper,
+      }
+    );
+
+    // Initial render state from manual `getWidgetRenderState`
+    expect(result.current).toEqual({
+      canRefine: false,
+      canToggleShowMore: false,
+      createURL: expect.any(Function),
+      hasExhaustiveItems: true,
+      isFromSearch: false,
+      isShowingMore: false,
+      items: [],
+      refine: expect.any(Function),
+      searchForItems: expect.any(Function),
+      sendEvent: expect.any(Function),
+      toggleShowMore: expect.any(Function),
+    });
+
+    await waitForNextUpdate();
+
+    // InstantSearch.js state from the `render` lifecycle step
+    expect(result.current).toEqual({
+      canRefine: false,
+      canToggleShowMore: false,
+      createURL: expect.any(Function),
+      hasExhaustiveItems: true,
+      isFromSearch: false,
+      isShowingMore: false,
+      items: [],
+      refine: expect.any(Function),
+      searchForItems: expect.any(Function),
+      sendEvent: expect.any(Function),
+      toggleShowMore: expect.any(Function),
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks/src/index.ts
+++ b/packages/react-instantsearch-hooks/src/index.ts
@@ -3,4 +3,5 @@ export * from './InstantSearch';
 export * from './SearchIndex';
 export * from './useConnector';
 export * from './useHits';
+export * from './useRefinementList';
 export * from './useSearchBox';

--- a/packages/react-instantsearch-hooks/src/useRefinementList.ts
+++ b/packages/react-instantsearch-hooks/src/useRefinementList.ts
@@ -1,0 +1,17 @@
+import connectRefinementList from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
+
+import { useConnector } from './useConnector';
+
+import type {
+  RefinementListConnectorParams,
+  RefinementListWidgetDescription,
+} from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
+
+export type UseRefinementListProps = RefinementListConnectorParams;
+
+export function useRefinementList(props: UseRefinementListProps) {
+  return useConnector<
+    RefinementListConnectorParams,
+    RefinementListWidgetDescription
+  >(connectRefinementList, props);
+}


### PR DESCRIPTION
This introduces the `useRefinementList` hook that is a bridge for `connectRefinementList`.

I added this official hook to validate the `useConnector` approach and as a convenience to use in our upcoming tests.