### PR TITLE
feat(hooks): introduce `useSortBy`

### DIFF
--- a/examples/hooks/App.css
+++ b/examples/hooks/App.css
@@ -20,7 +20,7 @@ body {
   display: grid;
   align-items: flex-start;
   grid-template-columns: 200px 1fr;
-  gap: 0.5rem;
+  gap: .5rem;
 }
 
 .Search {
@@ -29,12 +29,10 @@ body {
 }
 
 .Search-header {
-  display: flex;
-}
-
-.SearchBox {
-  flex: 1;
-  margin-right: .5rem;
+  display: grid;
+  align-items: flex-start;
+  grid-template-columns: 1fr auto;
+  gap: .5rem;
 }
 
 .Hit-label {

--- a/examples/hooks/App.css
+++ b/examples/hooks/App.css
@@ -16,6 +16,20 @@ body {
   margin: 0 auto;
 }
 
+.SearchBox {
+  flex: 1;
+  margin-right: 1rem;
+}
+
+.Hit-label {
+  flex: 1;
+  margin-right: 1rem;
+}
+
+.Hit-price {
+  color: lightslategray;
+}
+
 .Pagination {
   padding: 1rem 0;
   margin: 0 auto;

--- a/examples/hooks/App.css
+++ b/examples/hooks/App.css
@@ -16,9 +16,25 @@ body {
   margin: 0 auto;
 }
 
-.SearchBox {
+.Container {
+  display: grid;
+  align-items: flex-start;
+  grid-template-columns: 200px 1fr;
+  gap: 0.5rem;
+}
+
+.Search {
+  display: grid;
+  gap: .5rem;
+}
+
+.Search-header {
+  display: flex;
+}
+
+.Search-box {
   flex: 1;
-  margin-right: 1rem;
+  margin-right: .5rem;
 }
 
 .Hit-label {

--- a/examples/hooks/App.css
+++ b/examples/hooks/App.css
@@ -32,7 +32,7 @@ body {
   display: flex;
 }
 
-.Search-box {
+.SearchBox {
   flex: 1;
   margin-right: .5rem;
 }

--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -9,6 +9,7 @@ import {
   Pagination,
   RefinementList,
   SearchBox,
+  SortBy,
 } from './components';
 
 import './App.css';
@@ -21,16 +22,21 @@ const searchClient = algoliasearch(
 type HitProps = {
   hit: AlgoliaHit<{
     name: string;
+    price: number;
   }>;
 };
 
 function Hit({ hit }: HitProps) {
   return (
-    <span
-      dangerouslySetInnerHTML={{
-        __html: (hit._highlightResult as any).name.value,
-      }}
-    />
+    <>
+      <span
+        className="Hit-label"
+        dangerouslySetInnerHTML={{
+          __html: (hit._highlightResult as any).name.value,
+        }}
+      />
+      <span className="Hit-price">${hit.price}</span>
+    </>
   );
 }
 
@@ -56,7 +62,16 @@ export function App() {
           />
         </div>
         <div style={{ display: 'grid', gap: '.5rem' }}>
-          <SearchBox placeholder="Search" />
+          <div style={{ display: 'flex' }}>
+            <SearchBox className="SearchBox" placeholder="Search" />
+            <SortBy
+              items={[
+                { label: 'Relevance', value: 'instant_search' },
+                { label: 'Price (asc)', value: 'instant_search_price_asc' },
+                { label: 'Price (desc)', value: 'instant_search_price_desc' },
+              ]}
+            />
+          </div>
           <Hits hitComponent={Hit} />
           <Pagination className="Pagination" />
         </div>

--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -45,14 +45,7 @@ export function App() {
     <InstantSearch searchClient={searchClient} indexName="instant_search">
       <Configure hitsPerPage={15} />
 
-      <div
-        style={{
-          display: 'grid',
-          alignItems: 'flex-start',
-          gridTemplateColumns: '200px 1fr',
-          gap: '0.5rem',
-        }}
-      >
+      <div className="Container">
         <div>
           <RefinementList
             attribute="brand"
@@ -61,9 +54,9 @@ export function App() {
             showMore={true}
           />
         </div>
-        <div style={{ display: 'grid', gap: '.5rem' }}>
-          <div style={{ display: 'flex' }}>
-            <SearchBox className="SearchBox" placeholder="Search" />
+        <div className="Search">
+          <div className="Search-header">
+            <SearchBox className="Search-box" placeholder="Search" />
             <SortBy
               items={[
                 { label: 'Relevance', value: 'instant_search' },

--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -56,7 +56,7 @@ export function App() {
         </div>
         <div className="Search">
           <div className="Search-header">
-            <SearchBox className="Search-box" placeholder="Search" />
+            <SearchBox placeholder="Search" />
             <SortBy
               items={[
                 { label: 'Relevance', value: 'instant_search' },

--- a/examples/hooks/components/SortBy.tsx
+++ b/examples/hooks/components/SortBy.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { useSortBy, UseSortByProps } from 'react-instantsearch-hooks';
+
+export type SortByProps = React.ComponentProps<'div'> & UseSortByProps;
+export function SortBy(props: SortByProps) {
+  const { currentRefinement, options, refine } = useSortBy(props);
+
+  return (
+    <div className="ais-SortBy">
+      <select
+        className="ais-SortBy-select"
+        onChange={(event) => refine(event.target.value)}
+        defaultValue={currentRefinement}
+      >
+        {options.map(({ label, value }) => (
+          <option className="ais-SortBy-option" key={value} value={value}>
+            {label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/examples/hooks/components/index.ts
+++ b/examples/hooks/components/index.ts
@@ -3,3 +3,4 @@ export * from './Hits';
 export * from './Pagination';
 export * from './RefinementList';
 export * from './SearchBox';
+export * from './SortBy';

--- a/packages/react-instantsearch-hooks/src/__tests__/useSortBy.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/useSortBy.test.tsx
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { createInstantSearchTestWrapper } from '../../../../test/utils';
 import { useSortBy } from '../useSortBy';
 
-const getSortByTestItems = () => [
+const getSortByTestItems = [
   { label: 'Featured', value: 'indexName' },
   { label: 'Price (asc)', value: 'indexName_price_asc' },
   { label: 'Price (desc)', value: 'indexName_price_desc' },
@@ -15,7 +15,7 @@ describe('useSortBy', () => {
     const { result, waitForNextUpdate } = renderHook(
       () =>
         useSortBy({
-          items: getSortByTestItems(),
+          items: getSortByTestItems,
         }),
       {
         wrapper,
@@ -24,7 +24,7 @@ describe('useSortBy', () => {
 
     expect(result.current).toEqual({
       currentRefinement: 'indexName',
-      options: getSortByTestItems(),
+      options: getSortByTestItems,
       refine: expect.any(Function),
       hasNoResults: expect.any(Boolean),
     });
@@ -33,7 +33,7 @@ describe('useSortBy', () => {
 
     expect(result.current).toEqual({
       currentRefinement: 'indexName',
-      options: getSortByTestItems(),
+      options: getSortByTestItems,
       refine: expect.any(Function),
       hasNoResults: expect.any(Boolean),
     });

--- a/packages/react-instantsearch-hooks/src/__tests__/useSortBy.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/useSortBy.test.tsx
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { createInstantSearchTestWrapper } from '../../../../test/utils';
 import { useSortBy } from '../useSortBy';
 
-const getSortByTestItems = [
+const items = [
   { label: 'Featured', value: 'indexName' },
   { label: 'Price (asc)', value: 'indexName_price_asc' },
   { label: 'Price (desc)', value: 'indexName_price_desc' },
@@ -13,18 +13,13 @@ describe('useSortBy', () => {
   test('returns the connector render state', async () => {
     const wrapper = createInstantSearchTestWrapper();
     const { result, waitForNextUpdate } = renderHook(
-      () =>
-        useSortBy({
-          items: getSortByTestItems,
-        }),
-      {
-        wrapper,
-      }
+      () => useSortBy({ items }),
+      { wrapper }
     );
 
     expect(result.current).toEqual({
       currentRefinement: 'indexName',
-      options: getSortByTestItems,
+      options: items,
       refine: expect.any(Function),
       hasNoResults: expect.any(Boolean),
     });
@@ -33,7 +28,7 @@ describe('useSortBy', () => {
 
     expect(result.current).toEqual({
       currentRefinement: 'indexName',
-      options: getSortByTestItems,
+      options: items,
       refine: expect.any(Function),
       hasNoResults: expect.any(Boolean),
     });

--- a/packages/react-instantsearch-hooks/src/__tests__/useSortBy.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/useSortBy.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { createInstantSearchTestWrapper } from '../../../../test/utils';
+import { useSortBy } from '../useSortBy';
+
+const getSortByTestItems = () => [
+  { label: 'Featured', value: 'indexName' },
+  { label: 'Price (asc)', value: 'indexName_price_asc' },
+  { label: 'Price (desc)', value: 'indexName_price_desc' },
+];
+
+describe('useSortBy', () => {
+  test('returns the connector render state', async () => {
+    const wrapper = createInstantSearchTestWrapper();
+    const { result, waitForNextUpdate } = renderHook(
+      () =>
+        useSortBy({
+          items: getSortByTestItems(),
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current).toEqual({
+      currentRefinement: 'indexName',
+      options: getSortByTestItems(),
+      refine: expect.any(Function),
+      hasNoResults: expect.any(Boolean),
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual({
+      currentRefinement: 'indexName',
+      options: getSortByTestItems(),
+      refine: expect.any(Function),
+      hasNoResults: expect.any(Boolean),
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks/src/index.ts
+++ b/packages/react-instantsearch-hooks/src/index.ts
@@ -7,3 +7,4 @@ export * from './useHits';
 export * from './usePagination';
 export * from './useRefinementList';
 export * from './useSearchBox';
+export * from './useSortBy';

--- a/packages/react-instantsearch-hooks/src/useSortBy.ts
+++ b/packages/react-instantsearch-hooks/src/useSortBy.ts
@@ -1,0 +1,17 @@
+import connectSortBy from 'instantsearch.js/es/connectors/sort-by/connectSortBy';
+
+import { useConnector } from './useConnector';
+
+import type {
+  SortByConnectorParams,
+  SortByWidgetDescription,
+} from 'instantsearch.js/es/connectors/sort-by/connectSortBy';
+
+export type UseSortByProps = SortByConnectorParams;
+
+export function useSortBy(props: UseSortByProps) {
+  return useConnector<SortByConnectorParams, SortByWidgetDescription>(
+    connectSortBy,
+    props
+  );
+}


### PR DESCRIPTION
This adds `useSortBy` to our Hooks collection.

## API

This hook is a bridge to `connectSortBy`.

## Usage

```jsx
function SortBy(props) {
  const { currentRefinement, options, refine } = useSortBy(props);

  return <div>{/* ... */</div>;
}

function App(props) {
  return (
    <InstantSearch {...props}>
      {/* ... */}

      <SortBy items={[
        { label: 'Relevance', value: '...' },
        // ...
      ]} />
    </InstantSearch>
  );
}
```