### PR TITLE
docs(hooks): support `href` prop in `<Pagination>`

### DIFF
--- a/examples/hooks/components/CurrentRefinements.tsx
+++ b/examples/hooks/components/CurrentRefinements.tsx
@@ -5,7 +5,7 @@ import {
 } from 'react-instantsearch-hooks';
 
 import { cx } from '../cx';
-import { isSpecialClick } from '../isSpecialClick';
+import { isModifierClick } from '../isModifierClick';
 
 export type CurrentRefinementsProps = React.ComponentProps<'div'> &
   UseCurrentRefinementsProps;
@@ -42,7 +42,7 @@ export function CurrentRefinements(props: CurrentRefinementsProps) {
                 </span>
                 <button
                   onClick={(event) => {
-                    if (isSpecialClick(event)) {
+                    if (isModifierClick(event)) {
                       return;
                     }
 

--- a/examples/hooks/components/HierarchicalMenu.tsx
+++ b/examples/hooks/components/HierarchicalMenu.tsx
@@ -5,7 +5,7 @@ import {
 } from 'react-instantsearch-hooks';
 
 import { cx } from '../cx';
-import { isSpecialClick } from '../isSpecialClick';
+import { isModifierClick } from '../isModifierClick';
 
 export type HierarchicalMenuProps = React.ComponentProps<'div'> &
   UseHierarchicalMenuProps;
@@ -32,7 +32,7 @@ function HierarchicalList({
             className="ais-HierarchicalMenu-link"
             href={createURL(item.value)}
             onClick={(event) => {
-              if (isSpecialClick(event)) {
+              if (isModifierClick(event)) {
                 return;
               }
               event.preventDefault();

--- a/examples/hooks/components/Menu.tsx
+++ b/examples/hooks/components/Menu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useMenu, UseMenuProps } from 'react-instantsearch-hooks';
 
 import { cx } from '../cx';
-import { isSpecialClick } from '../isSpecialClick';
+import { isModifierClick } from '../isModifierClick';
 
 export type MenuProps = React.ComponentProps<'div'> & UseMenuProps;
 
@@ -30,7 +30,7 @@ export function Menu(props: MenuProps) {
             <a
               className="ais-Menu-link"
               onClick={(event) => {
-                if (isSpecialClick(event)) {
+                if (isModifierClick(event)) {
                   return;
                 }
                 event.preventDefault();

--- a/examples/hooks/components/Pagination.tsx
+++ b/examples/hooks/components/Pagination.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { usePagination, UsePaginationProps } from 'react-instantsearch-hooks';
 import { cx } from '../cx';
+import { isModifierClick } from '../isModifierClick';
 
 export type PaginationProps = React.ComponentProps<'div'> & UsePaginationProps;
 
 export function Pagination(props: PaginationProps) {
   const {
     refine,
+    createURL,
     pages,
     currentRefinement,
     isFirstPage,
@@ -25,31 +27,29 @@ export function Pagination(props: PaginationProps) {
     >
       <ul className="ais-Pagination-list">
         <PaginationItem
+          aria-label="First"
+          value={0}
+          isDisabled={isFirstPage}
+          createURL={createURL}
+          refine={refine}
           className={cx(
             'ais-Pagination-item',
             'ais-Pagination-item--firstPage'
           )}
-          aria-label="First"
-          isDisabled={isFirstPage}
-          onClick={(event) => {
-            event.preventDefault();
-            refine(0);
-          }}
         >
           ‹‹
         </PaginationItem>
 
         <PaginationItem
+          aria-label="Previous"
+          value={currentRefinement - 1}
+          isDisabled={isFirstPage}
+          createURL={createURL}
+          refine={refine}
           className={cx(
             'ais-Pagination-item',
             'ais-Pagination-item--previousPage'
           )}
-          aria-label="Previous"
-          isDisabled={isFirstPage}
-          onClick={(event) => {
-            event.preventDefault();
-            refine(currentRefinement - 1);
-          }}
         >
           ‹
         </PaginationItem>
@@ -57,41 +57,38 @@ export function Pagination(props: PaginationProps) {
         {pages.map((page) => (
           <PaginationItem
             key={page}
+            aria-label={String(page)}
+            value={page}
+            isDisabled={false}
+            createURL={createURL}
+            refine={refine}
             className={cx(
               'ais-Pagination-item',
               page === currentRefinement && 'ais-Pagination-item--selected'
             )}
-            aria-label={String(page)}
-            isDisabled={false}
-            onClick={(event) => {
-              event.preventDefault();
-              refine(page);
-            }}
           >
             {page + 1}
           </PaginationItem>
         ))}
 
         <PaginationItem
-          className={cx('ais-Pagination-item', 'ais-Pagination-item--nextPage')}
           aria-label="Next"
+          value={currentRefinement + 1}
           isDisabled={isLastPage}
-          onClick={(event) => {
-            event.preventDefault();
-            refine(currentRefinement + 1);
-          }}
+          createURL={createURL}
+          refine={refine}
+          className={cx('ais-Pagination-item', 'ais-Pagination-item--nextPage')}
         >
           ›
         </PaginationItem>
 
         <PaginationItem
-          className={cx('ais-Pagination-item', 'ais-Pagination-item--lastPage')}
           aria-label="Last"
+          value={nbPages - 1}
           isDisabled={isLastPage}
-          onClick={(event) => {
-            event.preventDefault();
-            refine(nbPages - 1);
-          }}
+          createURL={createURL}
+          refine={refine}
+          className={cx('ais-Pagination-item', 'ais-Pagination-item--lastPage')}
         >
           ››
         </PaginationItem>
@@ -100,12 +97,15 @@ export function Pagination(props: PaginationProps) {
   );
 }
 
-type PaginationItemProps = React.ComponentProps<'a'> & {
-  isDisabled: boolean;
-};
+type PaginationItemProps = React.ComponentProps<'a'> &
+  Pick<ReturnType<typeof usePagination>, 'refine' | 'createURL'> & {
+    isDisabled: boolean;
+    value: number;
+  };
 
 function PaginationItem(props: PaginationItemProps) {
-  const { isDisabled, className, ...rest } = props;
+  const { isDisabled, className, href, value, createURL, refine, ...rest } =
+    props;
 
   if (isDisabled) {
     return (
@@ -117,7 +117,19 @@ function PaginationItem(props: PaginationItemProps) {
 
   return (
     <li className={className}>
-      <a className="ais-Pagination-link" href="#" {...rest} />
+      <a
+        className="ais-Pagination-link"
+        href={createURL(value)}
+        onClick={(event) => {
+          if (isModifierClick(event)) {
+            return;
+          }
+
+          event.preventDefault();
+          refine(value);
+        }}
+        {...rest}
+      />
     </li>
   );
 }

--- a/examples/hooks/isModifierClick.ts
+++ b/examples/hooks/isModifierClick.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function isSpecialClick(event: React.MouseEvent) {
+export function isModifierClick(event: React.MouseEvent) {
   const isMiddleClick = event.button === 1;
   return Boolean(
     isMiddleClick ||


### PR DESCRIPTION
This adds support for the `href` HTML attribute on the `<Pagination>` links.

Prior to this PR, there was an accessibility issue because the `href` property wasn't computed, and it wasn't possible to open the page in a new link when <kbd>⌘</kbd> + Click.