### PR TITLE
fix(hooks): type `useConnector` return as render state

### DIFF
--- a/packages/react-instantsearch-hooks/src/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/useConnector.ts
@@ -10,7 +10,10 @@ import type { Connector, WidgetDescription } from 'instantsearch.js';
 export function useConnector<
   TProps extends Record<string, unknown>,
   TDescription extends WidgetDescription
->(connector: Connector<TDescription, TProps>, props: TProps = {} as TProps) {
+>(
+  connector: Connector<TDescription, TProps>,
+  props: TProps = {} as TProps
+): TDescription['renderState'] {
   const search = useInstantSearchContext();
   const parentIndex = useIndexContext();
   const stableProps = useStableValue(props);
@@ -35,7 +38,7 @@ export function useConnector<
     return createWidget(stableProps);
   }, [stableProps, connector]);
 
-  const [state, setState] = useState(() => {
+  const [state, setState] = useState<TDescription['renderState']>(() => {
     if (widget.getWidgetRenderState) {
       // The helper exists because we've started InstantSearch.
       const helper = parentIndex.getHelper()!;


### PR DESCRIPTION
This types the return of `useConnector` as the widget's render state.

![image](https://user-images.githubusercontent.com/6137112/137893234-51641434-bbbb-4bcd-a3b4-eeae90880b46.png)
