### PR TITLE
fix(hooks): enable pause on exceptions on warning

### DIFF
--- a/packages/react-instantsearch-hooks/src/lib/warn.ts
+++ b/packages/react-instantsearch-hooks/src/lib/warn.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, no-empty */
+
 export const warnCache = {
   current: {},
 };
@@ -22,7 +24,15 @@ export function warn(condition: boolean, message: string) {
     warnCache.current[sanitizedMessage] = true;
     const warning = `[InstantSearch] ${sanitizedMessage}`;
 
-    // eslint-disable-next-line no-console
     console.warn(warning);
+
+    try {
+      // Welcome to debugging InstantSearch.
+      //
+      // This error was thrown as a convenience so that you can find the source
+      // of the warning that appears in the console by enabling "Pause on exceptions"
+      // in your debugger.
+      throw new Error(warning);
+    } catch (error) {}
   }
 }


### PR DESCRIPTION
## Description

This slightly improves the DX by updating our `warning()` util to throw an error and catch it immediately as a convenience so that you can find the source of the warning that appears in the console by enabling "Pause on exceptions" in the JavaScript debugger.

A similar strategy is used in:

- [React](https://github.com/facebook/fbjs/blob/865675200037a867727c7361ff06be772effe169/packages/fbjs/src/__forks__/warning.js#L28-L33)
- [React Router](https://github.com/remix-run/react-router/blob/f16c5490dfa75f15dcfb86d2a981a7c58a9d1a33/packages/react-router/index.tsx#L27-L35)

## Preview

![Screen Shot 2022-01-28 at 11 38 16](https://user-images.githubusercontent.com/6137112/151532892-9d44097a-03e6-4e64-931a-b5b9cf113a99.png)

## Resources

- [Automatically pause on any exception](https://developers.google.com/web/updates/2015/05/automatically-pause-on-any-exception)
