### PR TITLE
chore(lerna): rely on Yarn Workspaces

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,5 @@
 {
   "version": "6.15.0",
   "npmClient": "yarn",
-  "useWorkspaces": true,
-  "packages": [
-    "packages/*",
-    "examples/@(default-theme|e-commerce|media|tourism|hooks)"
-  ]
+  "useWorkspaces": true
 }


### PR DESCRIPTION
With the `useWorkspaces` option, Lerna relies on Yarn Workspaces defined in the root `package.json`.
