### PR TITLE
feat(ui): introduce "classNames" prop for highlight

### DIFF
--- a/packages/react-instantsearch-hooks-dom/src/types/index.ts
+++ b/packages/react-instantsearch-hooks-dom/src/types/index.ts
@@ -7,7 +7,7 @@ export type PartialKeys<TObj, TKeys extends keyof TObj> = Omit<TObj, TKeys> &
   Partial<Pick<TObj, TKeys>>;
 
 /**
- * Map from CSS Classes used internally by `ui` to the classes passed by users
+ * Map from CSS classes used in UI components to the `classNames` API exposed to users
  */
 export type ClassNames<
   TProps extends { classNames: Record<string, CSSClass> }

--- a/packages/react-instantsearch-hooks-dom/src/types/index.ts
+++ b/packages/react-instantsearch-hooks-dom/src/types/index.ts
@@ -9,6 +9,6 @@ export type PartialKeys<TObj, TKeys extends keyof TObj> = Omit<TObj, TKeys> &
 /**
  * Map from CSS Classes used internally by `ui` to the classes passed by users
  */
-export type CSSClasses<
-  TProps extends { cssClasses: Record<string, CSSClass> }
-> = { cssClasses?: { [className in keyof TProps['cssClasses']]?: string } };
+export type ClassNames<
+  TProps extends { classNames: Record<string, CSSClass> }
+> = { classNames?: { [className in keyof TProps['classNames']]?: string } };

--- a/packages/react-instantsearch-hooks-dom/src/types/index.ts
+++ b/packages/react-instantsearch-hooks-dom/src/types/index.ts
@@ -1,5 +1,14 @@
+import { CSSClass } from '../ui/lib/cx';
+
 /**
  * Make certain keys of an object optional
  */
 export type PartialKeys<TObj, TKeys extends keyof TObj> = Omit<TObj, TKeys> &
   Partial<Pick<TObj, TKeys>>;
+
+/**
+ * Map from CSS Classes used internally by `ui` to the classes passed by users
+ */
+export type CSSClasses<
+  TProps extends { cssClasses: Record<string, CSSClass> }
+> = { cssClasses?: { [className in keyof TProps['cssClasses']]?: string } };

--- a/packages/react-instantsearch-hooks-dom/src/types/index.ts
+++ b/packages/react-instantsearch-hooks-dom/src/types/index.ts
@@ -1,4 +1,4 @@
-import { CSSClass } from '../ui/lib/cx';
+import type { CSSClass } from '../ui/lib/cx';
 
 /**
  * Make certain keys of an object optional

--- a/packages/react-instantsearch-hooks-dom/src/types/index.ts
+++ b/packages/react-instantsearch-hooks-dom/src/types/index.ts
@@ -1,5 +1,3 @@
-import type { CSSClass } from '../ui/lib/cx';
-
 /**
  * Make certain keys of an object optional
  */
@@ -9,6 +7,5 @@ export type PartialKeys<TObj, TKeys extends keyof TObj> = Omit<TObj, TKeys> &
 /**
  * Map from CSS classes used in UI components to the `classNames` API exposed to users
  */
-export type ClassNames<
-  TProps extends { classNames: Record<string, CSSClass> }
-> = { classNames?: { [className in keyof TProps['classNames']]?: string } };
+export type ClassNames<TProps extends { classNames: Record<string, string> }> =
+  Omit<TProps, 'classNames'> & { classNames?: Partial<TProps['classNames']> };

--- a/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
@@ -2,8 +2,6 @@ import React, { Fragment } from 'react';
 
 import { cx } from './lib/cx';
 
