### PR TITLE
fix(hooks): allow importing via require

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:e2e:saucelabs": "wdio wdio.saucelabs.conf.js",
     "test:integration": "NODE_ENV=development yarn test:regressions && yarn test:argos",
     "test:examples": "node scripts/test-examples.js",
-    "test:build": "yarn build && yarn test:size && node ./test/module/packages-are-es-modules.mjs",
+    "test:build": "yarn build && yarn test:size && node ./test/module/packages-are-es-modules.mjs && node ./test/module/packages-are-cjs-modules.cjs",
     "test:regressions": "webpack --config integration/webpack.config.js && node integration/runTest.js",
     "test:argos": "argos upload integration/screenshots --token $ARGOS_TOKEN || true",
     "test:size": "bundlesize",

--- a/packages/react-instantsearch-hooks-server/package.json
+++ b/packages/react-instantsearch-hooks-server/package.json
@@ -37,7 +37,7 @@
     "clean": "rm -rf dist",
     "watch": "yarn build:cjs --watch",
     "build": "yarn build:cjs && yarn build:es && yarn build:umd && yarn build:types",
-    "build:cjs": "babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/replace-import-for-cjs.sh",
+    "build:cjs": "babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
     "build:es": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet",
     "build:umd": "BABEL_ENV=rollup rollup -c rollup.config.js",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es"

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf dist",
     "watch": "yarn build:cjs --watch",
     "build": "yarn build:cjs && yarn build:es && yarn build:umd && yarn build:types",
-    "build:cjs": "babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/replace-import-for-cjs.sh",
+    "build:cjs": "babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
     "build:es": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet",
     "build:umd": "BABEL_ENV=rollup rollup -c rollup.config.js",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es"

--- a/scripts/prepare-cjs.sh
+++ b/scripts/prepare-cjs.sh
@@ -7,3 +7,7 @@ find dist/cjs -type f -exec sed -i.bak 's|instantsearch.js/es|instantsearch.js/c
 
 # clean up the .bak files, as the set -i'' can not be enabled on BSD/Mac and Linux with the same syntax
 find dist/cjs -name '*.bak' -type f -exec rm {} +
+
+# create a package.json to be able to import using require
+touch dist/cjs/package.json
+echo '{ "type": "commonjs", "sideEffects": false }' > dist/cjs/package.json

--- a/test/module/packages-are-cjs-modules.cjs
+++ b/test/module/packages-are-cjs-modules.cjs
@@ -1,0 +1,9 @@
+/* eslint-disable import/no-commonjs */
+
+const assert = require('assert');
+
+const ReactInstantSearchHooks = require('react-instantsearch-hooks');
+const ReactInstantSearchHooksServer = require('react-instantsearch-hooks-server');
+
+assert.ok(ReactInstantSearchHooks);
+assert.ok(ReactInstantSearchHooksServer);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

opposite of making sure esm is fully esm, the cjs also needs to be fully cjs.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- [x] a package.json in the cjs root
- [x] test similar to packages-are-es-modules but for cjs
- [x] [remix sandbox](https://codesandbox.io/s/react-instantsearch-hooks-with-remix-forked-p58r1) works ([forked with this PR](https://codesandbox.io/s/react-instantsearch-hooks-with-remix-forked-pvkgv))
