### PR TITLE
feat(hooks): introduce useCurrentRefinements

### DIFF
--- a/examples/hooks/App.css
+++ b/examples/hooks/App.css
@@ -20,19 +20,19 @@ body {
   display: grid;
   align-items: flex-start;
   grid-template-columns: minmax(min-content, 200px) 1fr;
-  gap: .5rem;
+  gap: 0.5rem;
 }
 
 .Search {
   display: grid;
-  gap: .5rem;
+  gap: 0.5rem;
 }
 
 .Search-header {
   display: grid;
   align-items: flex-start;
   grid-template-columns: 1fr auto auto;
-  gap: .5rem;
+  gap: 0.5rem;
 }
 
 .Hit-label {

--- a/examples/hooks/App.css
+++ b/examples/hooks/App.css
@@ -48,3 +48,7 @@ body {
   padding: 1rem 0;
   margin: 0 auto;
 }
+
+.ais-CurrentRefinements-label {
+  text-transform: capitalize;
+}

--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -100,7 +100,26 @@ export function App() {
             />
           </div>
 
-          <CurrentRefinements />
+          <CurrentRefinements
+            transformItems={(items) =>
+              items.map((item) => {
+                const attribute = item.attribute.startsWith(
+                  'hierarchicalCategories'
+                )
+                  ? 'Hierarchy'
+                  : item.attribute;
+
+                return {
+                  ...item,
+                  attribute,
+                  refinements: item.refinements.map((refinement) => ({
+                    ...refinement,
+                    attribute,
+                  })),
+                };
+              })
+            }
+          />
 
           <QueryRuleContext
             trackedFilters={{

--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -18,6 +18,7 @@ import {
   HitsPerPage,
   QueryRuleContext,
   QueryRuleCustomData,
+  CurrentRefinements,
 } from './components';
 
 import './App.css';
@@ -98,6 +99,8 @@ export function App() {
               ]}
             />
           </div>
+
+          <CurrentRefinements />
 
           <QueryRuleContext
             trackedFilters={{

--- a/examples/hooks/components/CurrentRefinements.tsx
+++ b/examples/hooks/components/CurrentRefinements.tsx
@@ -35,7 +35,7 @@ export function CurrentRefinements(props: CurrentRefinementsProps) {
         {refinements.map((refinement) => (
           <li key={refinement.label} className="ais-CurrentRefinements-item">
             <span className="ais-CurrentRefinements-label">
-              {getCategoryName(refinement)}:
+              {refinement.attribute}:
             </span>
             <span className="ais-CurrentRefinements-category">
               <span className="ais-CurrentRefinements-categoryLabel">
@@ -62,14 +62,4 @@ export function CurrentRefinements(props: CurrentRefinementsProps) {
       </ul>
     </div>
   );
-}
-
-function getCategoryName({
-  attribute,
-}: CurrentRefinementsConnectorParamsRefinement) {
-  if (attribute.startsWith('hierarchicalCategories')) {
-    return 'Hierarchy';
-  }
-
-  return attribute;
 }

--- a/examples/hooks/components/CurrentRefinements.tsx
+++ b/examples/hooks/components/CurrentRefinements.tsx
@@ -15,7 +15,7 @@ export function CurrentRefinements(props: CurrentRefinementsProps) {
   const { items, refine, canRefine } = useCurrentRefinements(props);
   const refinements = items.reduce(
     (acc, item) => [...acc, ...item.refinements],
-    []
+    [] as CurrentRefinementsConnectorParamsRefinement[]
   );
 
   return (

--- a/examples/hooks/components/CurrentRefinements.tsx
+++ b/examples/hooks/components/CurrentRefinements.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import {
+  useCurrentRefinements,
+  UseCurrentRefinementsProps,
+} from 'react-instantsearch-hooks';
+import { CurrentRefinementsConnectorParamsRefinement } from 'instantsearch.js/es/connectors/current-refinements/connectCurrentRefinements';
+
+import { cx } from '../cx';
+import { isSpecialClick } from '../isSpecialClick';
+
+export type CurrentRefinements = React.ComponentProps<'div'> &
+  UseCurrentRefinementsProps;
+
+export function CurrentRefinements(props: CurrentRefinements) {
+  const { items, refine, canRefine } = useCurrentRefinements(props);
+  const refinements = items.reduce(
+    (acc, item) => [...acc, ...item.refinements],
+    []
+  );
+
+  return (
+    <div
+      className={cx(
+        'ais-CurrentRefinements',
+        !canRefine && 'ais-CurrentRefinements-noRefinement',
+        props.className
+      )}
+    >
+      <ul
+        className={cx(
+          'ais-CurrentRefinements-list',
+          !canRefine && 'ais-CurrentRefinements-list--noRefinement'
+        )}
+      >
+        {refinements.map((refinement) => (
+          <li key={refinement.label} className="ais-CurrentRefinements-item">
+            <span className="ais-CurrentRefinements-label">
+              {getCategoryName(refinement)}:
+            </span>
+            <span className="ais-CurrentRefinements-category">
+              <span className="ais-CurrentRefinements-categoryLabel">
+                {refinement.label}
+              </span>
+            </span>
+            <button
+              aria-label={`Remove ${refinement.label} from refinements`}
+              onClick={(event) => {
+                if (isSpecialClick(event)) {
+                  return;
+                }
+
+                event.preventDefault();
+
+                refine(refinement);
+              }}
+              className="ais-CurrentRefinements-delete"
+            >
+              ✕
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function getCategoryName({
+  attribute,
+}: CurrentRefinementsConnectorParamsRefinement) {
+  if (attribute.startsWith('hierarchicalCategories')) {
+    return 'Hierarchy';
+  }
+
+  return attribute;
+}

--- a/examples/hooks/components/CurrentRefinements.tsx
+++ b/examples/hooks/components/CurrentRefinements.tsx
@@ -8,10 +8,10 @@ import { CurrentRefinementsConnectorParamsRefinement } from 'instantsearch.js/es
 import { cx } from '../cx';
 import { isSpecialClick } from '../isSpecialClick';
 
-export type CurrentRefinements = React.ComponentProps<'div'> &
+export type CurrentRefinementsProps = React.ComponentProps<'div'> &
   UseCurrentRefinementsProps;
 
-export function CurrentRefinements(props: CurrentRefinements) {
+export function CurrentRefinements(props: CurrentRefinementsProps) {
   const { items, refine, canRefine } = useCurrentRefinements(props);
   const refinements = items.reduce(
     (acc, item) => [...acc, ...item.refinements],

--- a/examples/hooks/components/CurrentRefinements.tsx
+++ b/examples/hooks/components/CurrentRefinements.tsx
@@ -3,7 +3,6 @@ import {
   useCurrentRefinements,
   UseCurrentRefinementsProps,
 } from 'react-instantsearch-hooks';
-import { CurrentRefinementsConnectorParamsRefinement } from 'instantsearch.js/es/connectors/current-refinements/connectCurrentRefinements';
 
 import { cx } from '../cx';
 import { isSpecialClick } from '../isSpecialClick';
@@ -13,16 +12,12 @@ export type CurrentRefinementsProps = React.ComponentProps<'div'> &
 
 export function CurrentRefinements(props: CurrentRefinementsProps) {
   const { items, refine, canRefine } = useCurrentRefinements(props);
-  const refinements = items.reduce(
-    (acc, item) => [...acc, ...item.refinements],
-    [] as CurrentRefinementsConnectorParamsRefinement[]
-  );
 
   return (
     <div
       className={cx(
         'ais-CurrentRefinements',
-        !canRefine && 'ais-CurrentRefinements-noRefinement',
+        !canRefine && 'ais-CurrentRefinements--noRefinement',
         props.className
       )}
     >
@@ -32,31 +27,35 @@ export function CurrentRefinements(props: CurrentRefinementsProps) {
           !canRefine && 'ais-CurrentRefinements-list--noRefinement'
         )}
       >
-        {refinements.map((refinement) => (
-          <li key={refinement.label} className="ais-CurrentRefinements-item">
+        {items.map((item) => (
+          <li key={item.label} className="ais-CurrentRefinements-item">
             <span className="ais-CurrentRefinements-label">
-              {refinement.attribute}:
+              {item.attribute}:
             </span>
-            <span className="ais-CurrentRefinements-category">
-              <span className="ais-CurrentRefinements-categoryLabel">
-                {refinement.label}
+            {item.refinements.map((refinement) => (
+              <span
+                key={refinement.label}
+                className="ais-CurrentRefinements-category"
+              >
+                <span className="ais-CurrentRefinements-categoryLabel">
+                  {refinement.label}
+                </span>
+                <button
+                  onClick={(event) => {
+                    if (isSpecialClick(event)) {
+                      return;
+                    }
+
+                    event.preventDefault();
+
+                    refine(refinement);
+                  }}
+                  className="ais-CurrentRefinements-delete"
+                >
+                  ✕
+                </button>
               </span>
-            </span>
-            <button
-              aria-label={`Remove ${refinement.label} from refinements`}
-              onClick={(event) => {
-                if (isSpecialClick(event)) {
-                  return;
-                }
-
-                event.preventDefault();
-
-                refine(refinement);
-              }}
-              className="ais-CurrentRefinements-delete"
-            >
-              ✕
-            </button>
+            ))}
           </li>
         ))}
       </ul>

--- a/examples/hooks/components/index.ts
+++ b/examples/hooks/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Configure';
+export * from './CurrentRefinements';
 export * from './HierarchicalMenu';
 export * from './Highlight';
 export * from './Hits';

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     },
     {
       "path": "packages/react-instantsearch-hooks/dist/umd/ReactInstantSearchHooks.min.js",
-      "maxSize": "34 kB"
+      "maxSize": "34.75 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",

--- a/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
@@ -1,0 +1,34 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { createInstantSearchTestWrapper } from '../../../../test/utils';
+import { useCurrentRefinements } from '../useCurrentRefinements';
+
+describe('useCurrentRefinements', () => {
+  test('returns the connector render state', async () => {
+    const wrapper = createInstantSearchTestWrapper();
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCurrentRefinements(),
+      {
+        wrapper,
+      }
+    );
+
+    // Initial render state from manual `getWidgetRenderState`
+    expect(result.current).toEqual({
+      items: [],
+      canRefine: false,
+      refine: expect.any(Function),
+      createURL: expect.any(Function),
+    });
+
+    await waitForNextUpdate();
+
+    // InstantSearch.js state from the `render` lifecycle step
+    expect(result.current).toEqual({
+      items: [],
+      canRefine: false,
+      refine: expect.any(Function),
+      createURL: expect.any(Function),
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
 
 import { RefinementList } from '../../../../examples/hooks/components';
 import { createInstantSearchTestWrapper } from '../../../../test/utils';

--- a/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
@@ -1,9 +1,11 @@
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 
-import { RefinementList } from '../../../../examples/hooks/components';
+import { useRefinementList } from '..';
 import { createInstantSearchTestWrapper } from '../../../../test/utils';
 import { useCurrentRefinements } from '../useCurrentRefinements';
+
+import type { UseRefinementListProps } from '..';
 
 describe('useCurrentRefinements', () => {
   test('returns the connector render state', async () => {
@@ -94,3 +96,9 @@ describe('useCurrentRefinements', () => {
     });
   });
 });
+
+function RefinementList(props: UseRefinementListProps) {
+  useRefinementList(props);
+
+  return null;
+}

--- a/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
@@ -1,9 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 
-import { useRefinementList } from '..';
 import { createInstantSearchTestWrapper } from '../../../../test/utils';
 import { useCurrentRefinements } from '../useCurrentRefinements';
+import { useRefinementList } from '../useRefinementList';
 
 import type { UseRefinementListProps } from '..';
 

--- a/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/useCurrentRefinements.test.tsx
@@ -1,5 +1,7 @@
+import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 
+import { RefinementList } from '../../../../examples/hooks/components';
 import { createInstantSearchTestWrapper } from '../../../../test/utils';
 import { useCurrentRefinements } from '../useCurrentRefinements';
 
@@ -27,6 +29,66 @@ describe('useCurrentRefinements', () => {
     expect(result.current).toEqual({
       items: [],
       canRefine: false,
+      refine: expect.any(Function),
+      createURL: expect.any(Function),
+    });
+  });
+
+  test('returns items on render', async () => {
+    const wrapper = createInstantSearchTestWrapper({
+      initialUiState: {
+        indexName: {
+          refinementList: {
+            brand: ['Apple'],
+          },
+        },
+      },
+    });
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCurrentRefinements(),
+      {
+        wrapper: ({ children }) =>
+          wrapper({
+            children: (
+              <>
+                <RefinementList attribute="brand" />
+                {children}
+              </>
+            ),
+          }),
+      }
+    );
+
+    // Initial render state from manual `getWidgetRenderState`
+    expect(result.current).toEqual({
+      items: [],
+      canRefine: false,
+      refine: expect.any(Function),
+      createURL: expect.any(Function),
+    });
+
+    await waitForNextUpdate();
+
+    // InstantSearch.js state from the `render` lifecycle step
+    expect(result.current).toEqual({
+      items: [
+        {
+          attribute: 'brand',
+          indexName: 'indexName',
+          label: 'brand',
+          refine: expect.any(Function),
+          refinements: [
+            {
+              attribute: 'brand',
+              label: 'Apple',
+              type: 'disjunctive',
+              value: 'Apple',
+            },
+          ],
+        },
+      ],
+      canRefine: true,
       refine: expect.any(Function),
       createURL: expect.any(Function),
     });

--- a/packages/react-instantsearch-hooks/src/index.ts
+++ b/packages/react-instantsearch-hooks/src/index.ts
@@ -4,6 +4,7 @@ export * from './InstantSearch';
 export * from './SearchIndex';
 export * from './useConfigure';
 export * from './useConnector';
+export * from './useCurrentRefinements';
 export * from './useDynamicWidgets';
 export * from './useHierarchicalMenu';
 export * from './useHits';

--- a/packages/react-instantsearch-hooks/src/useCurrentRefinements.ts
+++ b/packages/react-instantsearch-hooks/src/useCurrentRefinements.ts
@@ -1,0 +1,17 @@
+import connectCurrentRefinements from 'instantsearch.js/es/connectors/current-refinements/connectCurrentRefinements';
+
+import { useConnector } from './useConnector';
+
+import type {
+  CurrentRefinementsConnectorParams,
+  CurrentRefinementsWidgetDescription,
+} from 'instantsearch.js/es/connectors/current-refinements/connectCurrentRefinements';
+
+export type UseCurrentRefinementsProps = CurrentRefinementsConnectorParams;
+
+export function useCurrentRefinements(props?: UseCurrentRefinementsProps) {
+  return useConnector<
+    CurrentRefinementsConnectorParams,
+    CurrentRefinementsWidgetDescription
+  >(connectCurrentRefinements, props);
+}


### PR DESCRIPTION
## Summary

This introduces the `useCurrentRefinements` hook.

For the example, I've used the [specs](https://github.com/algolia/instantsearch-specs) and the existing [`CurrentRefinements`](https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-dom/src/components/CurrentRefinements.js) widget for inspiration. However I've used one list item per refinement, which looked clearer to me UI-wise.

<img width="761" alt="Capture d’écran 2021-12-03 à 21 20 36" src="https://user-images.githubusercontent.com/5370675/144674651-0e793f97-ef7b-46c9-a417-0420eb8bab53.png">

We can do a pass on responsiveness and refine the global UI at the end.

Documentation PR is open [here](https://github.com/algolia/doc/pull/6488).