### PR TITLE
fix(hooks): trigger single network request on load

### DIFF
--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -42,7 +42,7 @@
     "@babel/runtime": "^7.1.2",
     "algoliasearch-helper": "^3.5.3",
     "dequal": "^2.0.0",
-    "instantsearch.js": "^4.28.0"
+    "instantsearch.js": "^4.31.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.1 < 5",

--- a/packages/react-instantsearch-hooks/src/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/InstantSearch.test.tsx
@@ -2,11 +2,16 @@ import { render } from '@testing-library/react';
 import React, { version as ReactVersion } from 'react';
 
 import { createSearchClient } from '../../../../test/mock';
+import { wait } from '../../../../test/utils';
 import { IndexContext } from '../IndexContext';
 import { InstantSearch } from '../InstantSearch';
 import { InstantSearchContext } from '../InstantSearchContext';
+import { Index } from '../SearchIndex';
+import { useRefinementList } from '../useRefinementList';
+import { useSearchBox } from '../useSearchBox';
 import version from '../version';
 
+import type { UseRefinementListProps } from '../useRefinementList';
 import type { InstantSearch as InstantSearchType } from 'instantsearch.js';
 import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
 
@@ -128,6 +133,35 @@ describe('InstantSearch', () => {
     unmount();
 
     expect(searchContext!.started).toEqual(false);
+  });
+
+  test('triggers a single network request on mount with widgets', async () => {
+    const searchClient = createSearchClient();
+
+    function SearchBox() {
+      useSearchBox();
+
+      return null;
+    }
+
+    function RefinementList(props: UseRefinementListProps) {
+      useRefinementList(props);
+
+      return null;
+    }
+
+    render(
+      <InstantSearch indexName="indexName" searchClient={searchClient}>
+        <SearchBox />
+        <Index indexName="subIndexName">
+          <RefinementList attribute="brand" />
+        </Index>
+      </InstantSearch>
+    );
+
+    await wait(0);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
   });
 
   describe('experimental warning', () => {

--- a/packages/react-instantsearch-hooks/src/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/useConnector.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useLayoutEffect, useMemo, useState } from 'react';
 
 import { useIndexContext } from './useIndexContext';
 import { useInstantSearchContext } from './useInstantSearchContext';
@@ -80,7 +80,9 @@ export function useConnector<
     return {};
   });
 
-  useEffect(() => {
+  // We use a layout effect to add the widget to the index before the index
+  // renders, otherwise it triggers 2 network requests.
+  useLayoutEffect(() => {
     parentIndex.addWidgets([widget]);
 
     return () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12340,10 +12340,10 @@ instantsearch.css@7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-instantsearch.js@^4.28.0:
-  version "4.30.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.30.0.tgz#84d45f28ea1735fce14da94dc6a2128a7140e748"
-  integrity sha512-UTtDbAqaw9l0Zs+L/veYwtllqeeqc8WyPcXWrQxnLa+zAgS+9wj+kjKsLHlQF13EBuSp5szPoOQWugKE6Yoe2w==
+instantsearch.js@^4.31.0:
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.31.0.tgz#dad6b38fb6df1db7017cda4598682d886aaa32cc"
+  integrity sha512-2FtB83imhnGW3xyYY/HOWqN+jP5Dei6kF2Be9nyQGsjocptQcX+uCAzsplWQ8XS7i/5P8ZAnUNp+S1eiqW52vw==
   dependencies:
     "@types/google.maps" "^3.45.3"
     "@types/hogan.js" "^3.0.0"


### PR DESCRIPTION
Prior to this change, using `InstantSearch` and a widget with `useConnector` triggered two network requests because InstantSearch.js called the `search` method on start (which directly triggers a network request), and then scheduled a search when a widget mounted.

Updating to InstantSearch.js [4.31.0](https://github.com/algolia/instantsearch.js/releases/tag/v4.31.0) which now defers the initial search in algolia/instantsearch.js#4925 via scheduling a search instead of triggering a search enables us to trigger a single network request on load in combination with `useLayoutEffect`.

We need to use `useLayoutEffect` in the `useConnector` Hook to render the widgets at the same time as their parent index, otherwise we still get 2 network requests.