### PR TITLE
docs(hooks): fix URL computation in Next.js example

### DIFF
--- a/examples/hooks-next/pages/index.tsx
+++ b/examples/hooks-next/pages/index.tsx
@@ -83,9 +83,8 @@ function FallbackComponent({ attribute }: { attribute: string }) {
 }
 
 export async function getServerSideProps({ req }) {
-  const url = new URL(
-    req.headers.referer || `https://${req.headers.host}${req.url}`
-  ).toString();
+  const protocol = req.headers.referer?.split('://')[0] || 'https';
+  const url = `${protocol}://${req.headers.host}${req.url}`;
   const serverState = await getServerState(<HomePage url={url} />);
 
   return {


### PR DESCRIPTION
This updates the URL computation in the Next.js example.

- `req.headers.referer` was not correct because it's not the current route
- Next.js doesn't expose the protocol so we still get it from `req.headers.referer`
- We don't need to create a URL to then convert it to a string on the server

Then we need to update the [Next.js SSR guide](https://www.algolia.com/doc/guides/building-search-ui/going-further/server-side-rendering/react-hooks/#with-nextjs).