### PR TITLE
docs(hooks): update SSR example package name

### DIFF
--- a/examples/hooks-ssr/package.json
+++ b/examples/hooks-ssr/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "example-hooks-ssr",
-  "version": "1.0.0",
+  "name": "hooks-ssr-example",
+  "version": "6.16.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This updates the SSR Hooks example package name to follow the same pattern as the Hooks example name.