### PR TITLE
feat(hooks): introduce `usePagination`

### DIFF
--- a/examples/hooks/App.css
+++ b/examples/hooks/App.css
@@ -15,3 +15,8 @@ body {
   max-width: 1000px;
   margin: 0 auto;
 }
+
+.Pagination {
+  padding: 1rem 0;
+  margin: 0 auto;
+}

--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -3,7 +3,13 @@ import algoliasearch from 'algoliasearch/lite';
 import React from 'react';
 import { InstantSearch } from 'react-instantsearch-hooks';
 
-import { Hits, SearchBox, RefinementList, Configure } from './components';
+import {
+  Configure,
+  Hits,
+  Pagination,
+  RefinementList,
+  SearchBox,
+} from './components';
 
 import './App.css';
 
@@ -52,6 +58,7 @@ export function App() {
         <div style={{ display: 'grid', gap: '.5rem' }}>
           <SearchBox placeholder="Search" />
           <Hits hitComponent={Hit} />
+          <Pagination className="Pagination" />
         </div>
       </div>
     </InstantSearch>

--- a/examples/hooks/components/Pagination.tsx
+++ b/examples/hooks/components/Pagination.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { usePagination, UsePaginationProps } from 'react-instantsearch-hooks';
+import { cx } from '../cx';
+
+export type PaginationProps = React.ComponentProps<'div'> & UsePaginationProps;
+
+export function Pagination(props: PaginationProps) {
+  const {
+    refine,
+    pages,
+    currentRefinement,
+    isFirstPage,
+    isLastPage,
+    nbPages,
+    canRefine,
+  } = usePagination(props);
+
+  return (
+    <div
+      className={cx(
+        'ais-Pagination',
+        canRefine === false && 'ais-Pagination--noRefinement',
+        props.className
+      )}
+    >
+      <ul className="ais-Pagination-list">
+        <PaginationItem
+          className={cx(
+            'ais-Pagination-item',
+            'ais-Pagination-item--firstPage'
+          )}
+          aria-label="First"
+          isDisabled={isFirstPage}
+          onClick={(event) => {
+            event.preventDefault();
+            refine(0);
+          }}
+        >
+          ‹‹
+        </PaginationItem>
+
+        <PaginationItem
+          className={cx(
+            'ais-Pagination-item',
+            'ais-Pagination-item--previousPage'
+          )}
+          aria-label="Previous"
+          isDisabled={isFirstPage}
+          onClick={(event) => {
+            event.preventDefault();
+            refine(currentRefinement - 1);
+          }}
+        >
+          ‹
+        </PaginationItem>
+
+        {pages.map((page) => (
+          <PaginationItem
+            key={page}
+            className={cx(
+              'ais-Pagination-item',
+              page === currentRefinement && 'ais-Pagination-item--selected'
+            )}
+            aria-label={String(page)}
+            isDisabled={false}
+            onClick={(event) => {
+              event.preventDefault();
+              refine(page);
+            }}
+          >
+            {page + 1}
+          </PaginationItem>
+        ))}
+
+        <PaginationItem
+          className={cx('ais-Pagination-item', 'ais-Pagination-item--nextPage')}
+          aria-label="Next"
+          isDisabled={isLastPage}
+          onClick={(event) => {
+            event.preventDefault();
+            refine(currentRefinement + 1);
+          }}
+        >
+          ›
+        </PaginationItem>
+
+        <PaginationItem
+          className={cx('ais-Pagination-item', 'ais-Pagination-item--lastPage')}
+          aria-label="Last"
+          isDisabled={isLastPage}
+          onClick={(event) => {
+            event.preventDefault();
+            refine(nbPages - 1);
+          }}
+        >
+          ››
+        </PaginationItem>
+      </ul>
+    </div>
+  );
+}
+
+type PaginationItemProps = React.ComponentProps<'a'> & {
+  isDisabled: boolean;
+};
+
+function PaginationItem(props: PaginationItemProps) {
+  const { isDisabled, className, ...rest } = props;
+
+  if (isDisabled) {
+    return (
+      <li className={cx(className, 'ais-Pagination-item--disabled')}>
+        <span className="ais-Pagination-link" {...rest} />
+      </li>
+    );
+  }
+
+  return (
+    <li className={className}>
+      <a className="ais-Pagination-link" href="#" {...rest} />
+    </li>
+  );
+}

--- a/examples/hooks/components/index.ts
+++ b/examples/hooks/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Configure';
 export * from './Hits';
+export * from './Pagination';
 export * from './RefinementList';
 export * from './SearchBox';

--- a/packages/react-instantsearch-hooks/src/__tests__/usePagination.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/usePagination.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { createInstantSearchTestWrapper } from '../../../../test/utils';
+import { usePagination } from '../usePagination';
+
+describe('usePagination', () => {
+  test('returns the connector render state', async () => {
+    const wrapper = createInstantSearchTestWrapper();
+    const { result, waitForNextUpdate } = renderHook(
+      () => usePagination({ padding: 2 }),
+      {
+        wrapper,
+      }
+    );
+
+    // Initial render state from manual `getWidgetRenderState`
+    expect(result.current).toEqual({
+      canRefine: false,
+      createURL: expect.any(Function),
+      currentRefinement: 0,
+      isFirstPage: true,
+      isLastPage: true,
+      nbHits: 0,
+      nbPages: 0,
+      pages: [0],
+      refine: expect.any(Function),
+    });
+
+    await waitForNextUpdate();
+
+    // InstantSearch.js state from the `render` lifecycle step
+    expect(result.current).toEqual({
+      canRefine: false,
+      createURL: expect.any(Function),
+      currentRefinement: 0,
+      isFirstPage: true,
+      isLastPage: true,
+      nbHits: 0,
+      nbPages: 0,
+      pages: [0],
+      refine: expect.any(Function),
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks/src/index.ts
+++ b/packages/react-instantsearch-hooks/src/index.ts
@@ -4,5 +4,6 @@ export * from './SearchIndex';
 export * from './useConfigure';
 export * from './useConnector';
 export * from './useHits';
+export * from './usePagination';
 export * from './useRefinementList';
 export * from './useSearchBox';

--- a/packages/react-instantsearch-hooks/src/usePagination.ts
+++ b/packages/react-instantsearch-hooks/src/usePagination.ts
@@ -1,0 +1,17 @@
+import connectPagination from 'instantsearch.js/es/connectors/pagination/connectPagination';
+
+import { useConnector } from './useConnector';
+
+import type {
+  PaginationConnectorParams,
+  PaginationWidgetDescription,
+} from 'instantsearch.js/es/connectors/pagination/connectPagination';
+
+export type UsePaginationProps = PaginationConnectorParams;
+
+export function usePagination(props?: UsePaginationProps) {
+  return useConnector<PaginationConnectorParams, PaginationWidgetDescription>(
+    connectPagination,
+    props
+  );
+}


### PR DESCRIPTION
This adds `usePagination` to our Hooks collection.

## API

This hook is a bridge to `connectPagination`.

This hooks highlights the fact that some Widgets need to wait for the actual search results before rendering (`<Stats>` too). If you load the sandbox, you'll see that during the first render, the `<Pagination>` component shows with a single page coming from the fake initial results that we inject, and then it's updated with the actual search results coming from Algolia. In InstantSearch.js, we only display the widget on `render`, not on `init`.

For now, a user-land solution is to add this CSS instruction:

```css
.ais-Pagination--noRefinement {
  display: none;
}
```

But I've been working on the concept of Results Boundaries which are components that lets you display your Widgets only on certain conditions based on the search results:

```jsx
function App(props) {
  return (
    <InstantSearch {...props}>
      <SearchBox placeholder="Search" />

      {/* Renders <NoResults> when there's no results only (we're in charge of the loading logic) */}
      <NoResultsBoundary fallback={<NoResults />}>
        <Hits hitComponent={Hit} />
      </NoResultsBoundary>

      {/* Renders <Pagination> when there's results only (avoid initial state with fallback results) */}
      <ResultsBoundary>
        <Pagination />
      </ResultsBoundary>
    </InstantSearch>
  );
}

function NoResults() {
  return <p>No items found.</p>;
}
```

We'd be able to wrap our own widgets with these Results Boundaries, or let users compose their components with them. I think that's an interesting approach. I'll wrote RFCs about those.

## Usage

```js
function Pagination(props) {
  const {
    refine,
    pages,
    currentRefinement,
    isFirstPage,
    isLastPage,
    nbPages,
    canRefine,
  } = usePagination(props);

  return <div>{/* ... */}</div>;
}

function App(props) {
  return (
    <InstantSearch {...props}>
      {/* ... */}

      <Pagination />
    </InstantSearch>
  );
}
```