### PR TITLE
docs(react-instantsearch-hooks): fix typo

### DIFF
--- a/packages/react-instantsearch-hooks/README.md
+++ b/packages/react-instantsearch-hooks/README.md
@@ -1252,7 +1252,7 @@ type HitsPerPageRenderStateItem = {
 
 ```jsx
 function HitsPerPage(props) {
-  const { items, refine, hasNoResults } = useSortBy(props);
+  const { items, refine, hasNoResults } = useHitsPerPage(props);
 
   return {
     /* Markup */


### PR DESCRIPTION
**Summary**

The documentation had a case of bad copy/paste, it's now cured.