### PR TITLE
feat(dynamicWidgets): send facets * and maxValuesPerFacet by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,15 +146,15 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Connectors.min.js",
-      "maxSize": "25.25 kB"
+      "maxSize": "25.75 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Dom.min.js",
-      "maxSize": "42 kB"
+      "maxSize": "42.25 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "28.75 kB"
+      "maxSize": "29 kB"
     },
     {
       "path": "packages/react-instantsearch-hooks/dist/umd/ReactInstantSearchHooks.min.js",
@@ -162,7 +162,7 @@
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
-      "maxSize": "44.50 kB"
+      "maxSize": "44.75 kB"
     },
     {
       "path": "packages/react-instantsearch-dom-maps/dist/umd/ReactInstantSearchDOMMaps.min.js",

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectDynamicWidgets.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectDynamicWidgets.js
@@ -24,12 +24,81 @@ const EMPTY_RESPONSE = {
 
 describe('connectDynamicWidgets', () => {
   const empty = {};
+  const contextValue = {
+    mainTargetedIndex: 'index',
+  };
+
+  describe('getSearchParameters', () => {
+    it('sets facets * and maxValuesPerFacet by default', () => {
+      const props = {
+        contextValue,
+        ...connector.defaultProps,
+      };
+      const searchState = {};
+
+      const actual = connector.getSearchParameters(
+        new SearchParameters(),
+        props,
+        searchState
+      );
+
+      expect(actual).toEqual(
+        new SearchParameters({
+          facets: ['*'],
+          maxValuesPerFacet: 20,
+        })
+      );
+    });
+
+    it('gets added onto existing parameters', () => {
+      const props = {
+        contextValue,
+        ...connector.defaultProps,
+      };
+      const searchState = {};
+
+      const actual = connector.getSearchParameters(
+        new SearchParameters({
+          facets: ['123'],
+          maxValuesPerFacet: 1000,
+        }),
+        props,
+        searchState
+      );
+
+      expect(actual).toEqual(
+        new SearchParameters({
+          facets: ['123', '*'],
+          maxValuesPerFacet: 1000,
+        })
+      );
+    });
+
+    it('allows override of facets and maxValuesPerFacet', () => {
+      const props = {
+        contextValue,
+        ...connector.defaultProps,
+        facets: ['lol'],
+        maxValuesPerFacet: 1000,
+      };
+      const searchState = {};
+
+      const actual = connector.getSearchParameters(
+        new SearchParameters(),
+        props,
+        searchState
+      );
+
+      expect(actual).toEqual(
+        new SearchParameters({
+          facets: ['lol'],
+          maxValuesPerFacet: 1000,
+        })
+      );
+    });
+  });
 
   describe('single index', () => {
-    const contextValue = {
-      mainTargetedIndex: 'index',
-    };
-
     const createSingleIndexSearchResults = (result = {}, state) => ({
       results: new SearchResults(new SearchParameters(state), [
         {
@@ -151,11 +220,83 @@ describe('connectDynamicWidgets', () => {
 
         expect(actual.attributesToRender).toEqual(['one', 'two']);
       });
+
+      it('warns if maxValuesPerFacet is lower than set by another widget', () => {
+        const spy = jest.spyOn(console, 'warn');
+        const props = {
+          contextValue,
+          ...connector.defaultProps,
+        };
+        const searchState = {};
+        const searchResults = createSingleIndexSearchResults(
+          {},
+          new SearchParameters({ maxValuesPerFacet: 100 })
+        );
+
+        connector.getProvidedProps(props, searchState, searchResults);
+
+        expect(spy).toHaveBeenCalledWith(
+          'The maxValuesPerFacet set by dynamic widgets (20) is smaller than one of the limits set by a widget (100). This causes a mismatch in query parameters and thus an extra network request when that widget is mounted.'
+        );
+      });
+
+      it('warns if >20 facets are displayed due to implicit *', () => {
+        const spy = jest.spyOn(console, 'warn');
+        const props = {
+          contextValue,
+          transformItems: (_items, { results }) =>
+            results.userData[0].MOCK_FACET_ORDER,
+        };
+        const searchState = {};
+        const searchResults = createSingleIndexSearchResults({
+          userData: [
+            {
+              MOCK_FACET_ORDER: Array.from(
+                { length: 21 },
+                (_, i) => `item${i}`
+              ),
+            },
+          ],
+        });
+
+        const actual = connector.getProvidedProps(
+          props,
+          searchState,
+          searchResults
+        );
+
+        expect(spy).toHaveBeenCalledWith(
+          'More than 20 facets are requested to be displayed without explicitly setting which facets to retrieve. This could have a performance impact. Set "facets" to [] to do two smaller network requests, or explicitly to [\'*\'] to avoid this warning.'
+        );
+
+        expect(actual.attributesToRender).toEqual([
+          'item0',
+          'item1',
+          'item2',
+          'item3',
+          'item4',
+          'item5',
+          'item6',
+          'item7',
+          'item8',
+          'item9',
+          'item10',
+          'item11',
+          'item12',
+          'item13',
+          'item14',
+          'item15',
+          'item16',
+          'item17',
+          'item18',
+          'item19',
+          'item20',
+        ]);
+      });
     });
   });
 
   describe('multi index', () => {
-    const contextValue = { mainTargetedIndex: 'first' };
     const indexContextValue = { targetedIndex: 'second' };
 
     const createMultiIndexSearchState = (state = {}) => ({

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectDynamicWidgets.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectDynamicWidgets.js
@@ -221,6 +221,66 @@ describe('connectDynamicWidgets', () => {
         expect(actual.attributesToRender).toEqual(['one', 'two']);
       });
 
+      it('fails when a non-star facet is given', () => {
+        const props = {
+          contextValue,
+          ...connector.defaultProps,
+          facets: ['lol'],
+        };
+        const searchState = {};
+        const searchResults = createSingleIndexSearchResults({});
+
+        expect(() =>
+          connector.getProvidedProps(props, searchState, searchResults)
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"The \`facets\` prop only accepts [] or [\\"*\\"], you passed [\\"lol\\"]"`
+        );
+      });
+
+      it('fails when a multiple star facets are given', () => {
+        const props = {
+          contextValue,
+          ...connector.defaultProps,
+          facets: ['*', '*'],
+        };
+        const searchState = {};
+        const searchResults = createSingleIndexSearchResults({});
+
+        expect(() =>
+          connector.getProvidedProps(props, searchState, searchResults)
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"The \`facets\` prop only accepts [] or [\\"*\\"], you passed [\\"*\\",\\"*\\"]"`
+        );
+      });
+
+      it('does not fail when only star facet is given', () => {
+        const props = {
+          contextValue,
+          ...connector.defaultProps,
+          facets: ['*'],
+        };
+        const searchState = {};
+        const searchResults = createSingleIndexSearchResults({});
+
+        expect(() =>
+          connector.getProvidedProps(props, searchState, searchResults)
+        ).not.toThrow();
+      });
+
+      it('does not fail when no facet is given', () => {
+        const props = {
+          contextValue,
+          ...connector.defaultProps,
+          facets: [],
+        };
+        const searchState = {};
+        const searchResults = createSingleIndexSearchResults({});
+
+        expect(() =>
+          connector.getProvidedProps(props, searchState, searchResults)
+        ).not.toThrow();
+      });
+
       it('warns if maxValuesPerFacet is lower than set by another widget', () => {
         const spy = jest.spyOn(console, 'warn');
         const props = {

--- a/packages/react-instantsearch-core/src/connectors/connectDynamicWidgets.ts
+++ b/packages/react-instantsearch-core/src/connectors/connectDynamicWidgets.ts
@@ -25,6 +25,21 @@ export default createConnector({
       multiIndexContext: props.indexContextValue,
     });
 
+    if (
+      props.facets &&
+      !(
+        Array.isArray(props.facets) &&
+        props.facets.length <= 1 &&
+        (props.facets[0] === '*' || props.facets[0] === undefined)
+      )
+    ) {
+      throw new Error(
+        `The \`facets\` prop only accepts [] or ["*"], you passed ${JSON.stringify(
+          props.facets
+        )}`
+      );
+    }
+
     if (!results) {
       return { attributesToRender: [] };
     }

--- a/stories/DynamicWidgets.stories.js
+++ b/stories/DynamicWidgets.stories.js
@@ -11,35 +11,54 @@ import { WrapWithHits } from './util';
 
 const stories = storiesOf('DynamicWidgets', module);
 
-stories.add('default', () => (
-  <WrapWithHits
-    initialSearchState={{ refinementList: { brand: ['Apple'] } }}
-    hasPlayground={true}
-    linkedStoryGroup="DynamicWidgets.stories.js"
-  >
-    <DynamicWidgets
-      transformItems={(_attributes, { results }) => {
-        if (results._state.query === 'dog') {
-          return ['categories'];
-        }
-        if (results._state.query === 'lego') {
-          return ['categories', 'brand'];
-        }
-        return ['brand', 'hierarchicalCategories.lvl0', 'categories'];
-      }}
+stories
+  .add('default', () => (
+    <WrapWithHits
+      hasPlayground={true}
+      linkedStoryGroup="DynamicWidgets.stories.js"
     >
-      <HierarchicalMenu
-        attributes={[
-          'hierarchicalCategories.lvl0',
-          'hierarchicalCategories.lvl1',
-          'hierarchicalCategories.lvl2',
-          'hierarchicalCategories.lvl3',
-        ]}
-      />
-      <Panel>
-        <RefinementList attribute="brand" />
-      </Panel>
-      <Menu attribute="categories" />
-    </DynamicWidgets>
-  </WrapWithHits>
-));
+      <p>
+        try the queries: <q>dog</q> or <q>lego</q>.
+      </p>
+      <DynamicWidgets fallbackWidget={RefinementList}>
+        <HierarchicalMenu
+          attributes={[
+            'hierarchicalCategories.lvl0',
+            'hierarchicalCategories.lvl1',
+            'hierarchicalCategories.lvl2',
+            'hierarchicalCategories.lvl3',
+          ]}
+        />
+        <Panel header="Brand">
+          <RefinementList attribute="brand" />
+        </Panel>
+        <Menu attribute="categories" />
+      </DynamicWidgets>
+    </WrapWithHits>
+  ))
+  .add('multiple requests', () => (
+    <WrapWithHits
+      initialSearchState={{ refinementList: { brand: ['Apple'] } }}
+      hasPlayground={true}
+      linkedStoryGroup="DynamicWidgets.stories.js"
+    >
+      <p>
+        try the queries: <q>dog</q> or <q>lego</q>. Notice how there are two
+        network requests, with a minimal payload each.
+      </p>
+      <DynamicWidgets fallbackWidget={RefinementList} facets={[]}>
+        <HierarchicalMenu
+          attributes={[
+            'hierarchicalCategories.lvl0',
+            'hierarchicalCategories.lvl1',
+            'hierarchicalCategories.lvl2',
+            'hierarchicalCategories.lvl3',
+          ]}
+        />
+        <Panel header="Brand">
+          <RefinementList attribute="brand" />
+        </Panel>
+        <Menu attribute="categories" />
+      </DynamicWidgets>
+    </WrapWithHits>
+  ));


### PR DESCRIPTION
FX-622

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

The default additional search parameters of `{ facets: ['*'], maxValuesPerFacet: 20 }` prevents an extra network request when widgets mount/unmount, as both queries will be identical, and thus cached.

If a refinement is set, this still results in two network requests, as the refinements can't be applied before it's known if the widget should be mounted.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

When dynamic widgets is used without an explicit configure widget with `facets: ['*']` and `maxValuesPerFacet: highestLimit` an extra network request happens on load, which has a negative impact on performance. With the new additional parameters default value, widgets mounting or unmounting no longer require a separate network request

Two new parameters are added to `connectDynamicWidgets` and `dynamicWidgets`:

```js
<DynamicWidgets
  // ... other parameters
  // overridden with the default value
  facets={['*']}
  maxValuesPerFacet={20}
/>
```

The default behaviour can also be avoided, and the previous default (non-matching parameters, which does two network requests) can be done like this:

```js
<DynamicWidgets
  // ... other parameters
  // overridden default to ensure two requests are sent,
  // and that not all facets are requested
  facets={[]}
/>
```
