### PR TITLE
docs(changelog): update GitHub compare links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [6.13.0](https://github.com/algolia/react-instantsearch/compare/v6.11.0...v6.13.0) (2021-10-19)
+# [6.13.0](https://github.com/algolia/react-instantsearch/compare/v6.12.1...v6.13.0) (2021-10-19)
 
 This is the initial release of the experimental **React InstantSearch Hooks** package. Check out the [**Getting Started**](https://github.com/algolia/react-instantsearch/blob/e8d72cb1c7c45300ef7c273f1f163beb6dc57622/packages/react-instantsearch-hooks/README.md#getting-started) guide.
 
@@ -24,7 +24,7 @@ This is the initial release of the experimental **React InstantSearch Hooks** pa
 
 
 
-## [6.12.1](https://github.com/algolia/react-instantsearch/compare/v6.11.0...v6.12.1) (2021-08-02)
+## [6.12.1](https://github.com/algolia/react-instantsearch/compare/v6.12.0...v6.12.1) (2021-08-02)
 
 
 ### Bug Fixes
@@ -33,7 +33,7 @@ This is the initial release of the experimental **React InstantSearch Hooks** pa
 
 
 
-# [6.12.0](https://github.com/algolia/react-instantsearch/compare/v6.11.0...v6.12.0) (2021-07-06)
+# [6.12.0](https://github.com/algolia/react-instantsearch/compare/v6.11.2...v6.12.0) (2021-07-06)
 
 
 ### Bug Fixes
@@ -51,7 +51,7 @@ This is the initial release of the experimental **React InstantSearch Hooks** pa
 
 
 
-## [6.11.2](https://github.com/algolia/react-instantsearch/compare/v6.11.0...v6.11.2) (2021-06-28)
+## [6.11.2](https://github.com/algolia/react-instantsearch/compare/v6.11.1...v6.11.2) (2021-06-28)
 
 
 ### Bug Fixes


### PR DESCRIPTION
Our CI GitHub token had missing permission since v6.11.1 so the releasing process has [been half broken since then](https://app.circleci.com/pipelines/github/algolia/react-instantsearch/1490/workflows/f936b9b9-7173-4a2c-a352-5d8bb3a375c4/jobs/47115/parallel-runs/0/steps/0-106).

I had to:

- Update the GitHub token on Circle to have write permissions
- Manually push git tags
- Manually create [GitHub releases](https://github.com/algolia/react-instantsearch/releases) (waiting before publishing 6.13.0 because I'll sync it with Discussions, for which I'm preparing an announcement)

The changelog GitHub compare links were not correct because of this desynchronization.