### PR TITLE
Address native environment having a Window object but no location object

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectPoweredBy.jsdom.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectPoweredBy.jsdom.js
@@ -12,4 +12,16 @@ describe('connectPoweredBy', () => {
       url: 'https://www.algolia.com/?utm_source=react-instantsearch&utm_medium=website&utm_content=localhost&utm_campaign=poweredby',
     });
   });
+
+  it('handles react native environment in window without location object', () => {
+    const originalWindow = { ...window };
+    const windowSpy = jest.spyOn(global, 'window', 'get');
+    const { location, ...windowWithoutLocation } = originalWindow;
+    windowSpy.mockImplementation(() => windowWithoutLocation);
+    const props = getProvidedProps();
+    expect(props).toEqual({
+      url: 'https://www.algolia.com/?utm_source=react-instantsearch&utm_medium=website&utm_content=&utm_campaign=poweredby',
+    });
+    windowSpy.mockRestore();
+  });
 });

--- a/packages/react-instantsearch-core/src/connectors/connectPoweredBy.js
+++ b/packages/react-instantsearch-core/src/connectors/connectPoweredBy.js
@@ -12,7 +12,9 @@ export default createConnector({
 
   getProvidedProps() {
     const hostname =
-      typeof window === 'undefined' ? '' : window.location.hostname;
+      typeof window === 'undefined' || typeof window.location === 'undefined'
+        ? ''
+        : window.location.hostname;
 
     const url =
       'https://www.algolia.com/?' +


### PR DESCRIPTION
**Summary**

Creating a Powered By component in my React Native app results in an error due to the attempt to access window.location.hostname



![Screenshot_20211031-181243](https://user-images.githubusercontent.com/708458/139608733-ec396181-b011-494c-bb18-7ff78d63bac4.png)

**Result**

```
yarn jest packages/react-instantsearch-core/src/connectors/__tests__/connectPoweredBy.jsdom.js
yarn run v1.18.0
$ /Users/foush/Code/al/node_modules/.bin/jest packages/react-instantsearch-core/src/connectors/__tests__/connectPoweredBy.jsdom.js
 PASS  packages/react-instantsearch-core/src/connectors/__tests__/connectPoweredBy.jsdom.js
  connectPoweredBy
    ✓ provides the correct props to the component (1 ms)
    ✓ handles react native environment in window without location object (1 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        0.877 s
Ran all test suites matching /packages\/react-instantsearch-core\/src\/connectors\/__tests__\/connectPoweredBy.jsdom.js/i.
✨  Done in 2.46s.
```
