### PR TITLE
refactor(hooks-server): no longer use async/await

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -147,7 +147,7 @@ const config = {
     },
     {
       files: 'packages/**/*',
-      excludedFiles: '*.test.*',
+      excludedFiles: ['*.test.*', '**/__tests__/**'],
       rules: {
         'no-restricted-syntax': [
           'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -145,6 +145,40 @@ const config = {
         ],
       },
     },
+    {
+      files: 'packages/**/*',
+      excludedFiles: '*.test.*',
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: '[async=true]',
+            message:
+              'The polyfill for async/await is very large, which is why we use promise chains',
+          },
+          {
+            selector: 'ForInStatement',
+            message:
+              'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+          },
+          {
+            selector: 'ForOfStatement',
+            message:
+              'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
+          },
+          {
+            selector: 'LabeledStatement',
+            message:
+              'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+          },
+          {
+            selector: 'WithStatement',
+            message:
+              '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+          },
+        ],
+      },
+    },
     // Disable stricter rules introduced for the next versions of the libraries.
     {
       files: [

--- a/packages/react-instantsearch-core/src/core/translatable.js
+++ b/packages/react-instantsearch-core/src/core/translatable.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 const withKeysPropType = (keys) => (props, propName, componentName) => {
   const prop = props[propName];
   if (prop) {
+    // eslint-disable-next-line no-restricted-syntax
     for (const key of Object.keys(prop)) {
       if (keys.indexOf(key) === -1) {
         return new Error(

--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -14,7 +14,7 @@ import type {
 /**
  * Returns the InstantSearch server state from a component.
  */
-export async function getServerState(
+export function getServerState(
   children: ReactNode
 ): Promise<InstantSearchServerState> {
   const searchRef: { current: InstantSearch | undefined } = {
@@ -34,28 +34,30 @@ export async function getServerState(
   );
 
   // We wait for the component to mount so that `notifyServer()` is called.
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  return new Promise((resolve) => setTimeout(resolve, 0))
+    .then(() => {
+      // If `notifyServer()` is not called by then, it means that <InstantSearch>
+      // wasn't within the `children`.
+      // We decide to go with a strict behavior in that case; throwing. If users have
+      // some routes that don't mount the <InstantSearch> component, they would need
+      // to try/catch the `getServerState()` call.
+      // If this behavior turns out to be too strict for many users, we can decide
+      // to warn instead of throwing.
+      if (!searchRef.current) {
+        throw new Error(
+          "Unable to retrieve InstantSearch's server state in `getServerState()`. Did you mount the <InstantSearch> component?"
+        );
+      }
 
-  // If `notifyServer()` is not called by then, it means that <InstantSearch>
-  // wasn't within the `children`.
-  // We decide to go with a strict behavior in that case; throwing. If users have
-  // some routes that don't mount the <InstantSearch> component, they would need
-  // to try/catch the `getServerState()` call.
-  // If this behavior turns out to be too strict for many users, we can decide
-  // to warn instead of throwing.
-  if (!searchRef.current) {
-    throw new Error(
-      "Unable to retrieve InstantSearch's server state in `getServerState()`. Did you mount the <InstantSearch> component?"
-    );
-  }
+      return waitForResults(searchRef.current);
+    })
+    .then(() => {
+      const initialResults = getInitialResults(searchRef.current!.mainIndex);
 
-  await waitForResults(searchRef.current);
-
-  const initialResults = getInitialResults(searchRef.current.mainIndex);
-
-  return {
-    initialResults,
-  };
+      return {
+        initialResults,
+      };
+    });
 }
 
 /**


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

async/await adds the really big regenerator polyfill, that we don't really need. It also adds an eslint rule to make sure we don't use it again in the future, along with some other (not used so far) syntax


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

no async/await outside inside the real source code (tests/examples are allowed)