-import type { CSSClass } from './lib/cx';
-
 type HighlightPartProps = {
   children: React.ReactNode;
   classNames: HighlightClassNames;
@@ -24,9 +22,7 @@ function HighlightPart({
   return (
     <TagName
       className={
-        isHighlighted
-          ? cx(classNames.highlighted)
-          : cx(classNames.nonHighlighted)
+        isHighlighted ? classNames.highlighted : classNames.nonHighlighted
       }
     >
       {children}
@@ -43,19 +39,19 @@ export type HighlightClassNames = {
   /**
    * Class names to apply to the root element
    */
-  root: CSSClass;
+  root: string;
   /**
    * Class names to apply to the highlighted parts
    */
-  highlighted: CSSClass;
+  highlighted: string;
   /**
    * Class names to apply to the non-highlighted parts
    */
-  nonHighlighted: CSSClass;
+  nonHighlighted: string;
   /**
    * Class names to apply to the separator between highlighted parts
    */
-  separator: CSSClass;
+  separator: string;
 };
 
 export type HighlightProps = React.HTMLAttributes<HTMLSpanElement> & {
@@ -95,7 +91,7 @@ export function Highlight({
             ))}
 
             {!isLastPart && (
-              <span className={cx(classNames.separator)}>{separator}</span>
+              <span className={classNames.separator}>{separator}</span>
             )}
           </Fragment>
         );

--- a/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
@@ -6,14 +6,14 @@ import type { CSSClass } from './lib/cx';
 
 type HighlightPartProps = {
   children: React.ReactNode;
-  cssClasses: HighlightCSSClasses;
+  classNames: HighlightClassNames;
   highlightedTagName: React.ReactType;
   nonHighlightedTagName: React.ReactType;
   isHighlighted: boolean;
 };
 
 function HighlightPart({
-  cssClasses,
+  classNames,
   children,
   highlightedTagName,
   isHighlighted,
@@ -25,8 +25,8 @@ function HighlightPart({
     <TagName
       className={
         isHighlighted
-          ? cx(cssClasses.highlighted)
-          : cx(cssClasses.nonHighlighted)
+          ? cx(classNames.highlighted)
+          : cx(classNames.nonHighlighted)
       }
     >
       {children}
@@ -39,7 +39,7 @@ type HighlightedPart = {
   value: string;
 };
 
-export type HighlightCSSClasses = {
+export type HighlightClassNames = {
   /**
    * Class names to apply to the root element
    */
@@ -59,7 +59,7 @@ export type HighlightCSSClasses = {
 };
 
 export type HighlightProps = React.HTMLAttributes<HTMLSpanElement> & {
-  cssClasses: HighlightCSSClasses;
+  classNames: HighlightClassNames;
   highlightedTagName?: React.ReactType;
   nonHighlightedTagName?: React.ReactType;
   separator?: React.ReactNode;
@@ -71,11 +71,11 @@ export function Highlight({
   highlightedTagName = 'mark',
   nonHighlightedTagName = 'span',
   separator = ', ',
-  cssClasses,
+  classNames,
   ...props
 }: HighlightProps) {
   return (
-    <span {...props} className={cx(cssClasses.root, props.className)}>
+    <span {...props} className={cx(classNames.root, props.className)}>
       {parts.map((part, partIndex) => {
         const isLastPart = partIndex === parts.length - 1;
 
@@ -84,7 +84,7 @@ export function Highlight({
             {part.map((subPart, subPartIndex) => (
               <HighlightPart
                 key={subPartIndex}
-                cssClasses={cssClasses}
+                classNames={classNames}
                 highlightedTagName={highlightedTagName}
                 nonHighlightedTagName={nonHighlightedTagName}
                 isHighlighted={subPart.isHighlighted}
@@ -94,7 +94,7 @@ export function Highlight({
             ))}
 
             {!isLastPart && (
-              <span className={cx(cssClasses.separator)}>{separator}</span>
+              <span className={cx(classNames.separator)}>{separator}</span>
             )}
           </Fragment>
         );

--- a/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
@@ -60,7 +60,6 @@ export type HighlightCSSClasses = {
 
 export type HighlightProps = React.HTMLAttributes<HTMLSpanElement> & {
   cssClasses: HighlightCSSClasses;
-  userCssClasses: HighlightCSSClasses;
   highlightedTagName?: React.ReactType;
   nonHighlightedTagName?: React.ReactType;
   separator?: React.ReactNode;

--- a/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
@@ -45,15 +45,15 @@ export type HighlightClassNames = {
    */
   root: CSSClass;
   /**
-   * Class names to apply to the matching parts
+   * Class names to apply to the highlighted parts
    */
   highlighted: CSSClass;
   /**
-   * Class names to apply to the non-matching parts
+   * Class names to apply to the non-highlighted parts
    */
   nonHighlighted: CSSClass;
   /**
-   * Class names to apply to the separator between different matches
+   * Class names to apply to the separator between highlighted parts
    */
   separator: CSSClass;
 };

--- a/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
@@ -1,6 +1,8 @@
 import React, { Fragment } from 'react';
 
-import { CSSClass, cx } from './lib/cx';
+import { cx } from './lib/cx';
+
+import type { CSSClass } from './lib/cx';
 
 type HighlightPartProps = {
   children: React.ReactNode;

--- a/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
@@ -1,17 +1,17 @@
 import React, { Fragment } from 'react';
 
-import { cx } from './lib/cx';
+import { CSSClass, cx } from './lib/cx';
 
 type HighlightPartProps = {
   children: React.ReactNode;
-  baseClassName: string;
+  cssClasses: HighlightCSSClasses;
   highlightedTagName: React.ReactType;
   nonHighlightedTagName: React.ReactType;
   isHighlighted: boolean;
 };
 
 function HighlightPart({
-  baseClassName,
+  cssClasses,
   children,
   highlightedTagName,
   isHighlighted,
@@ -23,8 +23,8 @@ function HighlightPart({
     <TagName
       className={
         isHighlighted
-          ? `${baseClassName}-highlighted`
-          : `${baseClassName}-nonHighlighted`
+          ? cx(cssClasses.highlighted)
+          : cx(cssClasses.nonHighlighted)
       }
     >
       {children}
@@ -37,8 +37,28 @@ type HighlightedPart = {
   value: string;
 };
 
+export type HighlightCSSClasses = {
+  /**
+   * Class names to apply to the root element
+   */
+  root: CSSClass;
+  /**
+   * Class names to apply to the matching parts
+   */
+  highlighted: CSSClass;
+  /**
+   * Class names to apply to the non-matching parts
+   */
+  nonHighlighted: CSSClass;
+  /**
+   * Class names to apply to the separator between different matches
+   */
+  separator: CSSClass;
+};
+
 export type HighlightProps = React.HTMLAttributes<HTMLSpanElement> & {
-  baseClassName: string;
+  cssClasses: HighlightCSSClasses;
+  userCssClasses: HighlightCSSClasses;
   highlightedTagName?: React.ReactType;
   nonHighlightedTagName?: React.ReactType;
   separator?: React.ReactNode;
@@ -46,15 +66,15 @@ export type HighlightProps = React.HTMLAttributes<HTMLSpanElement> & {
 };
 
 export function Highlight({
-  baseClassName,
   parts,
   highlightedTagName = 'mark',
   nonHighlightedTagName = 'span',
   separator = ', ',
+  cssClasses,
   ...props
 }: HighlightProps) {
   return (
-    <span {...props} className={cx(baseClassName, props.className)}>
+    <span {...props} className={cx(cssClasses.root, props.className)}>
       {parts.map((part, partIndex) => {
         const isLastPart = partIndex === parts.length - 1;
 
@@ -63,7 +83,7 @@ export function Highlight({
             {part.map((subPart, subPartIndex) => (
               <HighlightPart
                 key={subPartIndex}
-                baseClassName={baseClassName}
+                cssClasses={cssClasses}
                 highlightedTagName={highlightedTagName}
                 nonHighlightedTagName={nonHighlightedTagName}
                 isHighlighted={subPart.isHighlighted}
@@ -73,7 +93,7 @@ export function Highlight({
             ))}
 
             {!isLastPart && (
-              <span className={`${baseClassName}-separator`}>{separator}</span>
+              <span className={cx(cssClasses.separator)}>{separator}</span>
             )}
           </Fragment>
         );

--- a/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Highlight.tsx
@@ -71,11 +71,12 @@ export function Highlight({
   highlightedTagName = 'mark',
   nonHighlightedTagName = 'span',
   separator = ', ',
+  className,
   classNames,
   ...props
 }: HighlightProps) {
   return (
-    <span {...props} className={cx(classNames.root, props.className)}>
+    <span {...props} className={cx(classNames.root, className)}>
       {parts.map((part, partIndex) => {
         const isLastPart = partIndex === parts.length - 1;
 

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Highlight.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Highlight.test.tsx
@@ -6,13 +6,21 @@ import { Highlight } from '../Highlight';
 describe('Highlight', () => {
   test('renders only wrapper with empty match', () => {
     const { container } = render(
-      <Highlight baseClassName="ais-Highlight" parts={[]} />
+      <Highlight
+        cssClasses={{
+          root: 'ROOT',
+          highlighted: 'HIGHLIGHTED',
+          nonHighlighted: 'NON-HIGHLIGHTED',
+          separator: 'SEPARATOR',
+        }}
+        parts={[]}
+      />
     );
 
     expect(container).toMatchInlineSnapshot(`
       <div>
         <span
-          class="ais-Highlight"
+          class="ROOT"
         />
       </div>
     `);
@@ -21,7 +29,12 @@ describe('Highlight', () => {
   test('renders parts', () => {
     const { container } = render(
       <Highlight
-        baseClassName="ais-Highlight"
+        cssClasses={{
+          root: 'ROOT',
+          highlighted: 'HIGHLIGHTED',
+          nonHighlighted: 'NON-HIGHLIGHTED',
+          separator: 'SEPARATOR',
+        }}
         parts={[
           [
             { isHighlighted: true, value: 'te' },
@@ -35,25 +48,25 @@ describe('Highlight', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <span
-          class="ais-Highlight"
+          class="ROOT"
         >
           <mark
-            class="ais-Highlight-highlighted"
+            class="HIGHLIGHTED"
           >
             te
           </mark>
           <span
-            class="ais-Highlight-nonHighlighted"
+            class="NON-HIGHLIGHTED"
           >
             st
           </span>
           <span
-            class="ais-Highlight-separator"
+            class="SEPARATOR"
           >
             , 
           </span>
           <span
-            class="ais-Highlight-nonHighlighted"
+            class="NON-HIGHLIGHTED"
           >
             nothing
           </span>
@@ -72,7 +85,12 @@ describe('Highlight', () => {
 
     const { container } = render(
       <Highlight
-        baseClassName="ais-Highlight"
+        cssClasses={{
+          root: 'ROOT',
+          highlighted: 'HIGHLIGHTED',
+          nonHighlighted: 'NON-HIGHLIGHTED',
+          separator: 'SEPARATOR',
+        }}
         highlightedTagName={Highlighted}
         nonHighlightedTagName={NonHighlighted}
         separator={<strong> - </strong>}
@@ -89,7 +107,7 @@ describe('Highlight', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <span
-          class="ais-Highlight"
+          class="ROOT"
         >
           <strong>
             te
@@ -98,7 +116,7 @@ describe('Highlight', () => {
             st
           </small>
           <span
-            class="ais-Highlight-separator"
+            class="SEPARATOR"
           >
             <strong>
                - 
@@ -115,7 +133,12 @@ describe('Highlight', () => {
   test('forwards `className` and root props', () => {
     const { container } = render(
       <Highlight
-        baseClassName="ais-Highlight"
+        cssClasses={{
+          root: 'ROOT',
+          highlighted: 'HIGHLIGHTED',
+          nonHighlighted: 'NON-HIGHLIGHTED',
+          separator: 'SEPARATOR',
+        }}
         parts={[]}
         className="custom-root"
         aria-hidden="true"
@@ -126,7 +149,32 @@ describe('Highlight', () => {
       <div>
         <span
           aria-hidden="true"
-          class="ais-Highlight custom-root"
+          class="ROOT custom-root"
+        />
+      </div>
+    `);
+  });
+
+  test('accepts array of classes for cssClasses', () => {
+    const { container } = render(
+      <Highlight
+        cssClasses={{
+          root: ['ROOT', 'EXTRA', false],
+          highlighted: 'HIGHLIGHTED',
+          nonHighlighted: 'NON-HIGHLIGHTED',
+          separator: 'SEPARATOR',
+        }}
+        parts={[]}
+        className="custom-root"
+        aria-hidden="true"
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          aria-hidden="true"
+          class="ROOT EXTRA custom-root"
         />
       </div>
     `);

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Highlight.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Highlight.test.tsx
@@ -159,7 +159,7 @@ describe('Highlight', () => {
     const { container } = render(
       <Highlight
         classNames={{
-          root: ['ROOT', 'EXTRA', false],
+          root: 'ROOT',
           highlighted: 'HIGHLIGHTED',
           nonHighlighted: 'NON-HIGHLIGHTED',
           separator: 'SEPARATOR',
@@ -174,7 +174,7 @@ describe('Highlight', () => {
       <div>
         <span
           aria-hidden="true"
-          class="ROOT EXTRA custom-root"
+          class="ROOT custom-root"
         />
       </div>
     `);

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Highlight.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Highlight.test.tsx
@@ -7,7 +7,7 @@ describe('Highlight', () => {
   test('renders only wrapper with empty match', () => {
     const { container } = render(
       <Highlight
-        cssClasses={{
+        classNames={{
           root: 'ROOT',
           highlighted: 'HIGHLIGHTED',
           nonHighlighted: 'NON-HIGHLIGHTED',
@@ -29,7 +29,7 @@ describe('Highlight', () => {
   test('renders parts', () => {
     const { container } = render(
       <Highlight
-        cssClasses={{
+        classNames={{
           root: 'ROOT',
           highlighted: 'HIGHLIGHTED',
           nonHighlighted: 'NON-HIGHLIGHTED',
@@ -85,7 +85,7 @@ describe('Highlight', () => {
 
     const { container } = render(
       <Highlight
-        cssClasses={{
+        classNames={{
           root: 'ROOT',
           highlighted: 'HIGHLIGHTED',
           nonHighlighted: 'NON-HIGHLIGHTED',
@@ -133,7 +133,7 @@ describe('Highlight', () => {
   test('forwards `className` and root props', () => {
     const { container } = render(
       <Highlight
-        cssClasses={{
+        classNames={{
           root: 'ROOT',
           highlighted: 'HIGHLIGHTED',
           nonHighlighted: 'NON-HIGHLIGHTED',
@@ -155,10 +155,10 @@ describe('Highlight', () => {
     `);
   });
 
-  test('accepts array of classes for cssClasses', () => {
+  test('accepts array of classes for classNames', () => {
     const { container } = render(
       <Highlight
-        cssClasses={{
+        classNames={{
           root: ['ROOT', 'EXTRA', false],
           highlighted: 'HIGHLIGHTED',
           nonHighlighted: 'NON-HIGHLIGHTED',

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Highlight.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Highlight.test.tsx
@@ -154,29 +154,4 @@ describe('Highlight', () => {
       </div>
     `);
   });
-
-  test('accepts array of classes for classNames', () => {
-    const { container } = render(
-      <Highlight
-        classNames={{
-          root: 'ROOT',
-          highlighted: 'HIGHLIGHTED',
-          nonHighlighted: 'NON-HIGHLIGHTED',
-          separator: 'SEPARATOR',
-        }}
-        parts={[]}
-        className="custom-root"
-        aria-hidden="true"
-      />
-    );
-
-    expect(container).toMatchInlineSnapshot(`
-      <div>
-        <span
-          aria-hidden="true"
-          class="ROOT custom-root"
-        />
-      </div>
-    `);
-  });
 });

--- a/packages/react-instantsearch-hooks-dom/src/ui/lib/cx.ts
+++ b/packages/react-instantsearch-hooks-dom/src/ui/lib/cx.ts
@@ -1,5 +1,5 @@
-export type CSSClass = string | number | boolean | undefined | null;
-
-export function cx(...classNames: CSSClass[]) {
+export function cx(
+  ...classNames: Array<string | number | boolean | undefined | null>
+) {
   return classNames.filter(Boolean).join(' ');
 }

--- a/packages/react-instantsearch-hooks-dom/src/ui/lib/cx.ts
+++ b/packages/react-instantsearch-hooks-dom/src/ui/lib/cx.ts
@@ -1,9 +1,5 @@
-type Root = string | number | boolean | undefined | null;
-export type CSSClass = Root | Root[];
+export type CSSClass = string | number | boolean | undefined | null;
 
 export function cx(...classNames: CSSClass[]) {
-  return classNames
-    .reduce<Root[]>((acc, curr) => acc.concat(curr), [])
-    .filter(Boolean)
-    .join(' ');
+  return classNames.filter(Boolean).join(' ');
 }

--- a/packages/react-instantsearch-hooks-dom/src/ui/lib/cx.ts
+++ b/packages/react-instantsearch-hooks-dom/src/ui/lib/cx.ts
@@ -1,5 +1,9 @@
-export function cx(
-  ...classNames: Array<string | number | boolean | undefined | null>
-) {
-  return classNames.filter(Boolean).join(' ');
+type Root = string | number | boolean | undefined | null;
+export type CSSClass = Root | Root[];
+
+export function cx(...classNames: CSSClass[]) {
+  return classNames
+    .reduce<Root[]>((acc, curr) => acc.concat(curr), [])
+    .filter(Boolean)
+    .join(' ');
 }

--- a/packages/react-instantsearch-hooks-dom/src/widgets/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/Highlight.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { Highlight as HighlightUiComponent } from '../ui/Highlight';
 
-import type { PartialKeys } from '../types';
+import type { PartialKeys, CSSClasses } from '../types';
 import type { HighlightProps as HighlightUiComponentProps } from '../ui/Highlight';
 import type { BaseHit, Hit } from 'instantsearch.js';
 
@@ -14,13 +14,15 @@ export type HighlightProps<THit extends Hit<BaseHit>> = {
   hit: THit;
   attribute: keyof THit | string[];
 } & PartialKeys<
-  Omit<HighlightUiComponentProps, 'baseClassName' | 'parts'>,
+  Omit<HighlightUiComponentProps, 'parts' | 'cssClasses'>,
   'highlightedTagName' | 'nonHighlightedTagName' | 'separator'
->;
+> &
+  CSSClasses<HighlightUiComponentProps>;
 
 export function Highlight<THit extends Hit<BaseHit>>({
   hit,
   attribute,
+  cssClasses = {},
   highlightedTagName,
   nonHighlightedTagName,
   separator,
@@ -37,7 +39,15 @@ export function Highlight<THit extends Hit<BaseHit>>({
   return (
     <HighlightUiComponent
       {...props}
-      baseClassName="ais-Highlight"
+      cssClasses={{
+        root: ['ais-Highlight', cssClasses.root],
+        highlighted: ['ais-Highlight-highlighted', cssClasses.highlighted],
+        nonHighlighted: [
+          'ais-Highlight-nonHighlighted',
+          cssClasses.nonHighlighted,
+        ],
+        separator: ['ais-Highlight-separator', cssClasses.separator],
+      }}
       parts={parts}
       highlightedTagName={highlightedTagName}
       nonHighlightedTagName={nonHighlightedTagName}

--- a/packages/react-instantsearch-hooks-dom/src/widgets/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/Highlight.tsx
@@ -15,10 +15,9 @@ export type HighlightProps<THit extends Hit<BaseHit>> = {
   hit: THit;
   attribute: keyof THit | string[];
 } & PartialKeys<
-  Omit<HighlightUiComponentProps, 'parts' | 'classNames'>,
+  Omit<ClassNames<HighlightUiComponentProps>, 'parts'>,
   'highlightedTagName' | 'nonHighlightedTagName' | 'separator'
-> &
-  ClassNames<HighlightUiComponentProps>;
+>;
 
 export function Highlight<THit extends Hit<BaseHit>>({
   hit,

--- a/packages/react-instantsearch-hooks-dom/src/widgets/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/Highlight.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { Highlight as HighlightUiComponent } from '../ui/Highlight';
 
-import type { PartialKeys, CSSClasses } from '../types';
+import type { PartialKeys, ClassNames } from '../types';
 import type { HighlightProps as HighlightUiComponentProps } from '../ui/Highlight';
 import type { BaseHit, Hit } from 'instantsearch.js';
 
@@ -14,15 +14,15 @@ export type HighlightProps<THit extends Hit<BaseHit>> = {
   hit: THit;
   attribute: keyof THit | string[];
 } & PartialKeys<
-  Omit<HighlightUiComponentProps, 'parts' | 'cssClasses'>,
+  Omit<HighlightUiComponentProps, 'parts' | 'classNames'>,
   'highlightedTagName' | 'nonHighlightedTagName' | 'separator'
 > &
-  CSSClasses<HighlightUiComponentProps>;
+  ClassNames<HighlightUiComponentProps>;
 
 export function Highlight<THit extends Hit<BaseHit>>({
   hit,
   attribute,
-  cssClasses = {},
+  classNames = {},
   highlightedTagName,
   nonHighlightedTagName,
   separator,
@@ -39,14 +39,14 @@ export function Highlight<THit extends Hit<BaseHit>>({
   return (
     <HighlightUiComponent
       {...props}
-      cssClasses={{
-        root: ['ais-Highlight', cssClasses.root],
-        highlighted: ['ais-Highlight-highlighted', cssClasses.highlighted],
+      classNames={{
+        root: ['ais-Highlight', classNames.root],
+        highlighted: ['ais-Highlight-highlighted', classNames.highlighted],
         nonHighlighted: [
           'ais-Highlight-nonHighlighted',
-          cssClasses.nonHighlighted,
+          classNames.nonHighlighted,
         ],
-        separator: ['ais-Highlight-separator', cssClasses.separator],
+        separator: ['ais-Highlight-separator', classNames.separator],
       }}
       parts={parts}
       highlightedTagName={highlightedTagName}

--- a/packages/react-instantsearch-hooks-dom/src/widgets/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/Highlight.tsx
@@ -5,6 +5,7 @@ import {
 import React from 'react';
 
 import { Highlight as HighlightUiComponent } from '../ui/Highlight';
+import { cx } from '../ui/lib/cx';
 
 import type { PartialKeys, ClassNames } from '../types';
 import type { HighlightProps as HighlightUiComponentProps } from '../ui/Highlight';
@@ -40,13 +41,13 @@ export function Highlight<THit extends Hit<BaseHit>>({
     <HighlightUiComponent
       {...props}
       classNames={{
-        root: ['ais-Highlight', classNames.root],
-        highlighted: ['ais-Highlight-highlighted', classNames.highlighted],
-        nonHighlighted: [
+        root: cx('ais-Highlight', classNames.root),
+        highlighted: cx('ais-Highlight-highlighted', classNames.highlighted),
+        nonHighlighted: cx(
           'ais-Highlight-nonHighlighted',
-          classNames.nonHighlighted,
-        ],
-        separator: ['ais-Highlight-separator', classNames.separator],
+          classNames.nonHighlighted
+        ),
+        separator: cx('ais-Highlight-separator', classNames.separator),
       }}
       parts={parts}
       highlightedTagName={highlightedTagName}

--- a/packages/react-instantsearch-hooks-dom/src/widgets/Snippet.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/Snippet.tsx
@@ -15,10 +15,9 @@ export type SnippetProps<THit extends Hit<BaseHit>> = {
   hit: THit;
   attribute: keyof THit | string[];
 } & PartialKeys<
-  Omit<HighlightUiComponentProps, 'parts' | 'classNames'>,
+  Omit<ClassNames<HighlightUiComponentProps>, 'parts'>,
   'highlightedTagName' | 'nonHighlightedTagName' | 'separator'
-> &
-  ClassNames<HighlightUiComponentProps>;
+>;
 
 export function Snippet<THit extends Hit<BaseHit>>({
   hit,

--- a/packages/react-instantsearch-hooks-dom/src/widgets/Snippet.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/Snippet.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { Highlight as HighlightUiComponent } from '../ui/Highlight';
 
-import type { PartialKeys } from '../types';
+import type { CSSClasses, PartialKeys } from '../types';
 import type { HighlightProps as HighlightUiComponentProps } from '../ui/Highlight';
 import type { BaseHit, Hit } from 'instantsearch.js';
 
@@ -14,13 +14,15 @@ export type SnippetProps<THit extends Hit<BaseHit>> = {
   hit: THit;
   attribute: keyof THit | string[];
 } & PartialKeys<
-  Omit<HighlightUiComponentProps, 'baseClassName' | 'parts'>,
+  Omit<HighlightUiComponentProps, 'parts' | 'cssClasses'>,
   'highlightedTagName' | 'nonHighlightedTagName' | 'separator'
->;
+> &
+  CSSClasses<HighlightUiComponentProps>;
 
 export function Snippet<THit extends Hit<BaseHit>>({
   hit,
   attribute,
+  cssClasses = {},
   highlightedTagName,
   nonHighlightedTagName,
   separator,
@@ -37,7 +39,15 @@ export function Snippet<THit extends Hit<BaseHit>>({
   return (
     <HighlightUiComponent
       {...props}
-      baseClassName="ais-Snippet"
+      cssClasses={{
+        root: ['ais-Snippet', cssClasses.root],
+        highlighted: ['ais-Snippet-highlighted', cssClasses.highlighted],
+        nonHighlighted: [
+          'ais-Snippet-nonHighlighted',
+          cssClasses.nonHighlighted,
+        ],
+        separator: ['ais-Snippet-separator', cssClasses.separator],
+      }}
       parts={parts}
       highlightedTagName={highlightedTagName}
       nonHighlightedTagName={nonHighlightedTagName}

--- a/packages/react-instantsearch-hooks-dom/src/widgets/Snippet.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/Snippet.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { Highlight as HighlightUiComponent } from '../ui/Highlight';
 
-import type { CSSClasses, PartialKeys } from '../types';
+import type { ClassNames, PartialKeys } from '../types';
 import type { HighlightProps as HighlightUiComponentProps } from '../ui/Highlight';
 import type { BaseHit, Hit } from 'instantsearch.js';
 
@@ -14,15 +14,15 @@ export type SnippetProps<THit extends Hit<BaseHit>> = {
   hit: THit;
   attribute: keyof THit | string[];
 } & PartialKeys<
-  Omit<HighlightUiComponentProps, 'parts' | 'cssClasses'>,
+  Omit<HighlightUiComponentProps, 'parts' | 'classNames'>,
   'highlightedTagName' | 'nonHighlightedTagName' | 'separator'
 > &
-  CSSClasses<HighlightUiComponentProps>;
+  ClassNames<HighlightUiComponentProps>;
 
 export function Snippet<THit extends Hit<BaseHit>>({
   hit,
   attribute,
-  cssClasses = {},
+  classNames = {},
   highlightedTagName,
   nonHighlightedTagName,
   separator,
@@ -39,14 +39,14 @@ export function Snippet<THit extends Hit<BaseHit>>({
   return (
     <HighlightUiComponent
       {...props}
-      cssClasses={{
-        root: ['ais-Snippet', cssClasses.root],
-        highlighted: ['ais-Snippet-highlighted', cssClasses.highlighted],
+      classNames={{
+        root: ['ais-Snippet', classNames.root],
+        highlighted: ['ais-Snippet-highlighted', classNames.highlighted],
         nonHighlighted: [
           'ais-Snippet-nonHighlighted',
-          cssClasses.nonHighlighted,
+          classNames.nonHighlighted,
         ],
-        separator: ['ais-Snippet-separator', cssClasses.separator],
+        separator: ['ais-Snippet-separator', classNames.separator],
       }}
       parts={parts}
       highlightedTagName={highlightedTagName}

--- a/packages/react-instantsearch-hooks-dom/src/widgets/Snippet.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/Snippet.tsx
@@ -5,6 +5,7 @@ import {
 import React from 'react';
 
 import { Highlight as HighlightUiComponent } from '../ui/Highlight';
+import { cx } from '../ui/lib/cx';
 
 import type { ClassNames, PartialKeys } from '../types';
 import type { HighlightProps as HighlightUiComponentProps } from '../ui/Highlight';
@@ -40,13 +41,13 @@ export function Snippet<THit extends Hit<BaseHit>>({
     <HighlightUiComponent
       {...props}
       classNames={{
-        root: ['ais-Snippet', classNames.root],
-        highlighted: ['ais-Snippet-highlighted', classNames.highlighted],
-        nonHighlighted: [
+        root: cx('ais-Snippet', classNames.root),
+        highlighted: cx('ais-Snippet-highlighted', classNames.highlighted),
+        nonHighlighted: cx(
           'ais-Snippet-nonHighlighted',
-          classNames.nonHighlighted,
-        ],
-        separator: ['ais-Snippet-separator', classNames.separator],
+          classNames.nonHighlighted
+        ),
+        separator: cx('ais-Snippet-separator', classNames.separator),
       }}
       parts={parts}
       highlightedTagName={highlightedTagName}

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Highlight.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Highlight.test.tsx
@@ -202,7 +202,10 @@ describe('Highlight', () => {
   test('forwards `className` and root props', () => {
     const { container } = render(
       <Highlight
-        className="custom-rootclass"
+        className="custom-className"
+        classNames={{
+          root: 'custom-rootClass',
+        }}
         hidden={true}
         hit={{
           objectID: '1',
@@ -215,7 +218,7 @@ describe('Highlight', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <span
-          class="ais-Highlight custom-rootclass"
+          class="ais-Highlight custom-rootClass custom-className"
           hidden=""
         />
       </div>

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Highlight.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Highlight.test.tsx
@@ -222,10 +222,10 @@ describe('Highlight', () => {
     `);
   });
 
-  test('forwards `cssClasses`', () => {
+  test('forwards `classNames`', () => {
     const { container } = render(
       <Highlight
-        cssClasses={{
+        classNames={{
           root: 'custom-rootclass',
         }}
         hit={{

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Highlight.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Highlight.test.tsx
@@ -222,6 +222,29 @@ describe('Highlight', () => {
     `);
   });
 
+  test('forwards `cssClasses`', () => {
+    const { container } = render(
+      <Highlight
+        cssClasses={{
+          root: 'custom-rootclass',
+        }}
+        hit={{
+          objectID: '1',
+          __position: 1,
+        }}
+        attribute="objectID"
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class="ais-Highlight custom-rootclass"
+        />
+      </div>
+    `);
+  });
+
   test('forwards tag names and separator', () => {
     function Highlighted({ children }) {
       return <strong>{children}</strong>;

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Snippet.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Snippet.test.tsx
@@ -198,7 +198,10 @@ describe('Snippet', () => {
   test('forwards `className` and root props', () => {
     const { container } = render(
       <Snippet
-        className="custom-rootclass"
+        className="custom-className"
+        classNames={{
+          root: 'custom-rootClass',
+        }}
         hidden={true}
         hit={{
           objectID: '1',
@@ -211,7 +214,7 @@ describe('Snippet', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <span
-          class="ais-Snippet custom-rootclass"
+          class="ais-Snippet custom-rootClass custom-className"
           hidden=""
         />
       </div>

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Snippet.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Snippet.test.tsx
@@ -204,8 +204,7 @@ describe('Snippet', () => {
           objectID: '1',
           __position: 1,
         }}
-        // @ts-expect-error TS doesn't allow an attribute which doesn't exist
-        attribute="something-that-doesnt-exist"
+        attribute="objectID"
       />
     );
 
@@ -214,6 +213,29 @@ describe('Snippet', () => {
         <span
           class="ais-Snippet custom-rootclass"
           hidden=""
+        />
+      </div>
+    `);
+  });
+
+  test('forwards `cssClasses`', () => {
+    const { container } = render(
+      <Snippet
+        cssClasses={{
+          root: 'custom-rootclass',
+        }}
+        hit={{
+          objectID: '1',
+          __position: 1,
+        }}
+        attribute="objectID"
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class="ais-Snippet custom-rootclass"
         />
       </div>
     `);

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Snippet.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Snippet.test.tsx
@@ -218,10 +218,10 @@ describe('Snippet', () => {
     `);
   });
 
-  test('forwards `cssClasses`', () => {
+  test('forwards `classNames`', () => {
     const { container } = render(
       <Snippet
-        cssClasses={{
+        classNames={{
           root: 'custom-rootclass',
         }}
         hit={{


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This allows us to reuse the same ui component for multiple widgets

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- ui component accepts an array of classes for every "key", and is required
- widget accepts a string for every "key", and isn't required, these are only additional