### PR TITLE
feat(server): load data twice in the case of dynamic widget usage

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -602,7 +602,8 @@ describe('createConnector', () => {
         expect.any(Function),
         { ais: context },
         { ...props, contextValue: context },
-        expect.any(Function)
+        expect.any(Function),
+        'CoolConnector'
       );
     });
 

--- a/packages/react-instantsearch-core/src/core/createConnector.tsx
+++ b/packages/react-instantsearch-core/src/core/createConnector.tsx
@@ -109,7 +109,8 @@ export function createConnectorWithoutContext(
               multiIndexContext: this.props.indexContextValue,
             },
             this.props,
-            connectorDesc.getMetadata && connectorDesc.getMetadata.bind(this)
+            connectorDesc.getMetadata && connectorDesc.getMetadata.bind(this),
+            connectorDesc.displayName
           );
         }
       }

--- a/packages/react-instantsearch-core/src/widgets/Index.tsx
+++ b/packages/react-instantsearch-core/src/widgets/Index.tsx
@@ -81,7 +81,8 @@ class Index extends Component<InnerProps, State> {
         multiIndexContext: this.state.indexContext,
       },
       this.props,
-      undefined
+      undefined,
+      Index.displayName
     );
   }
 

--- a/packages/react-instantsearch-core/src/widgets/InstantSearch.tsx
+++ b/packages/react-instantsearch-core/src/widgets/InstantSearch.tsx
@@ -64,6 +64,7 @@ type Props = {
     searchState: SearchState;
     context: { ais: InstantSearchContext; multiIndexContext: IndexContext };
     props: object;
+    displayName: string;
   }) => void;
   stalledSearchDelay?: number;
   resultsState?: ResultsState | { [indexId: string]: ResultsState };
@@ -276,7 +277,8 @@ class InstantSearch extends Component<Props, State> {
       multiIndexContext: IndexContext;
     },
     props: object,
-    getMetadata: ConnectorDescription['getMetadata']
+    getMetadata: ConnectorDescription['getMetadata'],
+    displayName: string
   ) {
     if (this.props.onSearchParameters) {
       const searchState = this.props.searchState ? this.props.searchState : {};
@@ -295,6 +297,7 @@ class InstantSearch extends Component<Props, State> {
         context,
         props,
         searchState,
+        displayName,
       });
     }
   }

--- a/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
+++ b/packages/react-instantsearch-dom/src/core/__tests__/createInstantSearchServer.js
@@ -21,6 +21,7 @@ describe('findResultsState', () => {
       Promise.resolve({
         results: requests.map(({ indexName, params: { query } }) => ({
           query,
+          hits: [],
           renderingContent: {
             facetOrdering: {
               facets: {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Same as #3259, but for React InstantSearch core, not hooks.

We render twice in the case that dynamic widgets are discovered

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- no search request when there's a refinement applied using server side rendering
- no flash of non-filtered content
- https://codesandbox.io/s/keen-moon-wdxou fixed by this PR (select a refinement and reload)
