### PR TITLE
chore(deps): remove lib dependencies from root package

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,9 +168,5 @@
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",
       "maxSize": "7.25 kB"
     }
-  ],
-  "dependencies": {
-    "react-instantsearch-dom": "6.16.0",
-    "react-instantsearch-dom-maps": "6.16.0"
-  }
+  ]
 }


### PR DESCRIPTION
These dependencies were mistakenly introduced in c772401bd5373264967ee053276b22f1f54f096b by our script to update example dependencies.