### PR TITLE
docs(examples): remove query state sync in `<SearchBox>`

### DIFF
--- a/examples/hooks-next/components/SearchBox.tsx
+++ b/examples/hooks-next/components/SearchBox.tsx
@@ -34,15 +34,6 @@ export function SearchBox(props: SearchBoxProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, refine]);
 
-  useEffect(() => {
-    if (query !== value) {
-      setValue(query);
-    }
-    // We want to track when the query coming from InstantSearch.js changes
-    // to update the React state, so we don't need to track the state value.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
-
   return (
     <ControlledSearchBox
       className={props.className}

--- a/examples/hooks-ssr/src/components/SearchBox.js
+++ b/examples/hooks-ssr/src/components/SearchBox.js
@@ -26,15 +26,6 @@ export function SearchBox(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refine, value]);
 
-  useEffect(() => {
-    if (query !== value) {
-      setValue(query);
-    }
-    // We want to track when the query coming from InstantSearch.js changes
-    // to update the React state, so we don't need to track the state value.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
-
   return (
     <ControlledSearchBox
       className={props.className}

--- a/examples/hooks/components/SearchBox.tsx
+++ b/examples/hooks/components/SearchBox.tsx
@@ -28,15 +28,6 @@ export function SearchBox(props: SearchBoxProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, refine]);
 
-  useEffect(() => {
-    if (query !== value) {
-      setValue(query);
-    }
-    // We want to track when the query coming from InstantSearch.js changes
-    // to update the React state, so we don't need to track the state value.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
-
   return (
     <ControlledSearchBox
       className={props.className}


### PR DESCRIPTION
This removes the `useEffect()` in the `<SearchBox>`  responsible for synchronizing the InstantSearch.js internal query to the `<SearchBox>` React state because it overrides the DOM value concurrently when typing fast.

This is temporary before releasing the library and documentation, until we find an alternative.