### PR TITLE
feat(hooks): avoid exposing translations for now

### DIFF
--- a/packages/react-instantsearch-hooks-dom/src/widgets/ClearRefinements.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/ClearRefinements.tsx
@@ -3,13 +3,12 @@ import { useClearRefinements } from 'react-instantsearch-hooks';
 
 import { ClearRefinements as ClearRefinementsUiComponent } from '../ui/ClearRefinements';
 
-import type { Translatable } from '../types';
 import type { ClearRefinementsProps as ClearRefinementsUiComponentProps } from '../ui/ClearRefinements';
 import type { UseClearRefinementsProps } from 'react-instantsearch-hooks';
 
 export type ClearRefinementsProps = Omit<
-  Translatable<ClearRefinementsUiComponentProps>,
-  'disabled' | 'onClick'
+  ClearRefinementsUiComponentProps,
+  'disabled' | 'onClick' | 'translations'
 > &
   UseClearRefinementsProps;
 
@@ -17,7 +16,6 @@ export function ClearRefinements({
   includedAttributes,
   excludedAttributes,
   transformItems,
-  translations,
   ...props
 }: ClearRefinementsProps) {
   const { canRefine, refine } = useClearRefinements(
@@ -36,7 +34,6 @@ export function ClearRefinements({
       {...props}
       translations={{
         resetLabel: 'Clear refinements',
-        ...translations,
       }}
       onClick={refine}
       disabled={!canRefine}

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/ClearRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/ClearRefinements.test.tsx
@@ -77,46 +77,6 @@ describe('ClearRefinements', () => {
     `);
   });
 
-  test('renders with a custom label', async () => {
-    const { container } = render(
-      <InstantSearchHooksTestWrapper
-        initialUiState={{
-          indexName: {
-            refinementList: {
-              brand: ['Apple'],
-            },
-          },
-        }}
-      >
-        <RefinementList attribute="brand" />
-        <ClearRefinements
-          translations={{
-            resetLabel: 'Clear',
-          }}
-        />
-      </InstantSearchHooksTestWrapper>
-    );
-
-    await wait(0);
-
-    expect(
-      document.querySelector('.ais-ClearRefinements-button')
-    ).toHaveTextContent('Clear');
-    expect(container).toMatchInlineSnapshot(`
-      <div>
-        <div
-          class="ais-ClearRefinements"
-        >
-          <button
-            class="ais-ClearRefinements-button"
-          >
-            Clear
-          </button>
-        </div>
-      </div>
-    `);
-  });
-
   test('clears all refinements', async () => {
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper


### PR DESCRIPTION
## Summary

This removes `translations` from the `ClearRefinements` widget, until we agree on the API.

We're keeping the API internally for now. This allows us to centralize strings to translate and prepares for the API later on.