### PR TITLE
chore(release): remove examples update after release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 
 
-# [6.15.0](https://github.com/algolia/react-instantsearch/compare/v6.13.0...v6.15.0) (2021-10-27)
+# [6.15.0](https://github.com/algolia/react-instantsearch/compare/v6.14.0...v6.15.0) (2021-10-27)
 
 
 ### Bug Fixes

--- a/ship.config.js
+++ b/ship.config.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const getLatestVersion = require('latest-version');
+// const getLatestVersion = require('latest-version');
 
 const packages = [
   'packages/react-instantsearch-core',
@@ -58,18 +58,22 @@ module.exports = {
   pullRequestTeamReviewers: ['frontend-experiences-web'],
   buildCommand: ({ version }) =>
     `NODE_ENV=production VERSION=${version} yarn build`,
-  afterPublish: async ({ exec, version }) => {
-    await waitUntil(async () => {
-      const latestVersion = await getLatestVersion('react-instantsearch', {
-        version: 'latest',
-      });
-      return latestVersion === version;
-    });
-    exec(`git config --global user.email "instantsearch-bot@algolia.com"`);
-    exec(`git config --global user.name "InstantSearch"`);
-    exec(`node scripts/update-examples.js ${version}`);
-    exec(`git push origin master`);
-  },
+  // @TODO: updating the examples and pushing to the `master` branch breaks
+  // the release process because of access rights.
+  // To keep the examples updated with the newly released version, we should rely
+  // on the monorepo feature.
+  // afterPublish: async ({ exec, version }) => {
+  //   await waitUntil(async () => {
+  //     const latestVersion = await getLatestVersion('react-instantsearch', {
+  //       version: 'latest',
+  //     });
+  //     return latestVersion === version;
+  //   });
+  //   exec(`git config --global user.email "instantsearch-bot@algolia.com"`);
+  //   exec(`git config --global user.name "InstantSearch"`);
+  //   exec(`node scripts/update-examples.js ${version}`);
+  //   exec(`git push origin master`);
+  // },
   slack: {
     // disable slack notification for `prepared` lifecycle.
     // Ship.js will send slack message only for `releaseSuccess`.
@@ -110,13 +114,13 @@ module.exports = {
   },
 };
 
-function waitUntil(checkFn) {
-  return new Promise((resolve) => {
-    const intervalId = setInterval(async () => {
-      if (await checkFn()) {
-        clearInterval(intervalId);
-        resolve();
-      }
-    }, 3000);
-  });
-}
+// function waitUntil(checkFn) {
+//   return new Promise((resolve) => {
+//     const intervalId = setInterval(async () => {
+//       if (await checkFn()) {
+//         clearInterval(intervalId);
+//         resolve();
+//       }
+//     }, 3000);
+//   });
+// }


### PR DESCRIPTION
This removes the examples update after release in an attempt at making the release script work. It's been broken for months and messes up our tags and releases.

I want to release the next version without this step to make sure that this is the culprit. Then, we should be able to rely on the monorepo feature instead of manually updating the examples.