### PR TITLE
feat(hooks): mark initial results as "artificial"

### DIFF
--- a/examples/hooks-react-native/package.json
+++ b/examples/hooks-react-native/package.json
@@ -14,7 +14,7 @@
     "algoliasearch": "4.12.1",
     "expo": "~44.0.0",
     "expo-status-bar": "~1.2.0",
-    "instantsearch.js": "4.39.0",
+    "instantsearch.js": "4.40.1",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-instantsearch-hooks": "6.22.0",

--- a/examples/hooks/package.json
+++ b/examples/hooks/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "algoliasearch": "4.11.0",
-    "instantsearch.js": "4.39.0",
+    "instantsearch.js": "4.40.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-instantsearch-hooks": "6.22.0",

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.7.0",
+    "algoliasearch-helper": "^3.7.4",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0"
   },

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.7.0",
+    "algoliasearch-helper": "^3.7.4",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0",

--- a/packages/react-instantsearch-hooks-dom/package.json
+++ b/packages/react-instantsearch-hooks-dom/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "react-instantsearch-hooks": "6.22.0",
-    "instantsearch.js": "^4.39.0"
+    "instantsearch.js": "^4.40.1"
   },
   "peerDependencies": {
     "react": ">= 16.8.0 < 19",

--- a/packages/react-instantsearch-hooks-server/package.json
+++ b/packages/react-instantsearch-hooks-server/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "instantsearch.js": "^4.39.0",
+    "instantsearch.js": "^4.40.1",
     "react-instantsearch-hooks": "6.22.0"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -47,9 +47,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.7.0",
+    "algoliasearch-helper": "^3.7.4",
     "dequal": "^2.0.0",
-    "instantsearch.js": "^4.39.0"
+    "instantsearch.js": "^4.40.1"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.1 < 5",

--- a/packages/react-instantsearch-hooks/src/lib/createSearchResults.ts
+++ b/packages/react-instantsearch-hooks/src/lib/createSearchResults.ts
@@ -3,19 +3,26 @@ import algoliasearchHelper from 'algoliasearch-helper';
 import type { SearchParameters } from 'algoliasearch-helper';
 
 export function createSearchResults<THit>(state: SearchParameters) {
-  return new algoliasearchHelper.SearchResults<THit>(state, [
+  return new algoliasearchHelper.SearchResults<THit>(
+    state,
+    [
+      {
+        query: state.query ?? '',
+        page: state.page ?? 0,
+        hitsPerPage: state.hitsPerPage ?? 20,
+        hits: [],
+        nbHits: 0,
+        nbPages: 0,
+        params: '',
+        exhaustiveNbHits: true,
+        exhaustiveFacetsCount: true,
+        processingTimeMS: 0,
+        index: state.index,
+      },
+    ],
     {
-      query: state.query ?? '',
-      page: state.page ?? 0,
-      hitsPerPage: state.hitsPerPage ?? 20,
-      hits: [],
-      nbHits: 0,
-      nbPages: 0,
-      params: '',
-      exhaustiveNbHits: true,
-      exhaustiveFacetsCount: true,
-      processingTimeMS: 0,
-      index: state.index,
-    },
-  ]);
+      /** used by connectors to prevent persisting these results */
+      __isArtificial: true,
+    }
+  );
 }

