### PR TITLE
fix(hooks): throw invariant violations in production

### DIFF
--- a/packages/react-instantsearch-hooks/src/utils/__tests__/invariant.test.ts
+++ b/packages/react-instantsearch-hooks/src/utils/__tests__/invariant.test.ts
@@ -1,6 +1,20 @@
 import { invariant } from '../invariant';
 
 describe('invariant', () => {
+  if (!__DEV__) {
+    test('throws a generic invariant violation in production', () => {
+      expect(() => {
+        invariant(false, 'invariant');
+      }).toThrow('Invariant failed');
+    });
+
+    test('does not throw when the condition is met in production', () => {
+      expect(() => {
+        invariant(true, 'invariant');
+      }).not.toThrow();
+    });
+  }
+
   if (__DEV__) {
     test('throws when the condition is unmet', () => {
       expect(() => {

--- a/packages/react-instantsearch-hooks/src/utils/invariant.ts
+++ b/packages/react-instantsearch-hooks/src/utils/invariant.ts
@@ -7,11 +7,15 @@ export function invariant(
   condition: boolean,
   message: string | (() => string)
 ) {
-  if (!__DEV__) {
+  if (condition) {
     return;
   }
 
-  if (!condition) {
+  if (!__DEV__) {
+    throw new Error('Invariant failed');
+  }
+
+  if (__DEV__) {
     throw new Error(
       `[InstantSearch] ${typeof message === 'function' ? message() : message}`
     );


### PR DESCRIPTION
Our `invariant` util used to throw with a specified error message in development only, and keep the flow going without throwing in production. This is a dangerous behavior to have different flows in development and in production.

This diff now also throws in production, but with a tiny generic error message to keep the bundle size lite. In the future, we'll be able to implement our error strategy with error redirects (similar to React or Next.js) in this invariant.

For reference, [`tiny-invariant`](https://github.com/alexreardon/tiny-invariant) and other projects throw in both environments, only the error messages differ.

I added the production path in the test so that we're able to test that `invariant` acts as expected in production. `__DEV__` is `true` by default when running the test, but you can run the tests in production with the following command: `NODE_ENV=production yarn test invariant`