### PR TITLE
chore(release): bump all lib deps on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-uglify": "6.0.3",
-    "shipjs": "0.24.0",
+    "shipjs": "0.24.1",
     "style-loader": "1.0.0",
     "typescript": "4.3.5",
     "webpack": "4.40.2",

--- a/ship.config.js
+++ b/ship.config.js
@@ -1,21 +1,20 @@
 const fs = require('fs');
 const path = require('path');
 
-const packages = [
-  'packages/react-instantsearch-core',
-  'packages/react-instantsearch-dom-maps',
-  'packages/react-instantsearch-dom',
-  'packages/react-instantsearch-hooks',
-  'packages/react-instantsearch-hooks-server',
-  'packages/react-instantsearch-native',
-  'packages/react-instantsearch',
-];
-
 module.exports = {
   monorepo: {
     mainVersionFile: 'lerna.json',
-    packagesToBump: packages,
-    packagesToPublish: packages,
+    // We rely on Lerna to bump our dependencies.
+    packagesToBump: [],
+    packagesToPublish: [
+      'packages/react-instantsearch-core',
+      'packages/react-instantsearch-dom-maps',
+      'packages/react-instantsearch-dom',
+      'packages/react-instantsearch-hooks',
+      'packages/react-instantsearch-hooks-server',
+      'packages/react-instantsearch-native',
+      'packages/react-instantsearch',
+    ],
   },
   versionUpdated: ({ version, exec, dir }) => {
     // Update version in `react-instantsearch-core`
@@ -42,17 +41,9 @@ module.exports = {
       `export default '${version}';\n`
     );
 
-    // update version in top level package
-    exec(`mversion ${version}`);
-
-    // update version in packages & dependencies
-    exec(`lerna version ${version} --no-git-tag-version --no-push --yes`);
-
-    // @TODO: We can remove after initial npm release of `react-instantsearch-hooks-server`
-    // We update the Hooks and Hooks Server package dependency in the example because Lerna doesn't
-    // and releasing fails because the Hooks Server package has not yet been released on npm.
+    // Update version in packages and dependencies
     exec(
-      `yarn workspace hooks-ssr-example upgrade react-instantsearch-hooks-server@${version}`
+      `yarn lerna version ${version} --exact --no-git-tag-version --no-push --yes`
     );
   },
   shouldPrepare: ({ releaseType, commitNumbersPerType }) => {
@@ -77,9 +68,11 @@ module.exports = {
       latestCommitUrl,
       repoURL,
     }) => ({
-      pretext: [`:tada: Successfully released *${appName}@${version}*`].join(
-        '\n'
-      ),
+      pretext: [
+        `:tada: Successfully released *${appName}@${version}*`,
+        '',
+        `Make sure to run \`yarn run release-templates\` in \`create-instantsearch-app\`.`,
+      ].join('\n'),
       fields: [
         {
           title: 'Branch',

--- a/ship.config.js
+++ b/ship.config.js
@@ -61,7 +61,6 @@ module.exports = {
     // Ship.js will send slack message only for `releaseSuccess`.
     prepared: null,
     releaseSuccess: ({
-      appName,
       version,
       tagName,
       latestCommitHash,
@@ -69,7 +68,7 @@ module.exports = {
       repoURL,
     }) => ({
       pretext: [
-        `:tada: Successfully released *${appName}@${version}*`,
+        `:tada: Successfully released *React InstantSearch v${version}*`,
         '',
         `Make sure to run \`yarn run release-templates\` in \`create-instantsearch-app\`.`,
       ].join('\n'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -25532,10 +25532,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shipjs-lib@0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/shipjs-lib/-/shipjs-lib-0.24.0.tgz#a14ed4f23422e2ae9429ec554f65deb258a1cb46"
-  integrity sha512-2j3rziFNx/rJX7xXDpgQPPUUNXZBXx1S3nMA44ZJ41kbfHJx/XhYCt6V2hZVpNnpCWnZE67lziHBXx8aUKr6tQ==
+shipjs-lib@0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/shipjs-lib/-/shipjs-lib-0.24.1.tgz#bf0951a0c2dd50d21e373a300e3f3c6de868c182"
+  integrity sha512-iQSGz80CJ+aR4fEWSjj32qNd25DwEWB0seZ+ieKFyHQuJCwi3VaRsVd3OSnFE1iotHU03azXuq+JOVqmkFzKsg==
   dependencies:
     deepmerge "^4.2.2"
     dotenv "^8.1.0"
@@ -25543,10 +25543,10 @@ shipjs-lib@0.24.0:
     semver "6.3.0"
     shelljs "0.8.4"
 
-shipjs@0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/shipjs/-/shipjs-0.24.0.tgz#480211d2bb353356d33400b75bd8716caf7ae1e2"
-  integrity sha512-OFBQi4hnlHU2N7UU13K/nZvweJI43TLhwwC0RvQ5ZhOYtYfk5t7x7tdLrKmOzTikIuG7wrvBcQrutIXrKUdweg==
+shipjs@0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/shipjs/-/shipjs-0.24.1.tgz#c8149594b4bc78abd3a84f171220179cf7f23755"
+  integrity sha512-9VdudGeMjXIDQe3YYIdbbTUc9xqBggBnfgAoJ4Clj+cIq19ACcqDaqGfZN/e4QMzjMyWPGb8FItCpAD2SEQKKQ==
   dependencies:
     "@babel/runtime" "^7.6.3"
     "@octokit/rest" "^17.0.0"
@@ -25570,7 +25570,7 @@ shipjs@0.24.0:
     prettier "^2.0.0"
     serialize-javascript "^3.0.0"
     shell-quote "^1.7.2"
-    shipjs-lib "0.24.0"
+    shipjs-lib "0.24.1"
     temp-write "4.0.0"
     tempfile "^3.0.0"
 


### PR DESCRIPTION
This fixes our release process by updating all our lib dependencies (including the ones in our examples) on release. The fix is to rely on Lerna to update the deps, and not Ship.js.

You can see #3273 that shows the output of this PR.