### PR TITLE
refactor(hooks): use invariant in context Hooks

### DIFF
--- a/packages/react-instantsearch-hooks/src/__tests__/compat.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/compat.test.tsx
@@ -26,7 +26,7 @@ describe('Compat', () => {
         </InstantSearchCore>
       );
     }).toThrowErrorMatchingInlineSnapshot(`
-      "Hooks must be used inside the <InstantSearch> component.
+      "[InstantSearch] Hooks must be used inside the <InstantSearch> component.
 
       They are not compatible with the \`react-instantsearch-core\` and \`react-instantsearch-dom\` packages, so make sure to use the <InstantSearch> component from \`react-instantsearch-hooks\`."
     `);

--- a/packages/react-instantsearch-hooks/src/components/__tests__/Index.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/Index.test.tsx
@@ -19,7 +19,7 @@ describe('Index', () => {
     expect(() => {
       render(<Index indexName="childIndex">Children</Index>);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"The <Index> component must be used within <InstantSearch>."`
+      `"[InstantSearch] The <Index> component must be used within <InstantSearch>."`
     );
 
     jest.spyOn(console, 'error').mockRestore();

--- a/packages/react-instantsearch-hooks/src/lib/invariant.ts
+++ b/packages/react-instantsearch-hooks/src/lib/invariant.ts
@@ -1,5 +1,8 @@
 /**
- * Throws an error if the condition is not met in development mode.
+ * Throws an error if the condition is not met.
+ *
+ * The error is exhaustive in development, and becomes generic in production.
+ *
  * This is used to make development a better experience to provide guidance as
  * to where the error comes from.
  */

--- a/packages/react-instantsearch-hooks/src/lib/useIndexContext.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useIndexContext.ts
@@ -1,15 +1,16 @@
 import { useContext } from 'react';
 
+import { invariant } from '../lib/invariant';
+
 import { IndexContext } from './IndexContext';
 
 export function useIndexContext() {
   const context = useContext(IndexContext);
 
-  if (context === null) {
-    throw new Error(
-      'The <Index> component must be used within <InstantSearch>.'
-    );
-  }
+  invariant(
+    context !== null,
+    'The <Index> component must be used within <InstantSearch>.'
+  );
 
   return context;
 }

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
@@ -1,16 +1,17 @@
 import { useContext } from 'react';
 
+import { invariant } from '../lib/invariant';
+
 import { InstantSearchContext } from './InstantSearchContext';
 
 export function useInstantSearchContext() {
   const context = useContext(InstantSearchContext);
 
-  if (context === null) {
-    throw new Error(
-      'Hooks must be used inside the <InstantSearch> component.\n\n' +
-        'They are not compatible with the `react-instantsearch-core` and `react-instantsearch-dom` packages, so make sure to use the <InstantSearch> component from `react-instantsearch-hooks`.'
-    );
-  }
+  invariant(
+    context !== null,
+    'Hooks must be used inside the <InstantSearch> component.\n\n' +
+      'They are not compatible with the `react-instantsearch-core` and `react-instantsearch-dom` packages, so make sure to use the <InstantSearch> component from `react-instantsearch-hooks`.'
+  );
 
   return context;
 }


### PR DESCRIPTION
This saves a couple of bytes on the production bundle by throwing via invariants when Context conditions are not met.