### PR TITLE
fix(hooks): compute initial search parameters from widget

### DIFF
--- a/packages/react-instantsearch-hooks/src/connectors/__tests__/useClearRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks/src/connectors/__tests__/useClearRefinements.test.tsx
@@ -64,8 +64,8 @@ describe('useClearRefinements', () => {
 
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
-      hasRefinements: false,
-      canRefine: false,
+      hasRefinements: true,
+      canRefine: true,
       refine: expect.any(Function),
       createURL: expect.any(Function),
     });

--- a/packages/react-instantsearch-hooks/src/connectors/__tests__/useCurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks/src/connectors/__tests__/useCurrentRefinements.test.tsx
@@ -64,8 +64,23 @@ describe('useCurrentRefinements', () => {
 
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
-      items: [],
-      canRefine: false,
+      items: [
+        {
+          attribute: 'brand',
+          indexName: 'indexName',
+          label: 'brand',
+          refine: expect.any(Function),
+          refinements: [
+            {
+              attribute: 'brand',
+              label: 'Apple',
+              type: 'disjunctive',
+              value: 'Apple',
+            },
+          ],
+        },
+      ],
+      canRefine: true,
       refine: expect.any(Function),
       createURL: expect.any(Function),
     });

--- a/packages/react-instantsearch-hooks/src/hooks/__tests__/useConnector.test.tsx
+++ b/packages/react-instantsearch-hooks/src/hooks/__tests__/useConnector.test.tsx
@@ -81,6 +81,9 @@ const connectCustomSearchBox: Connector<
           query: searchParameters.query,
         };
       },
+      getWidgetSearchParameters(searchParameters, { uiState }) {
+        return searchParameters.setQueryParameter('query', uiState.query || '');
+      },
     };
   };
 
@@ -223,7 +226,15 @@ describe('useConnector', () => {
 
     function SearchProvider({ children }) {
       return (
-        <InstantSearch searchClient={searchClient} indexName="indexName">
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="indexName"
+          initialUiState={{
+            indexName: {
+              query: 'query',
+            },
+          }}
+        >
           <InstantSearchContext.Consumer>
             {(searchContextValue) => {
               searchContext = searchContextValue;
@@ -247,9 +258,25 @@ describe('useConnector', () => {
       wrapper: SearchProvider,
     });
 
+    const helperState = {
+      disjunctiveFacets: [],
+      disjunctiveFacetsRefinements: {},
+      facets: [],
+      facetsExcludes: {},
+      facetsRefinements: {},
+      hierarchicalFacets: [],
+      hierarchicalFacetsRefinements: {},
+      index: 'indexName',
+      numericRefinements: {},
+      query: 'query',
+      tagRefinements: [],
+    };
+
     expect(getWidgetRenderState).toHaveBeenCalledTimes(1);
     expect(getWidgetRenderState).toHaveBeenCalledWith({
-      helper: expect.any(Object),
+      helper: expect.objectContaining({
+        state: helperState,
+      }),
       parent: indexContext!,
       instantSearchInstance: searchContext!,
       results: expect.objectContaining({
@@ -263,7 +290,7 @@ describe('useConnector', () => {
           helper: expect.any(Object),
         },
       ],
-      state: expect.any(Object),
+      state: helperState,
       renderState: searchContext!.renderState,
       templatesConfig: searchContext!.templatesConfig,
       createURL: indexContext!.createURL,

--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -89,17 +89,19 @@ export function useConnector<
     if (widget.getWidgetRenderState) {
       // The helper exists because we've started InstantSearch.
       const helper = parentIndex.getHelper()!;
+      const uiState = parentIndex.getWidgetUiState({})[
+        parentIndex.getIndexId()
+      ];
+      helper.state =
+        widget.getWidgetSearchParameters?.(helper.state, { uiState }) ||
+        helper.state;
       const results =
         // On SSR, we get the results injected on the Index.
         parentIndex.getResults() ||
         // On the browser, we create fallback results based on the widget's
         // `getWidgetSearchParameters()` method to inject the initial UI state,
         // or fall back to the helper state.
-        createSearchResults(
-          widget.getWidgetSearchParameters?.(helper.state, {
-            uiState: parentIndex.getWidgetUiState({})[parentIndex.getIndexId()],
-          }) || helper.state
-        );
+        createSearchResults(helper.state);
       const scopedResults = parentIndex
         .getScopedResults()
         .map((scopedResult) => {
@@ -124,7 +126,7 @@ export function useConnector<
         instantSearchInstance: search,
         results,
         scopedResults,
-        state: results._state,
+        state: helper.state,
         renderState: search.renderState,
         templatesConfig: search.templatesConfig,
         createURL: parentIndex.createURL,


### PR DESCRIPTION
## Description

This changes how we compute the initial Helper state that we give to `widget.getWidgetRenderState()` to retrieve the initial widget React state.

The problem originally surfaced when server-side rendering the `<Menu>` component:

> Error: Cannot refine the undeclared facet categories; it should be added to the helper options facets, disjunctiveFacets or hierarchicalFacets

This happens because the `helper.state` and `state` used to call `widget.getWidgetRenderState()` mismatched. In algolia/instantsearch.js#4960, we tried to fix this problem by always relying on `state`. But this constraint is hard to respect, and hard to implement in practice because of stale closures (in `refine()` and `createURL()`).

I explain in that PR why we had to do it this way, essentially because the helper state was the resolved helper state, including all the inherited search parameters from the parent indices. With a resolved helper state, InstantSearch considers the parameters as controlled and therefore doesn't get notified of new changes coming from other indices. The part that we were missing is that there's a way to compute the local index search parameters without inheriting the parent index via `index.getWidgetSearchParameters()`.

## Solution

This PR is another cleaner approach directly in React InstantSearch Hooks. We assign the widget search parameters gotten from `widget.getWidgetSearchParameters()` to the helper state so that the widget is directly aware of its search parameters.

## Result

- It fixes the original problem with `<Menu>` throwing about the undeclared facet.
- It also fixes `useClearRefinements()` and `useCurrentRefinements()` that used to initially render with an empty state. They're now directly aware of their refinements during first render.
- We'll be able to rollback some of the changes introduced in algolia/instantsearch.js#4960