### PR TITLE
chore(hooks-server): use same Ship.js and ESLint config as Hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,7 +110,10 @@ const config = {
       },
     },
     {
-      files: ['packages/react-instantsearch-hooks/**/*'],
+      files: [
+        'packages/react-instantsearch-hooks/**/*',
+        'packages/react-instantsearch-hooks-server/**/*',
+      ],
       rules: {
         // We don't ship PropTypes in the next version of the library.
         'react/prop-types': 'off',

--- a/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
@@ -3,8 +3,6 @@
  */
 
 import React, { version as ReactVersion } from 'react';
-
-import { createSearchClient } from '../../../../test/mock';
 import {
   InstantSearch,
   InstantSearchSSRProvider,
@@ -14,13 +12,15 @@ import {
   useSearchBox,
   version,
 } from 'react-instantsearch-hooks';
+
+import { createSearchClient } from '../../../../test/mock';
 import { getServerState } from '../getServerState';
 
+import type algoliasearch from 'algoliasearch/lite';
 import type {
   InstantSearchServerState,
   UseRefinementListProps,
 } from 'react-instantsearch-hooks';
-import type algoliasearch from 'algoliasearch/lite';
 
 type SearchClient = ReturnType<typeof algoliasearch>;
 

--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -1,16 +1,15 @@
 import { isIndexWidget } from 'instantsearch.js/es/widgets/index/index';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
-
 import { InstantSearchServerContext } from 'react-instantsearch-hooks';
 
+import type { InitialResults, InstantSearch } from 'instantsearch.js';
+import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
+import type { ReactNode } from 'react';
 import type {
   InstantSearchServerContextApi,
   InstantSearchServerState,
 } from 'react-instantsearch-hooks';
-import type { InitialResults, InstantSearch } from 'instantsearch.js';
-import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
-import type { ReactNode } from 'react';
 
 /**
  * Returns the InstantSearch server state from a component.

--- a/ship.config.js
+++ b/ship.config.js
@@ -7,6 +7,7 @@ const packages = [
   'packages/react-instantsearch-dom-maps',
   'packages/react-instantsearch-dom',
   'packages/react-instantsearch-hooks',
+  'packages/react-instantsearch-hooks-server',
   'packages/react-instantsearch-native',
   'packages/react-instantsearch',
 ];


### PR DESCRIPTION
This uses the same Ship.js and ESLint config in Hooks Server as in the Hooks package.