### PR TITLE
fix(release): publish packages as public

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -58,6 +58,7 @@ module.exports = {
   pullRequestTeamReviewers: ['instantsearch-for-websites'],
   buildCommand: ({ version }) =>
     `NODE_ENV=production VERSION=${version} yarn build`,
+  publishCommand: ({ tag }) => `yarn publish --access public --tag ${tag}`,
   afterPublish: async ({ exec, version }) => {
     await waitUntil(async () => {
       const latestVersion = await getLatestVersion('react-instantsearch', {


### PR DESCRIPTION
This updates the Ship.js command to publish our new monorepo packages as public. We use the same command in [Autocomplete](https://github.com/algolia/autocomplete/blob/e019b4dd7968f23ba500235e866e74f05fbed9de/ship.config.js#L20-L22) and [Search Client](https://github.com/algolia/algoliasearch-client-javascript/blob/master/ship.config.js#L19-L21).