### PR TITLE
wip: apply initial search parameters in hooks

### DIFF
--- a/packages/react-instantsearch-hooks/src/connectors/__tests__/useSearchBox.test.tsx
+++ b/packages/react-instantsearch-hooks/src/connectors/__tests__/useSearchBox.test.tsx
@@ -28,4 +28,35 @@ describe('useSearchBox', () => {
       refine: expect.any(Function),
     });
   });
+
+  test('returns the connector render state with ui state', async () => {
+    const wrapper = createInstantSearchTestWrapper({
+      initialUiState: {
+        indexName: {
+          query: 'testio',
+        },
+      },
+    });
+    const { result, waitForNextUpdate } = renderHook(() => useSearchBox(), {
+      wrapper,
+    });
+
+    // Initial render state from manual `getWidgetRenderState`
+    expect(result.current).toEqual({
+      query: 'testio',
+      isSearchStalled: false,
+      clear: expect.any(Function),
+      refine: expect.any(Function),
+    });
+
+    await waitForNextUpdate();
+
+    // InstantSearch.js state from the `render` lifecycle step
+    expect(result.current).toEqual({
+      query: 'testio',
+      isSearchStalled: false,
+      clear: expect.any(Function),
+      refine: expect.any(Function),
+    });
+  });
 });

--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -100,7 +100,13 @@ export function useConnector<
         instantSearchInstance: search,
         results,
         scopedResults,
-        state: results._state,
+        state: widget.getWidgetSearchParameters
+          ? widget.getWidgetSearchParameters(results._state, {
+              uiState: parentIndex.getWidgetUiState({})[
+                parentIndex.getIndexId()
+              ],
+            })
+          : results._state,
         renderState: search.renderState,
         templatesConfig: search.templatesConfig,
         createURL: parentIndex.createURL,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

the state of "results" when not doing server side rendering isn't aware of the widgets yet. This is incorrect, and thus we need to call getWidgetSearchParameters before rendering.

This is still wrong when the state has been set by another widget, in the case of breadcrumb/hierarchical menu. I think that can be fixed by having both widgets apply the same state (maybe the already do it, I didn't test)

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

slower initial mount, but actually correct 📦 