### PR TITLE
feat(hooks): allow additional widget properties to be passed from hooks

### DIFF
--- a/packages/react-instantsearch-hooks/src/components/Configure.tsx
+++ b/packages/react-instantsearch-hooks/src/components/Configure.tsx
@@ -5,7 +5,7 @@ import type { UseConfigureProps } from '../connectors/useConfigure';
 export type ConfigureProps = UseConfigureProps;
 
 export function Configure(props: ConfigureProps) {
-  useConfigure(props, 'ais.configure');
+  useConfigure(props, { $$widgetType: 'ais.configure' });
 
   return null;
 }

--- a/packages/react-instantsearch-hooks/src/components/Configure.tsx
+++ b/packages/react-instantsearch-hooks/src/components/Configure.tsx
@@ -5,7 +5,7 @@ import type { UseConfigureProps } from '../connectors/useConfigure';
 export type ConfigureProps = UseConfigureProps;
 
 export function Configure(props: ConfigureProps) {
-  useConfigure(props);
+  useConfigure(props, 'ais.configure');
 
   return null;
 }

--- a/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
@@ -29,7 +29,9 @@ export function DynamicWidgets({
   fallbackComponent: Fallback = FallbackComponent,
   ...props
 }: DynamicWidgetsProps) {
-  const { attributesToRender } = useDynamicWidgets(props, 'ais.dynamicWidgets');
+  const { attributesToRender } = useDynamicWidgets(props, {
+    $$widgetType: 'ais.dynamicWidgets',
+  });
   const widgets: Map<string, ReactChild> = new Map();
 
   React.Children.forEach(children, (child) => {

--- a/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
@@ -29,7 +29,7 @@ export function DynamicWidgets({
   fallbackComponent: Fallback = FallbackComponent,
   ...props
 }: DynamicWidgetsProps) {
-  const { attributesToRender } = useDynamicWidgets(props);
+  const { attributesToRender } = useDynamicWidgets(props, 'ais.dynamicWidgets');
   const widgets: Map<string, ReactChild> = new Map();
 
   React.Children.forEach(children, (child) => {

--- a/packages/react-instantsearch-hooks/src/connectors/useBreadcrumb.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useBreadcrumb.ts
@@ -9,9 +9,10 @@ import type {
 
 export type UseBreadcrumbProps = BreadcrumbConnectorParams;
 
-export function useBreadcrumb(props: UseBreadcrumbProps) {
+export function useBreadcrumb(props: UseBreadcrumbProps, widgetType?: string) {
   return useConnector<BreadcrumbConnectorParams, BreadcrumbWidgetDescription>(
     connectBreadcrumb,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useBreadcrumb.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useBreadcrumb.ts
@@ -2,6 +2,7 @@ import connectBreadcrumb from 'instantsearch.js/es/connectors/breadcrumb/connect
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   BreadcrumbConnectorParams,
   BreadcrumbWidgetDescription,
@@ -9,10 +10,13 @@ import type {
 
 export type UseBreadcrumbProps = BreadcrumbConnectorParams;
 
-export function useBreadcrumb(props: UseBreadcrumbProps, widgetType?: string) {
+export function useBreadcrumb(
+  props: UseBreadcrumbProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
   return useConnector<BreadcrumbConnectorParams, BreadcrumbWidgetDescription>(
     connectBreadcrumb,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useClearRefinements.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useClearRefinements.ts
@@ -9,9 +9,12 @@ import type {
 
 export type UseClearRefinementsProps = ClearRefinementsConnectorParams;
 
-export function useClearRefinements(props?: UseClearRefinementsProps) {
+export function useClearRefinements(
+  props?: UseClearRefinementsProps,
+  widgetType?: string
+) {
   return useConnector<
     ClearRefinementsConnectorParams,
     ClearRefinementsWidgetDescription
-  >(connectClearRefinements, props);
+  >(connectClearRefinements, props, widgetType);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useClearRefinements.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useClearRefinements.ts
@@ -2,6 +2,7 @@ import connectClearRefinements from 'instantsearch.js/es/connectors/clear-refine
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   ClearRefinementsConnectorParams,
   ClearRefinementsWidgetDescription,
@@ -11,10 +12,10 @@ export type UseClearRefinementsProps = ClearRefinementsConnectorParams;
 
 export function useClearRefinements(
   props?: UseClearRefinementsProps,
-  widgetType?: string
+  additionalWidgetProperties?: AdditionalWidgetProperties
 ) {
   return useConnector<
     ClearRefinementsConnectorParams,
     ClearRefinementsWidgetDescription
-  >(connectClearRefinements, props, widgetType);
+  >(connectClearRefinements, props, additionalWidgetProperties);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useConfigure.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useConfigure.ts
@@ -9,9 +9,10 @@ import type {
 
 export type UseConfigureProps = ConfigureConnectorParams['searchParameters'];
 
-export function useConfigure(props: UseConfigureProps) {
+export function useConfigure(props: UseConfigureProps, widgetType?: string) {
   return useConnector<ConfigureConnectorParams, ConfigureWidgetDescription>(
     connectConfigure,
-    { searchParameters: props }
+    { searchParameters: props },
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useConfigure.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useConfigure.ts
@@ -2,6 +2,7 @@ import connectConfigure from 'instantsearch.js/es/connectors/configure/connectCo
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   ConfigureConnectorParams,
   ConfigureWidgetDescription,
@@ -9,10 +10,13 @@ import type {
 
 export type UseConfigureProps = ConfigureConnectorParams['searchParameters'];
 
-export function useConfigure(props: UseConfigureProps, widgetType?: string) {
+export function useConfigure(
+  props: UseConfigureProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
   return useConnector<ConfigureConnectorParams, ConfigureWidgetDescription>(
     connectConfigure,
     { searchParameters: props },
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useCurrentRefinements.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useCurrentRefinements.ts
@@ -2,6 +2,7 @@ import connectCurrentRefinements from 'instantsearch.js/es/connectors/current-re
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   CurrentRefinementsConnectorParams,
   CurrentRefinementsWidgetDescription,
@@ -11,10 +12,10 @@ export type UseCurrentRefinementsProps = CurrentRefinementsConnectorParams;
 
 export function useCurrentRefinements(
   props?: UseCurrentRefinementsProps,
-  widgetType?: string
+  additionalWidgetProperties?: AdditionalWidgetProperties
 ) {
   return useConnector<
     CurrentRefinementsConnectorParams,
     CurrentRefinementsWidgetDescription
-  >(connectCurrentRefinements, props, widgetType);
+  >(connectCurrentRefinements, props, additionalWidgetProperties);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useCurrentRefinements.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useCurrentRefinements.ts
@@ -9,9 +9,12 @@ import type {
 
 export type UseCurrentRefinementsProps = CurrentRefinementsConnectorParams;
 
-export function useCurrentRefinements(props?: UseCurrentRefinementsProps) {
+export function useCurrentRefinements(
+  props?: UseCurrentRefinementsProps,
+  widgetType?: string
+) {
   return useConnector<
     CurrentRefinementsConnectorParams,
     CurrentRefinementsWidgetDescription
-  >(connectCurrentRefinements, props);
+  >(connectCurrentRefinements, props, widgetType);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useDynamicWidgets.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useDynamicWidgets.ts
@@ -12,14 +12,21 @@ export type UseDynamicWidgetsProps = Omit<
   'widgets' | 'fallbackWidget'
 >;
 
-export function useDynamicWidgets(props?: UseDynamicWidgetsProps) {
+export function useDynamicWidgets(
+  props?: UseDynamicWidgetsProps,
+  widgetType?: string
+) {
   return useConnector<
     DynamicWidgetsConnectorParams,
     DynamicWidgetsWidgetDescription
-  >(connectDynamicWidgets, {
-    ...props,
-    // We don't rely on InstantSearch.js for rendering widgets because React
-    // directly manipulates the children.
-    widgets: [],
-  });
+  >(
+    connectDynamicWidgets,
+    {
+      ...props,
+      // We don't rely on InstantSearch.js for rendering widgets because React
+      // directly manipulates the children.
+      widgets: [],
+    },
+    widgetType
+  );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useDynamicWidgets.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useDynamicWidgets.ts
@@ -2,6 +2,7 @@ import connectDynamicWidgets from 'instantsearch.js/es/connectors/dynamic-widget
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   DynamicWidgetsConnectorParams,
   DynamicWidgetsWidgetDescription,
@@ -14,7 +15,7 @@ export type UseDynamicWidgetsProps = Omit<
 
 export function useDynamicWidgets(
   props?: UseDynamicWidgetsProps,
-  widgetType?: string
+  additionalWidgetProperties?: AdditionalWidgetProperties
 ) {
   return useConnector<
     DynamicWidgetsConnectorParams,
@@ -27,6 +28,6 @@ export function useDynamicWidgets(
       // directly manipulates the children.
       widgets: [],
     },
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useHierarchicalMenu.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useHierarchicalMenu.ts
@@ -9,9 +9,12 @@ import type {
 
 export type UseHierarchicalMenuProps = HierarchicalMenuConnectorParams;
 
-export function useHierarchicalMenu(props: UseHierarchicalMenuProps) {
+export function useHierarchicalMenu(
+  props: UseHierarchicalMenuProps,
+  widgetType?: string
+) {
   return useConnector<
     HierarchicalMenuConnectorParams,
     HierarchicalMenuWidgetDescription
-  >(connectHierarchicalMenu, props);
+  >(connectHierarchicalMenu, props, widgetType);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useHierarchicalMenu.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useHierarchicalMenu.ts
@@ -2,6 +2,7 @@ import connectHierarchicalMenu from 'instantsearch.js/es/connectors/hierarchical
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   HierarchicalMenuConnectorParams,
   HierarchicalMenuWidgetDescription,
@@ -11,10 +12,10 @@ export type UseHierarchicalMenuProps = HierarchicalMenuConnectorParams;
 
 export function useHierarchicalMenu(
   props: UseHierarchicalMenuProps,
-  widgetType?: string
+  additionalWidgetProperties?: AdditionalWidgetProperties
 ) {
   return useConnector<
     HierarchicalMenuConnectorParams,
     HierarchicalMenuWidgetDescription
-  >(connectHierarchicalMenu, props, widgetType);
+  >(connectHierarchicalMenu, props, additionalWidgetProperties);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useHits.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useHits.ts
@@ -9,9 +9,10 @@ import type {
 
 export type UseHitsProps = HitsConnectorParams;
 
-export function useHits(props?: UseHitsProps) {
+export function useHits(props?: UseHitsProps, widgetType?: string) {
   return useConnector<HitsConnectorParams, HitsWidgetDescription>(
     connectHits,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useHits.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useHits.ts
@@ -2,6 +2,7 @@ import connectHits from 'instantsearch.js/es/connectors/hits/connectHits';
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   HitsConnectorParams,
   HitsWidgetDescription,
@@ -9,10 +10,13 @@ import type {
 
 export type UseHitsProps = HitsConnectorParams;
 
-export function useHits(props?: UseHitsProps, widgetType?: string) {
+export function useHits(
+  props?: UseHitsProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
   return useConnector<HitsConnectorParams, HitsWidgetDescription>(
     connectHits,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useHitsPerPage.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useHitsPerPage.ts
@@ -2,6 +2,7 @@ import connectHitsPerPage from 'instantsearch.js/es/connectors/hits-per-page/con
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   HitsPerPageConnectorParams,
   HitsPerPageWidgetDescription,
@@ -11,11 +12,11 @@ export type UseHitsPerPageProps = HitsPerPageConnectorParams;
 
 export function useHitsPerPage(
   props: UseHitsPerPageProps,
-  widgetType?: string
+  additionalWidgetProperties?: AdditionalWidgetProperties
 ) {
   return useConnector<HitsPerPageConnectorParams, HitsPerPageWidgetDescription>(
     connectHitsPerPage,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useHitsPerPage.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useHitsPerPage.ts
@@ -9,9 +9,13 @@ import type {
 
 export type UseHitsPerPageProps = HitsPerPageConnectorParams;
 
-export function useHitsPerPage(props: UseHitsPerPageProps) {
+export function useHitsPerPage(
+  props: UseHitsPerPageProps,
+  widgetType?: string
+) {
   return useConnector<HitsPerPageConnectorParams, HitsPerPageWidgetDescription>(
     connectHitsPerPage,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useInfiniteHits.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useInfiniteHits.ts
@@ -2,6 +2,7 @@ import connectInfiniteHits from 'instantsearch.js/es/connectors/infinite-hits/co
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   InfiniteHitsConnectorParams,
   InfiniteHitsWidgetDescription,
@@ -11,10 +12,10 @@ export type UseInfiniteHitsProps = InfiniteHitsConnectorParams;
 
 export function useInfiniteHits(
   props?: UseInfiniteHitsProps,
-  widgetType?: string
+  additionalWidgetProperties?: AdditionalWidgetProperties
 ) {
   return useConnector<
     InfiniteHitsConnectorParams,
     InfiniteHitsWidgetDescription
-  >(connectInfiniteHits, props, widgetType);
+  >(connectInfiniteHits, props, additionalWidgetProperties);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useInfiniteHits.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useInfiniteHits.ts
@@ -9,9 +9,12 @@ import type {
 
 export type UseInfiniteHitsProps = InfiniteHitsConnectorParams;
 
-export function useInfiniteHits(props?: UseInfiniteHitsProps) {
+export function useInfiniteHits(
+  props?: UseInfiniteHitsProps,
+  widgetType?: string
+) {
   return useConnector<
     InfiniteHitsConnectorParams,
     InfiniteHitsWidgetDescription
-  >(connectInfiniteHits, props);
+  >(connectInfiniteHits, props, widgetType);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useMenu.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useMenu.ts
@@ -9,9 +9,10 @@ import type {
 
 export type UseMenuProps = MenuConnectorParams;
 
-export function useMenu(props: UseMenuProps) {
+export function useMenu(props: UseMenuProps, widgetType?: string) {
   return useConnector<MenuConnectorParams, MenuWidgetDescription>(
     connectMenu,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useMenu.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useMenu.ts
@@ -2,6 +2,7 @@ import connectMenu from 'instantsearch.js/es/connectors/menu/connectMenu';
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   MenuConnectorParams,
   MenuWidgetDescription,
@@ -9,10 +10,13 @@ import type {
 
 export type UseMenuProps = MenuConnectorParams;
 
-export function useMenu(props: UseMenuProps, widgetType?: string) {
+export function useMenu(
+  props: UseMenuProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
   return useConnector<MenuConnectorParams, MenuWidgetDescription>(
     connectMenu,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useNumericMenu.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useNumericMenu.ts
@@ -9,9 +9,13 @@ import type {
 
 export type UseNumericMenuProps = NumericMenuConnectorParams;
 
-export function useNumericMenu(props: UseNumericMenuProps) {
+export function useNumericMenu(
+  props: UseNumericMenuProps,
+  widgetType?: string
+) {
   return useConnector<NumericMenuConnectorParams, NumericMenuWidgetDescription>(
     connectNumericMenu,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useNumericMenu.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useNumericMenu.ts
@@ -2,6 +2,7 @@ import connectNumericMenu from 'instantsearch.js/es/connectors/numeric-menu/conn
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   NumericMenuConnectorParams,
   NumericMenuWidgetDescription,
@@ -11,11 +12,11 @@ export type UseNumericMenuProps = NumericMenuConnectorParams;
 
 export function useNumericMenu(
   props: UseNumericMenuProps,
-  widgetType?: string
+  additionalWidgetProperties?: AdditionalWidgetProperties
 ) {
   return useConnector<NumericMenuConnectorParams, NumericMenuWidgetDescription>(
     connectNumericMenu,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/usePagination.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/usePagination.ts
@@ -9,9 +9,10 @@ import type {
 
 export type UsePaginationProps = PaginationConnectorParams;
 
-export function usePagination(props?: UsePaginationProps) {
+export function usePagination(props?: UsePaginationProps, widgetType?: string) {
   return useConnector<PaginationConnectorParams, PaginationWidgetDescription>(
     connectPagination,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/usePagination.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/usePagination.ts
@@ -2,6 +2,7 @@ import connectPagination from 'instantsearch.js/es/connectors/pagination/connect
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   PaginationConnectorParams,
   PaginationWidgetDescription,
@@ -9,10 +10,13 @@ import type {
 
 export type UsePaginationProps = PaginationConnectorParams;
 
-export function usePagination(props?: UsePaginationProps, widgetType?: string) {
+export function usePagination(
+  props?: UsePaginationProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
   return useConnector<PaginationConnectorParams, PaginationWidgetDescription>(
     connectPagination,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useQueryRules.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useQueryRules.ts
@@ -9,9 +9,10 @@ import type {
 
 export type UseQueryRulesProps = QueryRulesConnectorParams;
 
-export function useQueryRules(props?: UseQueryRulesProps) {
+export function useQueryRules(props?: UseQueryRulesProps, widgetType?: string) {
   return useConnector<QueryRulesConnectorParams, QueryRulesWidgetDescription>(
     connectQueryRules,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useQueryRules.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useQueryRules.ts
@@ -2,6 +2,7 @@ import connectQueryRules from 'instantsearch.js/es/connectors/query-rules/connec
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   QueryRulesConnectorParams,
   QueryRulesWidgetDescription,
@@ -9,10 +10,13 @@ import type {
 
 export type UseQueryRulesProps = QueryRulesConnectorParams;
 
-export function useQueryRules(props?: UseQueryRulesProps, widgetType?: string) {
+export function useQueryRules(
+  props?: UseQueryRulesProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
   return useConnector<QueryRulesConnectorParams, QueryRulesWidgetDescription>(
     connectQueryRules,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useRange.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useRange.ts
@@ -2,6 +2,7 @@ import connectRange from 'instantsearch.js/es/connectors/range/connectRange';
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   RangeConnectorParams,
   RangeWidgetDescription,
@@ -9,10 +10,13 @@ import type {
 
 export type UseRangeProps = RangeConnectorParams;
 
-export function useRange(props: UseRangeProps, widgetType?: string) {
+export function useRange(
+  props: UseRangeProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
   return useConnector<RangeConnectorParams, RangeWidgetDescription>(
     connectRange,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useRange.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useRange.ts
@@ -9,9 +9,10 @@ import type {
 
 export type UseRangeProps = RangeConnectorParams;
 
-export function useRange(props: UseRangeProps) {
+export function useRange(props: UseRangeProps, widgetType?: string) {
   return useConnector<RangeConnectorParams, RangeWidgetDescription>(
     connectRange,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useRefinementList.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useRefinementList.ts
@@ -2,6 +2,7 @@ import connectRefinementList from 'instantsearch.js/es/connectors/refinement-lis
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   RefinementListConnectorParams,
   RefinementListWidgetDescription,
@@ -11,10 +12,10 @@ export type UseRefinementListProps = RefinementListConnectorParams;
 
 export function useRefinementList(
   props: UseRefinementListProps,
-  widgetType?: string
+  additionalWidgetProperties?: AdditionalWidgetProperties
 ) {
   return useConnector<
     RefinementListConnectorParams,
     RefinementListWidgetDescription
-  >(connectRefinementList, props, widgetType);
+  >(connectRefinementList, props, additionalWidgetProperties);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useRefinementList.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useRefinementList.ts
@@ -9,9 +9,12 @@ import type {
 
 export type UseRefinementListProps = RefinementListConnectorParams;
 
-export function useRefinementList(props: UseRefinementListProps) {
+export function useRefinementList(
+  props: UseRefinementListProps,
+  widgetType?: string
+) {
   return useConnector<
     RefinementListConnectorParams,
     RefinementListWidgetDescription
-  >(connectRefinementList, props);
+  >(connectRefinementList, props, widgetType);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useSearchBox.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useSearchBox.ts
@@ -9,9 +9,10 @@ import type {
 
 export type UseSearchBoxProps = SearchBoxConnectorParams;
 
-export function useSearchBox(props?: UseSearchBoxProps) {
+export function useSearchBox(props?: UseSearchBoxProps, widgetType?: string) {
   return useConnector<SearchBoxConnectorParams, SearchBoxWidgetDescription>(
     connectSearchBox,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useSearchBox.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useSearchBox.ts
@@ -2,6 +2,7 @@ import connectSearchBox from 'instantsearch.js/es/connectors/search-box/connectS
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   SearchBoxConnectorParams,
   SearchBoxWidgetDescription,
@@ -9,10 +10,13 @@ import type {
 
 export type UseSearchBoxProps = SearchBoxConnectorParams;
 
-export function useSearchBox(props?: UseSearchBoxProps, widgetType?: string) {
+export function useSearchBox(
+  props?: UseSearchBoxProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
   return useConnector<SearchBoxConnectorParams, SearchBoxWidgetDescription>(
     connectSearchBox,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useSortBy.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useSortBy.ts
@@ -2,6 +2,7 @@ import connectSortBy from 'instantsearch.js/es/connectors/sort-by/connectSortBy'
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   SortByConnectorParams,
   SortByWidgetDescription,
@@ -9,10 +10,13 @@ import type {
 
 export type UseSortByProps = SortByConnectorParams;
 
-export function useSortBy(props: UseSortByProps, widgetType?: string) {
+export function useSortBy(
+  props: UseSortByProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
   return useConnector<SortByConnectorParams, SortByWidgetDescription>(
     connectSortBy,
     props,
-    widgetType
+    additionalWidgetProperties
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useSortBy.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useSortBy.ts
@@ -9,9 +9,10 @@ import type {
 
 export type UseSortByProps = SortByConnectorParams;
 
-export function useSortBy(props: UseSortByProps) {
+export function useSortBy(props: UseSortByProps, widgetType?: string) {
   return useConnector<SortByConnectorParams, SortByWidgetDescription>(
     connectSortBy,
-    props
+    props,
+    widgetType
   );
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useToggleRefinement.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useToggleRefinement.ts
@@ -9,9 +9,12 @@ import type {
 
 export type UseToggleRefinementProps = ToggleRefinementConnectorParams;
 
-export function useToggleRefinement(props: UseToggleRefinementProps) {
+export function useToggleRefinement(
+  props: UseToggleRefinementProps,
+  widgetType?: string
+) {
   return useConnector<
     ToggleRefinementConnectorParams,
     ToggleRefinementWidgetDescription
-  >(connectToggleRefinement, props);
+  >(connectToggleRefinement, props, widgetType);
 }

--- a/packages/react-instantsearch-hooks/src/connectors/useToggleRefinement.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useToggleRefinement.ts
@@ -2,6 +2,7 @@ import connectToggleRefinement from 'instantsearch.js/es/connectors/toggle-refin
 
 import { useConnector } from '../hooks/useConnector';
 
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   ToggleRefinementConnectorParams,
   ToggleRefinementWidgetDescription,
@@ -11,10 +12,10 @@ export type UseToggleRefinementProps = ToggleRefinementConnectorParams;
 
 export function useToggleRefinement(
   props: UseToggleRefinementProps,
-  widgetType?: string
+  additionalWidgetProperties?: AdditionalWidgetProperties
 ) {
   return useConnector<
     ToggleRefinementConnectorParams,
     ToggleRefinementWidgetDescription
-  >(connectToggleRefinement, props, widgetType);
+  >(connectToggleRefinement, props, additionalWidgetProperties);
 }

--- a/packages/react-instantsearch-hooks/src/hooks/__tests__/useConnector.test.tsx
+++ b/packages/react-instantsearch-hooks/src/hooks/__tests__/useConnector.test.tsx
@@ -126,7 +126,7 @@ describe('useConnector', () => {
     const wrapper = createInstantSearchTestWrapper();
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useConnector(connectCustomSearchBox, {}, undefined),
+      () => useConnector(connectCustomSearchBox, {}, {}),
       { wrapper }
     );
 
@@ -163,7 +163,7 @@ describe('useConnector', () => {
     }
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useConnector(connectCustomSearchBox, {}, undefined),
+      () => useConnector(connectCustomSearchBox, {}, {}),
       { wrapper: Wrapper }
     );
 
@@ -192,8 +192,7 @@ describe('useConnector', () => {
     const wrapper = createInstantSearchTestWrapper();
 
     const { result, waitForNextUpdate } = renderHook(
-      () =>
-        useConnector(connectCustomSearchBoxWithoutRenderState, {}, undefined),
+      () => useConnector(connectCustomSearchBoxWithoutRenderState, {}, {}),
       { wrapper }
     );
 
@@ -235,7 +234,7 @@ describe('useConnector', () => {
       );
     }
 
-    renderHook(() => useConnector(connectCustomSearchBoxMock, {}, undefined), {
+    renderHook(() => useConnector(connectCustomSearchBoxMock, {}, {}), {
       wrapper: SearchProvider,
     });
 
@@ -270,7 +269,7 @@ describe('useConnector', () => {
       useConnector<Record<never, never>, CustomSearchBoxWidgetDescription>(
         connectCustomSearchBox,
         {},
-        'test.customSearchBox'
+        { $$widgetType: 'test.customSearchBox' }
       );
 
       return null;

--- a/packages/react-instantsearch-hooks/src/hooks/__tests__/useConnector.test.tsx
+++ b/packages/react-instantsearch-hooks/src/hooks/__tests__/useConnector.test.tsx
@@ -126,7 +126,7 @@ describe('useConnector', () => {
     const wrapper = createInstantSearchTestWrapper();
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useConnector(connectCustomSearchBox, {}),
+      () => useConnector(connectCustomSearchBox, {}, undefined),
       { wrapper }
     );
 
@@ -163,7 +163,7 @@ describe('useConnector', () => {
     }
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useConnector(connectCustomSearchBox, {}),
+      () => useConnector(connectCustomSearchBox, {}, undefined),
       { wrapper: Wrapper }
     );
 
@@ -192,7 +192,8 @@ describe('useConnector', () => {
     const wrapper = createInstantSearchTestWrapper();
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useConnector(connectCustomSearchBoxWithoutRenderState, {}),
+      () =>
+        useConnector(connectCustomSearchBoxWithoutRenderState, {}, undefined),
       { wrapper }
     );
 
@@ -234,7 +235,7 @@ describe('useConnector', () => {
       );
     }
 
-    renderHook(() => useConnector(connectCustomSearchBoxMock, {}), {
+    renderHook(() => useConnector(connectCustomSearchBoxMock, {}, undefined), {
       wrapper: SearchProvider,
     });
 
@@ -268,7 +269,8 @@ describe('useConnector', () => {
     function CustomSearchBox() {
       useConnector<Record<never, never>, CustomSearchBoxWidgetDescription>(
         connectCustomSearchBox,
-        {}
+        {},
+        'test.customSearchBox'
       );
 
       return null;
@@ -305,7 +307,10 @@ describe('useConnector', () => {
     expect(indexContext!.addWidgets).toHaveBeenCalledTimes(1);
     expect(indexContext!.addWidgets).toHaveBeenCalledWith(
       expect.arrayContaining([
-        expect.objectContaining({ $$type: 'test.searchBox' }),
+        expect.objectContaining({
+          $$type: 'test.searchBox',
+          $$widgetType: 'test.customSearchBox',
+        }),
       ])
     );
 
@@ -314,7 +319,10 @@ describe('useConnector', () => {
     expect(indexContext!.removeWidgets).toHaveBeenCalledTimes(1);
     expect(indexContext!.removeWidgets).toHaveBeenCalledWith(
       expect.arrayContaining([
-        expect.objectContaining({ $$type: 'test.searchBox' }),
+        expect.objectContaining({
+          $$type: 'test.searchBox',
+          $$widgetType: 'test.customSearchBox',
+        }),
       ])
     );
   });

--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -15,7 +15,7 @@ export function useConnector<
 >(
   connector: Connector<TDescription, TProps>,
   props: TProps = {} as TProps,
-  widgetType?: string
+  widgetType: string | undefined
 ): TDescription['renderState'] {
   const serverContext = useInstantSearchServerContext();
   const search = useInstantSearchContext();

--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -14,7 +14,8 @@ export function useConnector<
   TDescription extends WidgetDescription
 >(
   connector: Connector<TDescription, TProps>,
-  props: TProps = {} as TProps
+  props: TProps = {} as TProps,
+  widgetType?: string
 ): TDescription['renderState'] {
   const serverContext = useInstantSearchServerContext();
   const search = useInstantSearchContext();
@@ -60,6 +61,7 @@ export function useConnector<
     );
 
     const instance = createWidget(stableProps);
+    instance.$$widgetType = widgetType;
 
     // On the server, we add the widget early in the memo to retrieve its search
     // parameters in the render pass.
@@ -68,7 +70,7 @@ export function useConnector<
     }
 
     return instance;
-  }, [connector, parentIndex, serverContext, stableProps]);
+  }, [connector, parentIndex, serverContext, stableProps, widgetType]);
 
   const [state, setState] = useState<TDescription['renderState']>(() => {
     if (widget.getWidgetRenderState) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

widgetType (one of the additional properties) gets used to distinguish between builtin components and user-defined components, which either have no widgetType or a user-defined one.

This also allows a user to override a specific life cycle of a widget, if that would be needed

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- useConnector accepts "additional properties" that get set on widget instance
- all hooks accept "additional properties" optionally
- builtin components (configure, dynamic widgets) set the default widgetType, but don't allow further "additional properties" (can be added later without breaking change)