### PR TITLE
fix(hooks): clear current refinement for hierarchical menu not working

### DIFF
--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -117,19 +117,13 @@ export function App() {
           <CurrentRefinements
             transformItems={(items) =>
               items.map((item) => {
-                const attribute = item.attribute.startsWith(
-                  'hierarchicalCategories'
-                )
+                const label = item.label.startsWith('hierarchicalCategories')
                   ? 'Hierarchy'
-                  : item.attribute;
+                  : item.label;
 
                 return {
                   ...item,
-                  attribute,
-                  refinements: item.refinements.map((refinement) => ({
-                    ...refinement,
-                    attribute,
-                  })),
+                  attribute: label,
                 };
               })
             }


### PR DESCRIPTION
**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In the `hooks` example, you can't clear the current refinement for the `HierarchicalMenu` widget.