### PR TITLE
fix: support React 18 as peer dependency

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -43,6 +43,6 @@
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.1 < 5",
-    "react": ">= 16.3.0 < 18"
+    "react": ">= 16.3.0 < 19"
   }
 }

--- a/packages/react-instantsearch-dom-maps/package.json
+++ b/packages/react-instantsearch-dom-maps/package.json
@@ -44,8 +44,8 @@
     "scriptjs": "^2.5.8"
   },
   "peerDependencies": {
-    "react": ">= 16.3.0 < 18",
-    "react-dom": ">= 16.3.0 < 18",
+    "react": ">= 16.3.0 < 19",
+    "react-dom": ">= 16.3.0 < 19",
     "react-instantsearch-dom": "6.21.0"
   }
 }

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -46,7 +46,7 @@
     "react-instantsearch-core": "6.23.0"
   },
   "peerDependencies": {
-    "react": ">= 16.3.0 < 18",
-    "react-dom": ">= 16.3.0 < 18"
+    "react": ">= 16.3.0 < 19",
+    "react-dom": ">= 16.3.0 < 19"
   }
 }


### PR DESCRIPTION
This adds support for React 18 as peer dependency in React InstantSearch Core and DOM (Hooks package were already marked as compatible). React Native is not yet compatible with React 18.