### PR TITLE
feat(hooks): implement Pagination component

### DIFF
--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -8,6 +8,7 @@ import {
   CurrentRefinements,
   DynamicWidgets,
   Hits,
+  Pagination,
   SearchBox,
 } from 'react-instantsearch-hooks-dom';
 
@@ -19,7 +20,6 @@ import {
   InfiniteHits,
   Menu,
   NumericMenu,
-  Pagination,
   Panel,
   PoweredBy,
   QueryRuleContext,

--- a/examples/hooks/components/index.ts
+++ b/examples/hooks/components/index.ts
@@ -4,7 +4,6 @@ export * from './Highlight';
 export * from './InfiniteHits';
 export * from './Menu';
 export * from './NumericMenu';
-export * from './Pagination';
 export * from './HitsPerPage';
 export * from './Panel';
 export * from './PoweredBy';

--- a/packages/react-instantsearch-hooks-dom/src/ui/Pagination.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Pagination.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+
+import { cx } from './lib/cx';
+
+import type { CreateURL } from 'instantsearch.js';
+
+export type PaginationItem = {
+  label: string;
+  value: number;
+};
+
+export type PaginationProps = React.HTMLAttributes<HTMLDivElement> & {
+  items: PaginationItem[];
+  currentPage: number;
+  isFirstPage: boolean;
+  isLastPage: boolean;
+  nbPages: number;
+  createURL: CreateURL<number>;
+  onClick: React.AnchorHTMLAttributes<HTMLAnchorElement>['onClick'];
+};
+
+export function Pagination({
+  items,
+  currentPage,
+  nbPages,
+  isFirstPage,
+  isLastPage,
+  createURL,
+  onClick,
+  ...props
+}: PaginationProps) {
+  return (
+    <div
+      {...props}
+      className={cx(
+        'ais-Pagination',
+        items.length === 0 && 'ais-Pagination--noRefinement',
+        props.className
+      )}
+    >
+      <ul className="ais-Pagination-list">
+        <PaginationItem
+          isDisabled={isFirstPage}
+          className="ais-Pagination-item--firstPage"
+          aria-label="First"
+          href={createURL(0)}
+          onClick={onClick}
+        >
+          ‹‹
+        </PaginationItem>
+        <PaginationItem
+          isDisabled={isFirstPage}
+          className="ais-Pagination-item--previousPage"
+          aria-label="Previous"
+          href={createURL(currentPage - 1)}
+          onClick={onClick}
+        >
+          ‹
+        </PaginationItem>
+        {items.map(({ label }, index) => (
+          <PaginationItem
+            key={index}
+            isDisabled={false}
+            className={cx(
+              index === currentPage && 'ais-Pagination-item--selected'
+            )}
+            aria-label={label}
+            href={createURL(index)}
+            onClick={onClick}
+          >
+            {label}
+          </PaginationItem>
+        ))}
+        <PaginationItem
+          isDisabled={isLastPage}
+          className="ais-Pagination-item--nextPage"
+          aria-label="Next"
+          href={createURL(currentPage + 1)}
+          onClick={onClick}
+        >
+          ›
+        </PaginationItem>
+        <PaginationItem
+          isDisabled={isLastPage}
+          className="ais-Pagination-item--lastPage"
+          aria-label="Last"
+          href={createURL(nbPages - 1)}
+          onClick={onClick}
+        >
+          ››
+        </PaginationItem>
+      </ul>
+    </div>
+  );
+}
+
+type PaginationItemProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+  isDisabled: boolean;
+};
+
+function PaginationItem({
+  isDisabled,
+  className,
+  href,
+  onClick,
+  ...props
+}: PaginationItemProps) {
+  if (isDisabled) {
+    return (
+      <li
+        className={cx(
+          'ais-Pagination-item ais-Pagination-item--disabled',
+          className
+        )}
+      >
+        <span className="ais-Pagination-link" {...props} />
+      </li>
+    );
+  }
+
+  return (
+    <li className={cx('ais-Pagination-item', className)}>
+      <a
+        className="ais-Pagination-link"
+        href={href}
+        onClick={onClick}
+        {...props}
+      />
+    </li>
+  );
+}

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
@@ -624,7 +624,7 @@ describe('Pagination', () => {
     expect(props.onNavigate).not.toHaveBeenCalled();
   });
 
