### PR TITLE
docs(examples): sync InstantSearch query with React state

### DIFF
--- a/examples/hooks-ssr/src/components/SearchBox.js
+++ b/examples/hooks-ssr/src/components/SearchBox.js
@@ -16,15 +16,27 @@ export function SearchBox(props) {
     setValue(event.currentTarget.value);
   }
 
+  // Track when the value coming from the React state changes to synchronize
+  // it with InstantSearch.
   useEffect(() => {
     if (query !== value) {
       refine(value);
     }
-    // We want to track when the value coming from the React state changes
-    // to update the InstantSearch.js query, so we don't need to track the
-    // InstantSearch.js query.
+    // We don't want to track when the InstantSearch query changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refine, value]);
+  }, [value, refine]);
+
+  // Track when the InstantSearch query changes to synchronize it with
+  // the React state.
+  useEffect(() => {
+    // We bypass the state update if the input is focused to avoid concurrent
+    // updates when typing.
+    if (document.activeElement !== inputRef.current && query !== value) {
+      setValue(query);
+    }
+    // We don't want to track when the React state value changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
 
   return (
     <ControlledSearchBox

--- a/examples/hooks/components/SearchBox.tsx
+++ b/examples/hooks/components/SearchBox.tsx
@@ -18,15 +18,27 @@ export function SearchBox(props: SearchBoxProps) {
     setValue(event.currentTarget.value);
   }
 
+  // Track when the value coming from the React state changes to synchronize
+  // it with InstantSearch.
   useEffect(() => {
     if (query !== value) {
       refine(value);
     }
-    // We want to track when the value coming from the React state changes
-    // to update the InstantSearch.js query, so we don't need to track the
-    // InstantSearch.js query.
+    // We don't want to track when the InstantSearch query changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, refine]);
+
+  // Track when the InstantSearch query changes to synchronize it with
+  // the React state.
+  useEffect(() => {
+    // We bypass the state update if the input is focused to avoid concurrent
+    // updates when typing.
+    if (document.activeElement !== inputRef.current && query !== value) {
+      setValue(query);
+    }
+    // We don't want to track when the React state value changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
 
   return (
     <ControlledSearchBox


### PR DESCRIPTION
This updates the Hooks `<SearchBox>` examples to synchronize the InstantSearch internal query with the component's React state.

The difference from #3264 is that before synchronizing the state, we check if the `<input>` is the active element. This avoids concurrency issues when typing fast, while still supporting scenarios like "Back button". ([Reference to similar code in InstantSearch.js](https://github.com/algolia/instantsearch.js/blob/7dcec376a36b42400f2b83bed9807c763303c058/src/components/SearchBox/SearchBox.tsx#L100)).