### PR TITLE
fix: update useSortBy transformItems type in documentation

### DIFF
--- a/packages/react-instantsearch-hooks/README.md
+++ b/packages/react-instantsearch-hooks/README.md
@@ -656,7 +656,7 @@ type UseSortByProps = {
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<SortByItem>;
+  transformItems?: TransformItems<SortByItem[]>;
 }
 ```
 


### PR DESCRIPTION
fixes https://algolia.atlassian.net/browse/FX-607

**Summary**

Fixes `transformItems` type in `useSortBy` documentation