-  test('hides the "First" item', () => {
+  test('hides the "First" item when `showFirst` is `false`', () => {
     const props = createProps({
       showFirst: false,
     });
@@ -702,7 +702,7 @@ describe('Pagination', () => {
     `);
   });
 
-  test('hides the "Previous" item', () => {
+  test('hides the "Previous" item when `showPrevious` is `false`', () => {
     const props = createProps({
       showPrevious: false,
     });
@@ -780,7 +780,7 @@ describe('Pagination', () => {
     `);
   });
 
-  test('hides the "Next" item', () => {
+  test('hides the "Next" item when `showNext` is `false`', () => {
     const props = createProps({
       showNext: false,
     });
@@ -855,7 +855,7 @@ describe('Pagination', () => {
     `);
   });
 
-  test('hides the "Last" item', () => {
+  test('hides the "Last" item when `showLast` is `false`', () => {
     const props = createProps({
       showLast: false,
     });

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
@@ -1,0 +1,741 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { Pagination } from '../Pagination';
+
+import type { PaginationProps } from '../Pagination';
+
+describe('Pagination', () => {
+  function createProps({ ...props }: Partial<PaginationProps>) {
+    const onClick = jest.fn();
+
+    return {
+      items: [
+        { label: '1', value: 0 },
+        { label: '2', value: 1 },
+      ],
+      currentPage: 0,
+      nbPages: 2,
+      isFirstPage: true,
+      isLastPage: false,
+      createURL: (value: number) => `/?page=${value + 1}`,
+      onClick,
+      ...props,
+    };
+  }
+
+  test('renders with items', () => {
+    const props = createProps({
+      currentPage: 1,
+      nbPages: 6,
+      isFirstPage: false,
+      isLastPage: false,
+    });
+
+    const { container } = render(<Pagination {...props} />);
+
+    const firstPageItem = document.querySelector(
+      '.ais-Pagination-item--firstPage'
+    );
+    const firstPageLink = firstPageItem!.querySelector('.ais-Pagination-link');
+    const previousPageItem = document.querySelector(
+      '.ais-Pagination-item--previousPage'
+    );
+    const previousPageLink = previousPageItem!.querySelector(
+      '.ais-Pagination-link'
+    );
+    const nextPageItem = document.querySelector(
+      '.ais-Pagination-item--nextPage'
+    );
+    const nextPageLink = nextPageItem!.querySelector('.ais-Pagination-link');
+    const lastPageItem = document.querySelector(
+      '.ais-Pagination-item--lastPage'
+    );
+    const lastPageLink = lastPageItem!.querySelector('.ais-Pagination-link');
+
+    expect(firstPageLink).toHaveAttribute('aria-label', 'First');
+    expect(firstPageLink).toHaveAttribute('href', '/?page=1');
+    expect(previousPageLink).toHaveAttribute('aria-label', 'Previous');
+    expect(previousPageLink).toHaveAttribute('href', '/?page=1');
+
+    expect(nextPageLink).toHaveAttribute('aria-label', 'Next');
+    expect(nextPageLink).toHaveAttribute('href', '/?page=3');
+    expect(lastPageLink).toHaveAttribute('aria-label', 'Last');
+    expect(lastPageLink).toHaveAttribute('href', '/?page=6');
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--firstPage"
+            >
+              <a
+                aria-label="First"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                ‹‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--previousPage"
+            >
+              <a
+                aria-label="Previous"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                ‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="/?page=3"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="/?page=6"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('enables first and previous page when current page is not the first page', () => {
+    const props = createProps({
+      currentPage: 1,
+      isFirstPage: false,
+      isLastPage: true,
+    });
+
+    const { container } = render(<Pagination {...props} />);
+
+    const firstPageItem = document.querySelector(
+      '.ais-Pagination-item--firstPage'
+    );
+    const previousPageItem = document.querySelector(
+      '.ais-Pagination-item--previousPage'
+    );
+
+    expect(firstPageItem).not.toHaveClass('ais-Pagination-item--disabled');
+    expect(previousPageItem).not.toHaveClass('ais-Pagination-item--disabled');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--firstPage"
+            >
+              <a
+                aria-label="First"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                ‹‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--previousPage"
+            >
+              <a
+                aria-label="Previous"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                ‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage"
+            >
+              <span
+                aria-label="Next"
+                class="ais-Pagination-link"
+              >
+                ›
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage"
+            >
+              <span
+                aria-label="Last"
+                class="ais-Pagination-link"
+              >
+                ››
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+
+    userEvent.click(
+      firstPageItem!.querySelector('.ais-Pagination-link') as HTMLButtonElement
+    );
+    userEvent.click(
+      previousPageItem!.querySelector(
+        '.ais-Pagination-link'
+      ) as HTMLButtonElement
+    );
+
+    expect(props.onClick).toHaveBeenCalledTimes(2);
+  });
+
+  test('disables first and previous page when current page is the first page', () => {
+    const props = createProps({});
+
+    const { container } = render(<Pagination {...props} />);
+
+    const firstPageItem = document.querySelector(
+      '.ais-Pagination-item--firstPage'
+    );
+    const previousPageItem = document.querySelector(
+      '.ais-Pagination-item--previousPage'
+    );
+
+    expect(firstPageItem).toHaveClass('ais-Pagination-item--disabled');
+    expect(previousPageItem).toHaveClass('ais-Pagination-item--disabled');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+
+    userEvent.click(
+      firstPageItem!.querySelector('.ais-Pagination-link') as HTMLButtonElement
+    );
+    userEvent.click(
+      previousPageItem!.querySelector(
+        '.ais-Pagination-link'
+      ) as HTMLButtonElement
+    );
+
+    expect(props.onClick).not.toHaveBeenCalled();
+  });
+
+  test('enables next and last page when current page is not the last page', () => {
+    const props = createProps({});
+
+    const { container } = render(<Pagination {...props} />);
+
+    const nextPageItem = document.querySelector(
+      '.ais-Pagination-item--nextPage'
+    );
+    const lastPageItem = document.querySelector(
+      '.ais-Pagination-item--lastPage'
+    );
+
+    expect(nextPageItem).not.toHaveClass('ais-Pagination-item--disabled');
+    expect(lastPageItem).not.toHaveClass('ais-Pagination-item--disabled');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+
+    userEvent.click(
+      nextPageItem!.querySelector('.ais-Pagination-link') as HTMLButtonElement
+    );
+    userEvent.click(
+      lastPageItem!.querySelector('.ais-Pagination-link') as HTMLButtonElement
+    );
+
+    expect(props.onClick).toHaveBeenCalledTimes(2);
+  });
+
+  test('disables next and last page when current page is the last page', () => {
+    const props = createProps({
+      currentPage: 1,
+      nbPages: 2,
+      isFirstPage: false,
+      isLastPage: true,
+    });
+
+    const { container } = render(<Pagination {...props} />);
+
+    const nextPageItem = document.querySelector(
+      '.ais-Pagination-item--nextPage'
+    );
+    const lastPageItem = document.querySelector(
+      '.ais-Pagination-item--lastPage'
+    );
+
+    expect(nextPageItem).toHaveClass('ais-Pagination-item--disabled');
+    expect(lastPageItem).toHaveClass('ais-Pagination-item--disabled');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--firstPage"
+            >
+              <a
+                aria-label="First"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                ‹‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--previousPage"
+            >
+              <a
+                aria-label="Previous"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                ‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage"
+            >
+              <span
+                aria-label="Next"
+                class="ais-Pagination-link"
+              >
+                ›
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage"
+            >
+              <span
+                aria-label="Last"
+                class="ais-Pagination-link"
+              >
+                ››
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+
+    userEvent.click(
+      nextPageItem!.querySelector('.ais-Pagination-link') as HTMLButtonElement
+    );
+    userEvent.click(
+      lastPageItem!.querySelector('.ais-Pagination-link') as HTMLButtonElement
+    );
+
+    expect(props.onClick).not.toHaveBeenCalled();
+  });
+
+  test('forwards a custom class name to the root element', () => {
+    const props = createProps({});
+
+    const { container } = render(
+      <Pagination {...props} className="MyPagination" />
+    );
+
+    expect(document.querySelector('.ais-Pagination')).toHaveClass(
+      'MyPagination'
+    );
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination MyPagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('forwards `div` props to the root element', () => {
+    const props = createProps({});
+
+    const { container } = render(
+      <Pagination {...props} title="Some custom title" />
+    );
+
+    expect(document.querySelector('.ais-Pagination')).toHaveAttribute(
+      'title',
+      'Some custom title'
+    );
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+          title="Some custom title"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+});

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
@@ -8,19 +8,20 @@ import type { PaginationProps } from '../Pagination';
 
 describe('Pagination', () => {
   function createProps({ ...props }: Partial<PaginationProps>) {
-    const onClick = jest.fn();
+    const onNavigate = jest.fn();
 
     return {
-      items: [
-        { label: '1', value: 0 },
-        { label: '2', value: 1 },
-      ],
+      pages: [0, 1],
       currentPage: 0,
       nbPages: 2,
       isFirstPage: true,
       isLastPage: false,
+      showFirst: true,
+      showPrevious: true,
+      showNext: true,
+      showLast: true,
       createURL: (value: number) => `/?page=${value + 1}`,
-      onClick,
+      onNavigate,
       ...props,
     };
   }
@@ -95,7 +96,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item"
+              class="ais-Pagination-item ais-Pagination-item--page"
             >
               <a
                 aria-label="1"
@@ -106,7 +107,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--selected"
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
                 aria-label="2"
@@ -193,7 +194,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item"
+              class="ais-Pagination-item ais-Pagination-item--page"
             >
               <a
                 aria-label="1"
@@ -204,7 +205,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--selected"
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
                 aria-label="2"
@@ -248,7 +249,7 @@ describe('Pagination', () => {
       ) as HTMLButtonElement
     );
 
-    expect(props.onClick).toHaveBeenCalledTimes(2);
+    expect(props.onNavigate).toHaveBeenCalledTimes(2);
   });
 
   test('disables first and previous page when current page is the first page', () => {
@@ -294,7 +295,7 @@ describe('Pagination', () => {
               </span>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--selected"
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
                 aria-label="1"
@@ -305,7 +306,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item"
+              class="ais-Pagination-item ais-Pagination-item--page"
             >
               <a
                 aria-label="2"
@@ -351,7 +352,7 @@ describe('Pagination', () => {
       ) as HTMLButtonElement
     );
 
-    expect(props.onClick).not.toHaveBeenCalled();
+    expect(props.onNavigate).not.toHaveBeenCalled();
   });
 
   test('enables next and last page when current page is not the last page', () => {
@@ -397,7 +398,7 @@ describe('Pagination', () => {
               </span>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--selected"
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
                 aria-label="1"
@@ -408,7 +409,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item"
+              class="ais-Pagination-item ais-Pagination-item--page"
             >
               <a
                 aria-label="2"
@@ -452,7 +453,7 @@ describe('Pagination', () => {
       lastPageItem!.querySelector('.ais-Pagination-link') as HTMLButtonElement
     );
 
-    expect(props.onClick).toHaveBeenCalledTimes(2);
+    expect(props.onNavigate).toHaveBeenCalledTimes(2);
   });
 
   test('disables next and last page when current page is the last page', () => {
@@ -505,7 +506,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item"
+              class="ais-Pagination-item ais-Pagination-item--page"
             >
               <a
                 aria-label="1"
@@ -516,7 +517,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--selected"
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
                 aria-label="2"
@@ -558,7 +559,375 @@ describe('Pagination', () => {
       lastPageItem!.querySelector('.ais-Pagination-link') as HTMLButtonElement
     );
 
-    expect(props.onClick).not.toHaveBeenCalled();
+    expect(props.onNavigate).not.toHaveBeenCalled();
+  });
+
+  test('does not trigger `onNavigate` callback when pressing a modifier key', () => {
+    const props = createProps({});
+
+    const { getByText } = render(<Pagination {...props} />);
+
+    const firstPageItem = document.querySelector(
+      '.ais-Pagination-item--firstPage'
+    );
+    const firstPageLink = firstPageItem!.querySelector('.ais-Pagination-link');
+
+    userEvent.click(firstPageLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(firstPageLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(firstPageLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(firstPageLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(firstPageLink as HTMLAnchorElement, { shiftKey: true });
+
+    const previousPageItem = document.querySelector(
+      '.ais-Pagination-item--previousPage'
+    );
+    const previousPageLink = previousPageItem!.querySelector(
+      '.ais-Pagination-link'
+    );
+
+    userEvent.click(previousPageLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(previousPageLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(previousPageLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(previousPageLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(previousPageLink as HTMLAnchorElement, { shiftKey: true });
+
+    const nextPageItem = document.querySelector(
+      '.ais-Pagination-item--nextPage'
+    );
+    const nextPageLink = nextPageItem!.querySelector('.ais-Pagination-link');
+
+    userEvent.click(nextPageLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(nextPageLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(nextPageLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(nextPageLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(nextPageLink as HTMLAnchorElement, { shiftKey: true });
+
+    const lastPageItem = document.querySelector(
+      '.ais-Pagination-item--lastPage'
+    );
+    const lastPageLink = lastPageItem!.querySelector('.ais-Pagination-link');
+
+    userEvent.click(lastPageLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(lastPageLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(lastPageLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(lastPageLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(lastPageLink as HTMLAnchorElement, { shiftKey: true });
+
+    const pageOneLink = getByText('1');
+
+    userEvent.click(pageOneLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(pageOneLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(pageOneLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(pageOneLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(pageOneLink as HTMLAnchorElement, { shiftKey: true });
+
+    expect(props.onNavigate).not.toHaveBeenCalled();
+  });
+
+  test('hides the "First" item', () => {
+    const props = createProps({
+      showFirst: false,
+    });
+
+    const { container } = render(<Pagination {...props} />);
+
+    expect(
+      document.querySelector('.ais-Pagination-item--firstPage')
+    ).toBeNull();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('hides the "Previous" item', () => {
+    const props = createProps({
+      showPrevious: false,
+    });
+
+    const { container } = render(<Pagination {...props} />);
+
+    expect(
+      document.querySelector('.ais-Pagination-item--previousPage')
+    ).toBeNull();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('hides the "Next" item', () => {
+    const props = createProps({
+      showNext: false,
+    });
+
+    const { container } = render(<Pagination {...props} />);
+
+    expect(document.querySelector('.ais-Pagination-item--nextPage')).toBeNull();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('hides the "Last" item', () => {
+    const props = createProps({
+      showLast: false,
+    });
+
+    const { container } = render(<Pagination {...props} />);
+
+    expect(document.querySelector('.ais-Pagination-item--lastPage')).toBeNull();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="/?page=1"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="/?page=2"
+              >
+                ›
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
   });
 
   test('forwards a custom class name to the root element', () => {
@@ -600,7 +969,7 @@ describe('Pagination', () => {
               </span>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--selected"
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
                 aria-label="1"
@@ -611,7 +980,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item"
+              class="ais-Pagination-item ais-Pagination-item--page"
             >
               <a
                 aria-label="2"
@@ -690,7 +1059,7 @@ describe('Pagination', () => {
               </span>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--selected"
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
                 aria-label="1"
@@ -701,7 +1070,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item"
+              class="ais-Pagination-item ais-Pagination-item--page"
             >
               <a
                 aria-label="2"

--- a/packages/react-instantsearch-hooks-dom/src/widgets/Pagination.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/Pagination.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { usePagination } from 'react-instantsearch-hooks';
+
+import { Pagination as PaginationUiComponent } from '../ui/Pagination';
+
+import type { PaginationProps as PaginationUiComponentProps } from '../ui/Pagination';
+import type { UsePaginationProps } from 'react-instantsearch-hooks';
+
+export type PaginationProps = Omit<
+  PaginationUiComponentProps,
+  | 'pages'
+  | 'currentPage'
+  | 'isFirstPage'
+  | 'isLastPage'
+  | 'nbPages'
+  | 'createURL'
+  | 'onNavigate'
+> &
+  UsePaginationProps;
+
+export function Pagination({
+  showFirst,
+  showPrevious,
+  showNext,
+  showLast,
+  padding,
+  totalPages,
+  ...props
+}: PaginationProps) {
+  const {
+    pages,
+    currentRefinement,
+    isFirstPage,
+    isLastPage,
+    nbPages,
+    createURL,
+    refine,
+  } = usePagination(
+    { padding, totalPages },
+    {
+      $$widgetType: 'ais.pagination',
+    }
+  );
+
+  return (
+    <PaginationUiComponent
+      {...props}
+      showFirst={showFirst}
+      showPrevious={showPrevious}
+      showNext={showNext}
+      showLast={showLast}
+      isFirstPage={isFirstPage}
+      isLastPage={isLastPage}
+      currentPage={currentRefinement}
+      nbPages={nbPages}
+      createURL={createURL}
+      onNavigate={refine}
+      pages={pages}
+    />
+  );
+}

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Pagination.test.tsx
@@ -1751,7 +1751,7 @@ describe('Pagination', () => {
     `);
   });
 
-  test('hides the "First" item', async () => {
+  test('hides the "First" item when `showFirst` is `false`', async () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <Pagination showFirst={false} />
@@ -1818,7 +1818,7 @@ describe('Pagination', () => {
     `);
   });
 
-  test('hides the "Previous" item', async () => {
+  test('hides the "Previous" item when `showPrevious` is `false`', async () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <Pagination showPrevious={false} />
@@ -1885,7 +1885,7 @@ describe('Pagination', () => {
     `);
   });
 
-  test('hides the "Next" item', async () => {
+  test('hides the "Next" item when `showNext` is `false`', async () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <Pagination showNext={false} />
@@ -1950,7 +1950,7 @@ describe('Pagination', () => {
     `);
   });
 
-  test('hides the "Last" item', async () => {
+  test('hides the "Last" item when `showLast` is `false`', async () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <Pagination showLast={false} />

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Pagination.test.tsx
@@ -1,0 +1,2096 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import {
+  createMultiSearchResponse,
+  createSearchClient,
+  createSingleSearchResponse,
+} from '../../../../../test/mock';
+import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { Pagination } from '../Pagination';
+
+describe('Pagination', () => {
+  test('renders with default props', async () => {
+    const { container } = render(
+      <InstantSearchHooksTestWrapper>
+        <Pagination />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination ais-Pagination--noRefinement"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage"
+            >
+              <span
+                aria-label="Next"
+                class="ais-Pagination-link"
+              >
+                ›
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage"
+            >
+              <span
+                aria-label="Last"
+                class="ais-Pagination-link"
+              >
+                ››
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('renders with items', async () => {
+    const client = createSearchClient({
+      search: (requests) =>
+        Promise.resolve(
+          createMultiSearchResponse(
+            ...requests.map((request) =>
+              createSingleSearchResponse({
+                hits: Array.from({ length: 1000 }).map((_, index) => ({
+                  objectID: String(index),
+                })),
+                index: request.indexName,
+              })
+            )
+          )
+        ),
+    });
+
+    const { container } = render(
+      <InstantSearchHooksTestWrapper searchClient={client}>
+        <Pagination />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    const pageItems = document.querySelectorAll('.ais-Pagination-item--page');
+
+    expect(pageItems).toHaveLength(7);
+    expect(pageItems[0]).toHaveClass('ais-Pagination-item--selected');
+    expect(
+      document.querySelector('.ais-Pagination-item--firstPage')
+    ).toHaveClass('ais-Pagination-item--disabled');
+    expect(
+      document.querySelector('.ais-Pagination-item--previousPage')
+    ).toHaveClass('ais-Pagination-item--disabled');
+    expect(
+      document.querySelector('.ais-Pagination-item--nextPage')
+    ).not.toHaveClass('ais-Pagination-item--disabled');
+    expect(
+      document.querySelector('.ais-Pagination-item--lastPage')
+    ).not.toHaveClass('ais-Pagination-item--disabled');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="3"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="4"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="5"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="6"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                6
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="7"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                7
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('navigates between pages', async () => {
+    const search = jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map((request) =>
+            createSingleSearchResponse({
+              hits: Array.from({ length: 1000 }).map((_, index) => ({
+                objectID: String(index),
+              })),
+              index: request.indexName,
+            })
+          )
+        )
+      )
+    );
+    const client = createSearchClient({ search });
+
+    const { container, getByText } = render(
+      <InstantSearchHooksTestWrapper searchClient={client}>
+        <Pagination />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    search.mockClear();
+
+    expect(
+      document.querySelector('.ais-Pagination-item--selected')
+    ).toHaveTextContent('1');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="3"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="4"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="5"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="6"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                6
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="7"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                7
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+
+    const firstPageItem = document.querySelector(
+      '.ais-Pagination-item--firstPage'
+    );
+    const previousPageItem = document.querySelector(
+      '.ais-Pagination-item--previousPage'
+    );
+    const nextPageItem = document.querySelector(
+      '.ais-Pagination-item--nextPage'
+    );
+    const lastPageItem = document.querySelector(
+      '.ais-Pagination-item--lastPage'
+    );
+
+    // We're on page 1, "First" and "Previous" links are disabled
+    expect(firstPageItem).toHaveClass('ais-Pagination-item--disabled');
+    expect(previousPageItem).toHaveClass('ais-Pagination-item--disabled');
+
+    userEvent.click(
+      firstPageItem!.querySelector('.ais-Pagination-link') as HTMLAnchorElement
+    );
+    userEvent.click(
+      previousPageItem!.querySelector(
+        '.ais-Pagination-link'
+      ) as HTMLAnchorElement
+    );
+
+    await wait(0);
+
+    expect(search).not.toHaveBeenCalled();
+
+    // We navigate to page 2
+    userEvent.click(getByText('2'));
+
+    await wait(0);
+
+    expect(search).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 1 }),
+      }),
+    ]);
+    expect(
+      document.querySelector('.ais-Pagination-item--selected')
+    ).toHaveTextContent('2');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--firstPage"
+            >
+              <a
+                aria-label="First"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ‹‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--previousPage"
+            >
+              <a
+                aria-label="Previous"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="3"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="4"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="5"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="6"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                6
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="7"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                7
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+
+    // We click on "Next" link
+    userEvent.click(getByText('›'));
+
+    await wait(0);
+
+    expect(search).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 2 }),
+      }),
+    ]);
+    expect(
+      document.querySelector('.ais-Pagination-item--selected')
+    ).toHaveTextContent('3');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--firstPage"
+            >
+              <a
+                aria-label="First"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ‹‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--previousPage"
+            >
+              <a
+                aria-label="Previous"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="3"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="4"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="5"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="6"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                6
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="7"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                7
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+
+    // We click on "Last" link
+    userEvent.click(getByText('››'));
+
+    await wait(0);
+
+    expect(search).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 49 }),
+      }),
+    ]);
+    expect(
+      document.querySelector('.ais-Pagination-item--selected')
+    ).toHaveTextContent('50');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--firstPage"
+            >
+              <a
+                aria-label="First"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ‹‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--previousPage"
+            >
+              <a
+                aria-label="Previous"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="44"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                44
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="45"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                45
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="46"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                46
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="47"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                47
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="48"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                48
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="49"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                49
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="50"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                50
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage"
+            >
+              <span
+                aria-label="Next"
+                class="ais-Pagination-link"
+              >
+                ›
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage"
+            >
+              <span
+                aria-label="Last"
+                class="ais-Pagination-link"
+              >
+                ››
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+
+    search.mockClear();
+
+    // We're on last page, "Next" and "Last" links are disabled
+    expect(nextPageItem).toHaveClass('ais-Pagination-item--disabled');
+    expect(lastPageItem).toHaveClass('ais-Pagination-item--disabled');
+
+    userEvent.click(
+      nextPageItem!.querySelector('.ais-Pagination-link') as HTMLAnchorElement
+    );
+    userEvent.click(
+      lastPageItem!.querySelector('.ais-Pagination-link') as HTMLAnchorElement
+    );
+
+    await wait(0);
+
+    expect(search).not.toHaveBeenCalled();
+
+    // We click on "Previous" link
+    userEvent.click(
+      previousPageItem!.querySelector(
+        '.ais-Pagination-link'
+      ) as HTMLAnchorElement
+    );
+
+    await wait(0);
+
+    expect(search).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 48 }),
+      }),
+    ]);
+    expect(
+      document.querySelector('.ais-Pagination-item--selected')
+    ).toHaveTextContent('49');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--firstPage"
+            >
+              <a
+                aria-label="First"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ‹‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--previousPage"
+            >
+              <a
+                aria-label="Previous"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ‹
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="44"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                44
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="45"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                45
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="46"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                46
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="47"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                47
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="48"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                48
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="49"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                49
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="50"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                50
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+
+    // We click on "First" link
+    userEvent.click(
+      firstPageItem!.querySelector('.ais-Pagination-link') as HTMLAnchorElement
+    );
+
+    await wait(0);
+
+    expect(search).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 0 }),
+      }),
+    ]);
+    expect(
+      document.querySelector('.ais-Pagination-item--selected')
+    ).toHaveTextContent('1');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="3"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="4"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="5"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="6"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                6
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="7"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                7
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('does not navigate when pressing a modifier key', async () => {
+    const search = jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map((request) =>
+            createSingleSearchResponse({
+              hits: Array.from({ length: 1000 }).map((_, index) => ({
+                objectID: String(index),
+              })),
+              index: request.indexName,
+            })
+          )
+        )
+      )
+    );
+    const client = createSearchClient({ search });
+
+    const { getByText } = render(
+      <InstantSearchHooksTestWrapper searchClient={client}>
+        <Pagination />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    search.mockClear();
+
+    const firstPageItem = document.querySelector(
+      '.ais-Pagination-item--firstPage'
+    );
+    const firstPageLink = firstPageItem!.querySelector('.ais-Pagination-link');
+
+    userEvent.click(firstPageLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(firstPageLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(firstPageLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(firstPageLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(firstPageLink as HTMLAnchorElement, { shiftKey: true });
+
+    const previousPageItem = document.querySelector(
+      '.ais-Pagination-item--previousPage'
+    );
+    const previousPageLink = previousPageItem!.querySelector(
+      '.ais-Pagination-link'
+    );
+
+    userEvent.click(previousPageLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(previousPageLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(previousPageLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(previousPageLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(previousPageLink as HTMLAnchorElement, { shiftKey: true });
+
+    const nextPageItem = document.querySelector(
+      '.ais-Pagination-item--nextPage'
+    );
+    const nextPageLink = nextPageItem!.querySelector('.ais-Pagination-link');
+
+    userEvent.click(nextPageLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(nextPageLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(nextPageLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(nextPageLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(nextPageLink as HTMLAnchorElement, { shiftKey: true });
+
+    const lastPageItem = document.querySelector(
+      '.ais-Pagination-item--lastPage'
+    );
+    const lastPageLink = lastPageItem!.querySelector('.ais-Pagination-link');
+
+    userEvent.click(lastPageLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(lastPageLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(lastPageLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(lastPageLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(lastPageLink as HTMLAnchorElement, { shiftKey: true });
+
+    const pageOneLink = getByText('1');
+
+    userEvent.click(pageOneLink as HTMLAnchorElement, { button: 1 });
+    userEvent.click(pageOneLink as HTMLAnchorElement, { altKey: true });
+    userEvent.click(pageOneLink as HTMLAnchorElement, { ctrlKey: true });
+    userEvent.click(pageOneLink as HTMLAnchorElement, { metaKey: true });
+    userEvent.click(pageOneLink as HTMLAnchorElement, { shiftKey: true });
+
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  test('adds items around the current one', async () => {
+    const search = jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map((request) =>
+            createSingleSearchResponse({
+              hits: Array.from({ length: 1000 }).map((_, index) => ({
+                objectID: String(index),
+              })),
+              index: request.indexName,
+            })
+          )
+        )
+      )
+    );
+    const client = createSearchClient({ search });
+
+    const { container } = render(
+      <InstantSearchHooksTestWrapper searchClient={client}>
+        <Pagination padding={4} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    expect(
+      document.querySelectorAll('.ais-Pagination-item--page')
+    ).toHaveLength(9);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="3"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="4"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="5"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="6"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                6
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="7"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                7
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="8"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                8
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="9"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                9
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('does not add items around the current one when there are not enough pages', async () => {
+    const search = jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map((request) =>
+            createSingleSearchResponse({
+              hits: Array.from({ length: 120 }).map((_, index) => ({
+                objectID: String(index),
+              })),
+              index: request.indexName,
+            })
+          )
+        )
+      )
+    );
+    const client = createSearchClient({ search });
+
+    const { container } = render(
+      <InstantSearchHooksTestWrapper searchClient={client}>
+        <Pagination padding={4} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    expect(
+      document.querySelectorAll('.ais-Pagination-item--page')
+    ).toHaveLength(6);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="3"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="4"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="5"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="6"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                6
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('limits the total pages to display', async () => {
+    const search = jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map((request) =>
+            createSingleSearchResponse({
+              hits: Array.from({ length: 1000 }).map((_, index) => ({
+                objectID: String(index),
+              })),
+              index: request.indexName,
+            })
+          )
+        )
+      )
+    );
+    const client = createSearchClient({ search });
+
+    const { container } = render(
+      <InstantSearchHooksTestWrapper searchClient={client}>
+        <Pagination totalPages={4} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    expect(
+      document.querySelectorAll('.ais-Pagination-item--page')
+    ).toHaveLength(4);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="2"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                2
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="3"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                3
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page"
+            >
+              <a
+                aria-label="4"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                4
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--nextPage"
+            >
+              <a
+                aria-label="Next"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ›
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--lastPage"
+            >
+              <a
+                aria-label="Last"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                ››
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('hides the "First" item', async () => {
+    const { container } = render(
+      <InstantSearchHooksTestWrapper>
+        <Pagination showFirst={false} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    expect(
+      document.querySelector('.ais-Pagination-item--firstPage')
+    ).toBeNull();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination ais-Pagination--noRefinement"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage"
+            >
+              <span
+                aria-label="Next"
+                class="ais-Pagination-link"
+              >
+                ›
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage"
+            >
+              <span
+                aria-label="Last"
+                class="ais-Pagination-link"
+              >
+                ››
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('hides the "Previous" item', async () => {
+    const { container } = render(
+      <InstantSearchHooksTestWrapper>
+        <Pagination showPrevious={false} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    expect(
+      document.querySelector('.ais-Pagination-item--previousPage')
+    ).toBeNull();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination ais-Pagination--noRefinement"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage"
+            >
+              <span
+                aria-label="Next"
+                class="ais-Pagination-link"
+              >
+                ›
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage"
+            >
+              <span
+                aria-label="Last"
+                class="ais-Pagination-link"
+              >
+                ››
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('hides the "Next" item', async () => {
+    const { container } = render(
+      <InstantSearchHooksTestWrapper>
+        <Pagination showNext={false} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    expect(document.querySelector('.ais-Pagination-item--nextPage')).toBeNull();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination ais-Pagination--noRefinement"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage"
+            >
+              <span
+                aria-label="Last"
+                class="ais-Pagination-link"
+              >
+                ››
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('hides the "Last" item', async () => {
+    const { container } = render(
+      <InstantSearchHooksTestWrapper>
+        <Pagination showLast={false} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    expect(document.querySelector('.ais-Pagination-item--lastPage')).toBeNull();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination ais-Pagination--noRefinement"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage"
+            >
+              <span
+                aria-label="Next"
+                class="ais-Pagination-link"
+              >
+                ›
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+
+  test('forwards `div` props to the root element', async () => {
+    const { container } = render(
+      <InstantSearchHooksTestWrapper>
+        <Pagination className="MyPagination" title="Some custom title" />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    const root = document.querySelector('.ais-Pagination');
+
+    expect(root).toHaveClass('MyPagination');
+    expect(root).toHaveAttribute('title', 'Some custom title');
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Pagination ais-Pagination--noRefinement MyPagination"
+          title="Some custom title"
+        >
+          <ul
+            class="ais-Pagination-list"
+          >
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage"
+            >
+              <span
+                aria-label="First"
+                class="ais-Pagination-link"
+              >
+                ‹‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage"
+            >
+              <span
+                aria-label="Previous"
+                class="ais-Pagination-link"
+              >
+                ‹
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+            >
+              <a
+                aria-label="1"
+                class="ais-Pagination-link"
+                href="#"
+              >
+                1
+              </a>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage"
+            >
+              <span
+                aria-label="Next"
+                class="ais-Pagination-link"
+              >
+                ›
+              </span>
+            </li>
+            <li
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage"
+            >
+              <span
+                aria-label="Last"
+                class="ais-Pagination-link"
+              >
+                ››
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `);
+  });
+});

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/index.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/index.test.tsx
@@ -130,6 +130,11 @@ describe('widgets', () => {
           "name": "Hits",
         },
         Object {
+          "$$type": "ais.pagination",
+          "$$widgetType": "ais.pagination",
+          "name": "Pagination",
+        },
+        Object {
           "$$type": "ais.searchBox",
           "$$widgetType": "ais.searchBox",
           "name": "SearchBox",

--- a/packages/react-instantsearch-hooks-dom/src/widgets/index.ts
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/index.ts
@@ -1,4 +1,5 @@
 export * from './ClearRefinements';
 export * from './CurrentRefinements';
 export * from './Hits';
+export * from './Pagination';
 export * from './SearchBox';


### PR DESCRIPTION
## Summary

This introduces the `Pagination` DOM widget.

The implementation slightly differs from the spec, which doesn't add a `ais-Pagination-item--page` class on numeric pagination items if they're also selected. This behavior is inconsistently implemented in every flavor, but InstantSearch.js does allow the class on every numeric pagination item, which makes sense. The spec is updated [here](https://github.com/algolia/instantsearch-specs/pull/119).

Ticket: [FX-1158](https://algolia.atlassian.net/browse/FX-1158)

## Results

- New `Pagination` widget
- DOM tests for both UI component and widget
- New `isModifierClick` utility (tested in #3368)
- Replaced `Pagination` with the widget in example