--- a/test/mock/createAPIResponse.ts
+++ b/test/mock/createAPIResponse.ts
@@ -1,7 +1,33 @@
-import type {
-  SearchForFacetValuesResponse,
-  SearchResponse,
-} from '@algolia/client-search';
+import type algoliasearch from 'algoliasearch/lite';
+import type * as AlgoliaSearch from 'algoliasearch/lite';
+/** @ts-ignore */
+import type * as ClientSearch from '@algolia/client-search';
+
+/** @ts-ignore */
+type SearchResponseV3<TObject> = AlgoliaSearch.Response<TObject>;
+/** @ts-ignore */
+type SearchResponseV4<TObject> = ClientSearch.SearchResponse<TObject>;
+
+type SearchForFacetValuesResponseV3 =
+  /** @ts-ignore */
+  AlgoliaSearch.SearchForFacetValues.Response;
+/** @ts-ignore */
+type SearchForFacetValuesResponseV4 = ClientSearch.SearchForFacetValuesResponse;
+
+type DummySearchClientV4 = {
+  readonly transporter: any;
+};
+
+type DefaultSearchClient = ReturnType<typeof algoliasearch>;
+
+type SearchResponse<THit> = DefaultSearchClient extends DummySearchClientV4
+  ? SearchResponseV4<THit>
+  : SearchResponseV3<THit>;
+
+type SearchForFacetValuesResponse =
+  DefaultSearchClient extends DummySearchClientV4
+    ? SearchForFacetValuesResponseV4
+    : SearchForFacetValuesResponseV3;
 
 export function createSingleSearchResponse<THit = any>(
   options: Partial<SearchResponse<THit>> = {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7692,10 +7692,10 @@ algolia-aerial@^1.5.3:
   resolved "https://registry.yarnpkg.com/algolia-aerial/-/algolia-aerial-1.5.3.tgz#c8b8ca6bc484164ffc7b36717689a424ea6bfe6c"
   integrity sha512-LZTpVlYnhqNFd+ru/Spm73omhsagiRQLmjrosa5bJ6/I9OMRp4Sb9pYZkAxcx3RSr+ZNXZqthL7rpXqMFdrnPA==
 
-algoliasearch-helper@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.7.0.tgz#c0a0493df84d850360f664ad7a9d4fc78a94fd78"
-  integrity sha512-XJ3QfERBLfeVCyTVx80gon7r3/rgm/CE8Ha1H7cbablRe/X7SfYQ14g/eO+MhjVKIQp+gy9oC6G5ilmLwS1k6w==
+algoliasearch-helper@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.7.4.tgz#3812ea161da52463ec88da52612c9a363c1b181d"
+  integrity sha512-KmJrsHVm5TmxZ9Oj53XdXuM4CQeu7eVFnB15tpSFt+7is1d1yVCv3hxCLMqYSw/rH42ccv013miQpRr268P8vw==
   dependencies:
     "@algolia/events" "^4.0.1"
 
@@ -17452,16 +17452,16 @@ instantsearch.css@7.4.5:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.4.5.tgz#2a521aa634329bf1680f79adf87c79d67669ec8d"
   integrity sha512-iIGBYjCokU93DDB8kbeztKtlu4qVEyTg1xvS6iSO1YvqRwkIZgf0tmsl/GytsLdZhuw8j4wEaeYsCzNbeJ/zEQ==
 
-instantsearch.js@4.39.0, instantsearch.js@^4.39.0:
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.39.0.tgz#edb4b9ccdaf7e1736c7d59285d01ec23d528097d"
-  integrity sha512-dFPiNmsj9xt3ltVjEFlXe+BLs+C8AT00vG0ZUQDZHoznVlKOdPjyd8IHhtyspJUD13yqkMrvm+JL5dyHZIZFuA==
+instantsearch.js@4.40.1, instantsearch.js@^4.40.1:
+  version "4.40.1"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.40.1.tgz#9c702a1e7e3bc14e5137b1236be2ee68bb0bf643"
+  integrity sha512-0wIuz1vAHPo2aUpsSsym5urLDpAqQIVBx4QzbHZmmXhA+DEQq5bHmNCCo3FnyKFZ2/79dNmg0OwJTMQM6Je/fg==
   dependencies:
     "@algolia/events" "^4.0.1"
     "@types/google.maps" "^3.45.3"
     "@types/hogan.js" "^3.0.0"
     "@types/qs" "^6.5.3"
-    algoliasearch-helper "^3.7.0"
+    algoliasearch-helper "^3.7.4"
     classnames "^2.2.5"
     hogan.js "^3.0.2"
     preact "^10.6.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The initial results used for rendering the "initial state" (before init or render happens) is now marked as artificial, so that it can be hidden in eg. pagination, stats. 

Note that in server-side rendering, the initial results come from an actual network request, and thus aren't artificial.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Initial results are artificial.