### PR TITLE
Save on hits triggering rerenders

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
+++ b/packages/react-instantsearch-core/src/connectors/connectGeoSearch.js
@@ -173,9 +173,10 @@ export default createConnector({
 
     const position =
       currentPositionFromSearchState || currentPositionFromSearchParameters;
+    const theHits = !results ? [] : results.hits;
 
     return {
-      hits: !results ? [] : results.hits.filter((_) => Boolean(_._geoloc)),
+      hits: theHits.every(x => Boolean(x._geoloc)) ? theHits : theHits.filter((_) => Boolean(_._geoloc)), //save on rerenders and effects further down the line
       isRefinedWithMap: Boolean(currentRefinement),
       currentRefinement,
       position,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
I'm having an issue with hits being always new in connected component and triggering useEffect excessively. This is a moderate tweak which could be done better (with useMemo but i'm not sure how to use it in this instance), but even this should help with majority of usecases

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
The connected component would get rendered a lot with always different array of hits, which throws useEffect out of whack. Hits should be memoized.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
