### PR TITLE
chore(release): update Hooks Server example dependencies on release

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -48,6 +48,16 @@ module.exports = {
 
     // update version in packages & dependencies
     exec(`lerna version ${version} --no-git-tag-version --no-push --yes`);
+
+    // @TODO: We can remove after initial npm release of `react-instantsearch-hooks-server`
+    // We update the Hooks and Hooks Server package dependency in the example because Lerna doesn't
+    // and releasing fails because the Hooks Server package has not yet been released on npm.
+    exec(
+      `yarn workspace hooks-ssr-example upgrade react-instantsearch-hooks@${version}`
+    );
+    exec(
+      `yarn workspace hooks-ssr-example upgrade react-instantsearch-hooks-server@${version}`
+    );
   },
   shouldPrepare: ({ releaseType, commitNumbersPerType }) => {
     const { fix = 0 } = commitNumbersPerType;


### PR DESCRIPTION
Similar to #3173.

We update the Hooks and Hooks Server package dependencies in the SSR example because Lerna doesn't and releasing fails because the Hooks Server package has not yet been released on npm.

