### PR TITLE
feat(hooks): expose `displayName` on Contexts

### DIFF
--- a/packages/react-instantsearch-hooks/src/IndexContext.ts
+++ b/packages/react-instantsearch-hooks/src/IndexContext.ts
@@ -3,3 +3,7 @@ import { createContext } from 'react';
 import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
 
 export const IndexContext = createContext<IndexWidget | null>(null);
+
+if (__DEV__) {
+  IndexContext.displayName = 'Index';
+}

--- a/packages/react-instantsearch-hooks/src/InstantSearchContext.ts
+++ b/packages/react-instantsearch-hooks/src/InstantSearchContext.ts
@@ -3,3 +3,7 @@ import { createContext } from 'react';
 import type { InstantSearch } from 'instantsearch.js';
 
 export const InstantSearchContext = createContext<InstantSearch | null>(null);
+
+if (__DEV__) {
+  InstantSearchContext.displayName = 'InstantSearch';
+}

--- a/packages/react-instantsearch-hooks/src/__tests__/IndexContext.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/IndexContext.test.tsx
@@ -1,0 +1,7 @@
+import { IndexContext } from '../IndexContext';
+
+describe('IndexContext', () => {
+  test('exposes a displayName', () => {
+    expect(IndexContext.displayName).toEqual('Index');
+  });
+});

--- a/packages/react-instantsearch-hooks/src/__tests__/InstantSearchContext.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/InstantSearchContext.test.tsx
@@ -1,0 +1,7 @@
+import { InstantSearchContext } from '../InstantSearchContext';
+
+describe('InstantSearchContext', () => {
+  test('exposes a displayName', () => {
+    expect(InstantSearchContext.displayName).toEqual('InstantSearch');
+  });
+});


### PR DESCRIPTION
This exposes a [`Context.displayName`](https://reactjs.org/docs/context.html#contextdisplayname) on our Context Providers so that they display properly on React DevTools.

**Before**

<img width="292" alt="before" src="https://user-images.githubusercontent.com/6137112/137873346-9d96e411-b866-458e-9cf6-ebce4edd5976.png">



**After**

<img width="292" alt="after" src="https://user-images.githubusercontent.com/6137112/137873214-bac8d2ee-4217-4c2a-bdf4-e6462d305778.png">


