### PR TITLE
docs(hooks): update query on change only

### DIFF
--- a/examples/hooks/components/RefinementList.tsx
+++ b/examples/hooks/components/RefinementList.tsx
@@ -21,12 +21,15 @@ export function RefinementList(props: RefinementListProps) {
     toggleShowMore,
   } = useRefinementList(props);
   const [query, setQuery] = useState('');
+  const previousQueryRef = useRef(query);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    searchForItems(query);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+    if (previousQueryRef.current !== query) {
+      previousQueryRef.current = query;
+      searchForItems(query);
+    }
+  }, [query, searchForItems]);
 
   return (
     <div className={cx('ais-RefinementList', props.className)}>

--- a/examples/hooks/components/SearchBox.tsx
+++ b/examples/hooks/components/SearchBox.tsx
@@ -19,8 +19,14 @@ export function SearchBox(props?: SearchBoxProps) {
   }
 
   useEffect(() => {
-    refine(value);
-  }, [refine, value]);
+    if (query !== value) {
+      refine(value);
+    }
+    // We want to track when the value coming from the React state changes
+    // to update the InstantSearch.js query, so we don't need to track the
+    // InstantSearch.js query.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, refine]);
 
   useEffect(() => {
     if (query !== value) {


### PR DESCRIPTION
The components from our Hooks example always triggered a query change on mount. This triggered additional renders, network requests, and created some routing issues by resetting the query.
