### PR TITLE
feat(refinements): use escaped value for refining

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.7.4",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0"
   },

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0"
   },

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0"
   },

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper",
+    "algoliasearch-helper": "^3.8.0",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0"
   },

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectBreadcrumb.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectBreadcrumb.js
@@ -32,18 +32,21 @@ describe('connectBreadcrumb', () => {
           {
             name: 'wat',
             path: 'wat',
+            value: 'wat',
             count: 20,
             isRefined: true,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
+                value: 'wat > wot',
                 isRefined: true,
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
+                value: 'wat > wut',
                 isRefined: false,
                 count: 5,
               },
@@ -52,6 +55,7 @@ describe('connectBreadcrumb', () => {
           {
             name: 'oy',
             path: 'oy',
+            value: 'oy',
             isRefined: false,
             count: 10,
           },
@@ -148,18 +152,21 @@ describe('connectBreadcrumb', () => {
           {
             name: 'wat',
             path: 'wat',
+            value: 'wat',
             count: 20,
             isRefined: true,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
+                value: 'wat > wot',
                 isRefined: true,
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
+                value: 'wat > wut',
                 isRefined: false,
                 count: 5,
               },
@@ -168,6 +175,7 @@ describe('connectBreadcrumb', () => {
           {
             name: 'oy',
             path: 'oy',
+            value: 'oy',
             isRefined: false,
             count: 10,
           },

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectBreadcrumb.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectBreadcrumb.js
@@ -32,21 +32,21 @@ describe('connectBreadcrumb', () => {
           {
             name: 'wat',
             path: 'wat',
-            value: 'wat',
+            escapedValue: 'wat',
             count: 20,
             isRefined: true,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
-                value: 'wat > wot',
+                escapedValue: 'wat > wot',
                 isRefined: true,
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
-                value: 'wat > wut',
+                escapedValue: 'wat > wut',
                 isRefined: false,
                 count: 5,
               },
@@ -55,7 +55,7 @@ describe('connectBreadcrumb', () => {
           {
             name: 'oy',
             path: 'oy',
-            value: 'oy',
+            escapedValue: 'oy',
             isRefined: false,
             count: 10,
           },
@@ -152,21 +152,21 @@ describe('connectBreadcrumb', () => {
           {
             name: 'wat',
             path: 'wat',
-            value: 'wat',
+            escapedValue: 'wat',
             count: 20,
             isRefined: true,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
-                value: 'wat > wot',
+                escapedValue: 'wat > wot',
                 isRefined: true,
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
-                value: 'wat > wut',
+                escapedValue: 'wat > wut',
                 isRefined: false,
                 count: 5,
               },
@@ -175,7 +175,7 @@ describe('connectBreadcrumb', () => {
           {
             name: 'oy',
             path: 'oy',
-            value: 'oy',
+            escapedValue: 'oy',
             isRefined: false,
             count: 10,
           },

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
@@ -44,19 +44,19 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'wat',
             path: 'wat',
-            value: 'wat',
+            escapedValue: 'wat',
             count: 20,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
-                value: 'wat > wot',
+                escapedValue: 'wat > wot',
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
-                value: 'wat > wut',
+                escapedValue: 'wat > wut',
                 count: 5,
               },
             ],
@@ -64,7 +64,7 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'oy',
             path: 'oy',
-            value: 'oy',
+            escapedValue: 'oy',
             count: 10,
           },
         ],
@@ -342,25 +342,25 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'wat',
             path: 'wat',
-            value: 'wat',
+            escapedValue: 'wat',
             count: 20,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
-                value: 'wat > wot',
+                escapedValue: 'wat > wot',
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
-                value: 'wat > wut',
+                escapedValue: 'wat > wut',
                 count: 3,
               },
               {
                 name: 'wit',
                 path: 'wat > wit',
-                value: 'wat > wit',
+                escapedValue: 'wat > wit',
                 count: 5,
               },
             ],
@@ -368,13 +368,13 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'oy',
             path: 'oy',
-            value: 'oy',
+            escapedValue: 'oy',
             count: 10,
           },
           {
             name: 'ay',
             path: 'ay',
-            value: 'ay',
+            escapedValue: 'ay',
             count: 3,
           },
         ],
@@ -429,25 +429,25 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'wat',
             path: 'wat',
-            value: 'wat',
+            escapedValue: 'wat',
             count: 20,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
-                value: 'wat > wot',
+                escapedValue: 'wat > wot',
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
-                value: 'wat > wut',
+                escapedValue: 'wat > wut',
                 count: 3,
               },
               {
                 name: 'wit',
                 path: 'wat > wit',
-                value: 'wat > wit',
+                escapedValue: 'wat > wit',
                 count: 5,
               },
             ],
@@ -455,13 +455,13 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'oy',
             path: 'oy',
-            value: 'oy',
+            escapedValue: 'oy',
             count: 10,
           },
           {
             name: 'ay',
             path: 'ay',
-            value: 'ay',
+            escapedValue: 'ay',
             count: 3,
           },
         ],
@@ -801,19 +801,19 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'wat',
             path: 'wat',
-            value: 'wat',
+            escapedValue: 'wat',
             count: 20,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
-                value: 'wat > wot',
+                escapedValue: 'wat > wot',
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
-                value: 'wat > wut',
+                escapedValue: 'wat > wut',
                 count: 5,
               },
             ],
@@ -821,7 +821,7 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'oy',
             path: 'oy',
-            value: 'oy',
+            escapedValue: 'oy',
             count: 10,
           },
         ],

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
@@ -44,16 +44,19 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'wat',
             path: 'wat',
+            value: 'wat',
             count: 20,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
+                value: 'wat > wot',
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
+                value: 'wat > wut',
                 count: 5,
               },
             ],
@@ -61,6 +64,7 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'oy',
             path: 'oy',
+            value: 'oy',
             count: 10,
           },
         ],
@@ -338,21 +342,25 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'wat',
             path: 'wat',
+            value: 'wat',
             count: 20,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
+                value: 'wat > wot',
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
+                value: 'wat > wut',
                 count: 3,
               },
               {
                 name: 'wit',
                 path: 'wat > wit',
+                value: 'wat > wit',
                 count: 5,
               },
             ],
@@ -360,11 +368,13 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'oy',
             path: 'oy',
+            value: 'oy',
             count: 10,
           },
           {
             name: 'ay',
             path: 'ay',
+            value: 'ay',
             count: 3,
           },
         ],
@@ -419,21 +429,25 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'wat',
             path: 'wat',
+            value: 'wat',
             count: 20,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
+                value: 'wat > wot',
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
+                value: 'wat > wut',
                 count: 3,
               },
               {
                 name: 'wit',
                 path: 'wat > wit',
+                value: 'wat > wit',
                 count: 5,
               },
             ],
@@ -441,11 +455,13 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'oy',
             path: 'oy',
+            value: 'oy',
             count: 10,
           },
           {
             name: 'ay',
             path: 'ay',
+            value: 'ay',
             count: 3,
           },
         ],
@@ -785,16 +801,19 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'wat',
             path: 'wat',
+            value: 'wat',
             count: 20,
             data: [
               {
                 name: 'wot',
                 path: 'wat > wot',
+                value: 'wat > wot',
                 count: 15,
               },
               {
                 name: 'wut',
                 path: 'wat > wut',
+                value: 'wat > wut',
                 count: 5,
               },
             ],
@@ -802,6 +821,7 @@ describe('connectHierarchicalMenu', () => {
           {
             name: 'oy',
             path: 'oy',
+            value: 'oy',
             count: 10,
           },
         ],

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectMenu.js
@@ -86,13 +86,13 @@ describe('connectMenu', () => {
       results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
-          value: 'wat',
+          escapedValue: 'wat',
           isRefined: true,
           count: 20,
         },
         {
           name: 'oy',
-          value: 'oy',
+          escapedValue: 'oy',
           isRefined: false,
           count: 10,
         },
@@ -161,6 +161,7 @@ describe('connectMenu', () => {
           ok: [
             {
               value: 'wat',
+              escapedValue: 'wat',
               count: 10,
               highlighted: 'wat',
               isRefined: false,
@@ -226,7 +227,7 @@ describe('connectMenu', () => {
       results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
-          value: 'wat',
+          escapedValue: 'wat',
           isRefined: true,
           count: 20,
         },
@@ -534,13 +535,13 @@ describe('connectMenu', () => {
         getFacetValues: jest.fn(() => [
           {
             name: 'oy',
-            value: 'oy',
+            escapedValue: 'oy',
             isRefined: true,
             count: 10,
           },
           {
             name: 'wat',
-            value: 'wat',
+            escapedValue: 'wat',
             isRefined: false,
             count: 20,
           },
@@ -581,13 +582,13 @@ describe('connectMenu', () => {
         getFacetValues: jest.fn(() => [
           {
             name: 'oy',
-            value: 'oy',
+            escapedValue: 'oy',
             isRefined: true,
             count: 10,
           },
           {
             name: 'wat',
-            value: 'wat',
+            escapedValue: 'wat',
             isRefined: false,
             count: 20,
           },
@@ -734,13 +735,13 @@ describe('connectMenu', () => {
       results.second.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
-          value: 'wat',
+          escapedValue: 'wat',
           isRefined: true,
           count: 20,
         },
         {
           name: 'oy',
-          value: 'oy',
+          escapedValue: 'oy',
           isRefined: false,
           count: 10,
         },
@@ -810,6 +811,7 @@ describe('connectMenu', () => {
           ok: [
             {
               value: 'wat',
+              escapedValue: 'wat',
               count: 10,
               highlighted: 'wat',
               isRefined: false,
@@ -876,7 +878,7 @@ describe('connectMenu', () => {
       results.second.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
-          value: 'wat',
+          escapedValue: 'wat',
           isRefined: true,
           count: 20,
         },

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectMenu.js
@@ -86,11 +86,13 @@ describe('connectMenu', () => {
       results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
+          value: 'wat',
           isRefined: true,
           count: 20,
         },
         {
           name: 'oy',
+          value: 'oy',
           isRefined: false,
           count: 10,
         },
@@ -224,6 +226,7 @@ describe('connectMenu', () => {
       results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
+          value: 'wat',
           isRefined: true,
           count: 20,
         },
@@ -531,11 +534,13 @@ describe('connectMenu', () => {
         getFacetValues: jest.fn(() => [
           {
             name: 'oy',
+            value: 'oy',
             isRefined: true,
             count: 10,
           },
           {
             name: 'wat',
+            value: 'wat',
             isRefined: false,
             count: 20,
           },
@@ -576,11 +581,13 @@ describe('connectMenu', () => {
         getFacetValues: jest.fn(() => [
           {
             name: 'oy',
+            value: 'oy',
             isRefined: true,
             count: 10,
           },
           {
             name: 'wat',
+            value: 'wat',
             isRefined: false,
             count: 20,
           },
@@ -727,11 +734,13 @@ describe('connectMenu', () => {
       results.second.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
+          value: 'wat',
           isRefined: true,
           count: 20,
         },
         {
           name: 'oy',
+          value: 'oy',
           isRefined: false,
           count: 10,
         },
@@ -867,6 +876,7 @@ describe('connectMenu', () => {
       results.second.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
+          value: 'wat',
           isRefined: true,
           count: 20,
         },

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
@@ -82,13 +82,13 @@ describe('connectRefinementList', () => {
       results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
-          value: 'wat',
+          escapedValue: 'wat',
           isRefined: true,
           count: 20,
         },
         {
           name: 'oy',
-          value: 'oy',
+          escapedValue: 'oy',
           isRefined: false,
           count: 10,
         },
@@ -137,6 +137,7 @@ describe('connectRefinementList', () => {
           ok: [
             {
               value: 'wat',
+              escapedValue: 'wat',
               count: 10,
               highlighted: 'wat',
               isRefined: false,
@@ -222,7 +223,8 @@ describe('connectRefinementList', () => {
         {
           ok: [
             {
-              value: ['wat'],
+              value: 'wat',
+              escapedValue: 'wat',
               label: 'wat',
               isRefined: true,
               count: 20,
@@ -236,8 +238,8 @@ describe('connectRefinementList', () => {
           _highlightResult: { label: { value: 'wat' } },
           count: 20,
           isRefined: true,
-          label: ['wat'],
-          value: [['wat']],
+          label: 'wat',
+          value: ['wat'],
         },
       ]);
       expect(props.isFromSearch).toBe(true);

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
@@ -82,11 +82,13 @@ describe('connectRefinementList', () => {
       results.getFacetValues.mockImplementation(() => [
         {
           name: 'wat',
+          value: 'wat',
           isRefined: true,
           count: 20,
         },
         {
           name: 'oy',
+          value: 'oy',
           isRefined: false,
           count: 10,
         },

--- a/packages/react-instantsearch-core/src/connectors/connectBreadcrumb.js
+++ b/packages/react-instantsearch-core/src/connectors/connectBreadcrumb.js
@@ -20,7 +20,7 @@ function transformValue(values) {
         label: item.name,
         // If dealing with a nested "items", "value" is equal to the previous value concatenated with the current value
         // If dealing with the first level, "value" is equal to the current value
-        value: item.value,
+        value: item.escapedValue,
       });
       // Create a variable in order to keep the same acc for the recursion, otherwise "reduce" returns a new one
       if (item.data) {

--- a/packages/react-instantsearch-core/src/connectors/connectBreadcrumb.js
+++ b/packages/react-instantsearch-core/src/connectors/connectBreadcrumb.js
@@ -18,9 +18,9 @@ function transformValue(values) {
     if (item.isRefined) {
       acc.push({
         label: item.name,
-        // If dealing with a nested "items", "value" is equal to the previous value concatenated with the current label
-        // If dealing with the first level, "value" is equal to the current label
-        value: item.path,
+        // If dealing with a nested "items", "value" is equal to the previous value concatenated with the current value
+        // If dealing with the first level, "value" is equal to the current value
+        value: item.value,
       });
       // Create a variable in order to keep the same acc for the recursion, otherwise "reduce" returns a new one
       if (item.data) {

--- a/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
@@ -61,7 +61,7 @@ function getValue(value, props, searchState, context) {
 function transformValue(value, props, searchState, context) {
   return value.map((v) => ({
     label: v.name,
-    value: getValue(v.value, props, searchState, context),
+    value: getValue(v.escapedValue, props, searchState, context),
     count: v.count,
     isRefined: v.isRefined,
     items: v.data && transformValue(v.data, props, searchState, context),

--- a/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
@@ -28,14 +28,14 @@ function getCurrentRefinement(props, searchState, context) {
   return currentRefinement;
 }
 
-function getValue(path, props, searchState, context) {
+function getValue(value, props, searchState, context) {
   const { id, attributes, separator, rootPath, showParentLevel } = props;
 
   const currentRefinement = getCurrentRefinement(props, searchState, context);
   let nextRefinement;
 
   if (currentRefinement === null) {
-    nextRefinement = path;
+    nextRefinement = value;
   } else {
     const tmpSearchParameters = new algoliasearchHelper.SearchParameters({
       hierarchicalFacets: [
@@ -51,7 +51,7 @@ function getValue(path, props, searchState, context) {
 
     nextRefinement = tmpSearchParameters
       .toggleHierarchicalFacetRefinement(id, currentRefinement)
-      .toggleHierarchicalFacetRefinement(id, path)
+      .toggleHierarchicalFacetRefinement(id, value)
       .getHierarchicalRefinement(id)[0];
   }
 
@@ -61,7 +61,7 @@ function getValue(path, props, searchState, context) {
 function transformValue(value, props, searchState, context) {
   return value.map((v) => ({
     label: v.name,
-    value: getValue(v.path, props, searchState, context),
+    value: getValue(v.value, props, searchState, context),
     count: v.count,
     isRefined: v.isRefined,
     items: v.data && transformValue(v.data, props, searchState, context),
@@ -98,7 +98,7 @@ const sortBy = ['name:asc'];
  * websites. From a UX point of view, we suggest not displaying more than two levels deep.
  * @name connectHierarchicalMenu
  * @requirements To use this widget, your attributes must be formatted in a specific way.
- * If you want for example to have a hiearchical menu of categories, objects in your index
+ * If you want for example to have a hierarchical menu of categories, objects in your index
  * should be formatted this way:
  *
  * ```json

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -155,7 +155,7 @@ export default createConnector({
         })
         .map((v) => ({
           label: v.name,
-          value: getValue(v.value, props, searchState, {
+          value: getValue(v.escapedValue, props, searchState, {
             ais: props.contextValue,
             multiIndexContext: props.indexContextValue,
           }),

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -29,9 +29,9 @@ function getCurrentRefinement(props, searchState, context) {
   return currentRefinement;
 }
 
-function getValue(name, props, searchState, context) {
+function getValue(value, props, searchState, context) {
   const currentRefinement = getCurrentRefinement(props, searchState, context);
-  return name === currentRefinement ? '' : name;
+  return value === currentRefinement ? '' : value;
 }
 
 function getLimit({ showMore, limit, showMoreLimit }) {
@@ -155,7 +155,7 @@ export default createConnector({
         })
         .map((v) => ({
           label: v.name,
-          value: getValue(v.name, props, searchState, {
+          value: getValue(v.value, props, searchState, {
             ais: props.contextValue,
             multiIndexContext: props.indexContextValue,
           }),

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -139,7 +139,7 @@ export default createConnector({
     if (isFromSearch) {
       items = searchForFacetValuesResults[attribute].map((v) => ({
         label: v.value,
-        value: getValue(v.safeValue, props, searchState, {
+        value: getValue(v.escapedValue, props, searchState, {
           ais: props.contextValue,
           multiIndexContext: props.indexContextValue,
         }),

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -139,7 +139,7 @@ export default createConnector({
     if (isFromSearch) {
       items = searchForFacetValuesResults[attribute].map((v) => ({
         label: v.value,
-        value: getValue(v.value, props, searchState, {
+        value: getValue(v.safeValue, props, searchState, {
           ais: props.contextValue,
           multiIndexContext: props.indexContextValue,
         }),

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -34,12 +34,12 @@ function getCurrentRefinement(props, searchState, context) {
   return [];
 }
 
-function getValue(name, props, searchState, context) {
+function getValue(value, props, searchState, context) {
   const currentRefinement = getCurrentRefinement(props, searchState, context);
-  const isAnewValue = currentRefinement.indexOf(name) === -1;
+  const isAnewValue = currentRefinement.indexOf(value) === -1;
   const nextRefinement = isAnewValue
-    ? currentRefinement.concat([name]) // cannot use .push(), it mutates
-    : currentRefinement.filter((selectedValue) => selectedValue !== name); // cannot use .splice(), it mutates
+    ? currentRefinement.concat([value]) // cannot use .push(), it mutates
+    : currentRefinement.filter((selectedValue) => selectedValue !== value); // cannot use .splice(), it mutates
   return nextRefinement;
 }
 
@@ -161,6 +161,7 @@ export default createConnector({
     const items = isFromSearch
       ? searchForFacetValuesResults[attribute].map((v) => ({
           label: v.value,
+          // TODO: does this need to be escaped?
           value: getValue(v.value, props, searchState, {
             ais: props.contextValue,
             multiIndexContext: props.indexContextValue,
@@ -173,7 +174,7 @@ export default createConnector({
           .getFacetValues(attribute, { sortBy, facetOrdering })
           .map((v) => ({
             label: v.name,
-            value: getValue(v.name, props, searchState, {
+            value: getValue(v.value, props, searchState, {
               ais: props.contextValue,
               multiIndexContext: props.indexContextValue,
             }),

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -161,7 +161,7 @@ export default createConnector({
     const items = isFromSearch
       ? searchForFacetValuesResults[attribute].map((v) => ({
           label: v.value,
-          value: getValue(v.value, props, searchState, {
+          value: getValue(v.escapedValue, props, searchState, {
             ais: props.contextValue,
             multiIndexContext: props.indexContextValue,
           }),

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -161,7 +161,6 @@ export default createConnector({
     const items = isFromSearch
       ? searchForFacetValuesResults[attribute].map((v) => ({
           label: v.value,
-          // TODO: does this need to be escaped?
           value: getValue(v.value, props, searchState, {
             ais: props.contextValue,
             multiIndexContext: props.indexContextValue,

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -173,7 +173,7 @@ export default createConnector({
           .getFacetValues(attribute, { sortBy, facetOrdering })
           .map((v) => ({
             label: v.name,
-            value: getValue(v.value, props, searchState, {
+            value: getValue(v.safeValue, props, searchState, {
               ais: props.contextValue,
               multiIndexContext: props.indexContextValue,
             }),

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -173,7 +173,7 @@ export default createConnector({
           .getFacetValues(attribute, { sortBy, facetOrdering })
           .map((v) => ({
             label: v.name,
-            value: getValue(v.safeValue, props, searchState, {
+            value: getValue(v.escapedValue, props, searchState, {
               ais: props.contextValue,
               multiIndexContext: props.indexContextValue,
             }),

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.7.4",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0",

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0",

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper",
+    "algoliasearch-helper": "^3.8.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0",

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0",

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper",
     "dequal": "^2.0.0",
     "instantsearch.js": "^4.40.1"
   },

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper",
     "dequal": "^2.0.0",
     "instantsearch.js": "^4.40.1"
   },

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.8.0",
+    "algoliasearch-helper": "^3.7.4",
     "dequal": "^2.0.0",
     "instantsearch.js": "^4.40.1"
   },

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.7.4",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper",
     "dequal": "^2.0.0",
     "instantsearch.js": "^4.40.1"
   },

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper",
+    "algoliasearch-helper": "^3.8.0",
     "dequal": "^2.0.0",
     "instantsearch.js": "^4.40.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7699,10 +7699,10 @@ algoliasearch-helper@^3.7.4:
   dependencies:
     "@algolia/events" "^4.0.1"
 
-"algoliasearch-helper@https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper":
+"algoliasearch-helper@https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper":
   version "3.7.4"
-  uid ef4ddbf32d08675e0f4a77ae3fac7ee87945a095
-  resolved "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper#ef4ddbf32d08675e0f4a77ae3fac7ee87945a095"
+  uid f67e3eda5e5f4cfa2ec4d39a9941ec9191e5f3c2
+  resolved "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper#f67e3eda5e5f4cfa2ec4d39a9941ec9191e5f3c2"
   dependencies:
     "@algolia/events" "^4.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7699,10 +7699,10 @@ algoliasearch-helper@^3.7.4:
   dependencies:
     "@algolia/events" "^4.0.1"
 
-"algoliasearch-helper@https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper":
-  version "3.7.4"
-  uid "29a0180760d065f7341531e5215cca2b6197b596"
-  resolved "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper#29a0180760d065f7341531e5215cca2b6197b596"
+algoliasearch-helper@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.8.0.tgz#5880eb4fb375adca50004e4c287575a59c8f4641"
+  integrity sha512-c1ZuXe6bf1JH/zD5h65gk04tMJ36UtvdfCmSC9F6QfTspa/smrbSnJy9F4X7SNkXdj+MKFP82IXhs9lEt+x5+w==
   dependencies:
     "@algolia/events" "^4.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7699,6 +7699,13 @@ algoliasearch-helper@^3.7.4:
   dependencies:
     "@algolia/events" "^4.0.1"
 
+"algoliasearch-helper@https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper":
+  version "3.7.4"
+  uid ef4ddbf32d08675e0f4a77ae3fac7ee87945a095
+  resolved "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/493f99a3/algoliasearch-helper#ef4ddbf32d08675e0f4a77ae3fac7ee87945a095"
+  dependencies:
+    "@algolia/events" "^4.0.1"
+
 algoliasearch@4.11.0, "algoliasearch@>= 3.27.1 < 5":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.11.0.tgz#234befb3ac355c094077f0edf3777240b1ee013c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7699,10 +7699,10 @@ algoliasearch-helper@^3.7.4:
   dependencies:
     "@algolia/events" "^4.0.1"
 
-"algoliasearch-helper@https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper":
+"algoliasearch-helper@https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper":
   version "3.7.4"
-  uid f67e3eda5e5f4cfa2ec4d39a9941ec9191e5f3c2
-  resolved "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/a74fc213/algoliasearch-helper#f67e3eda5e5f4cfa2ec4d39a9941ec9191e5f3c2"
+  uid "29a0180760d065f7341531e5215cca2b6197b596"
+  resolved "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/e5182d67/algoliasearch-helper#29a0180760d065f7341531e5215cca2b6197b596"
   dependencies:
     "@algolia/events" "^4.0.1"
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

The helper exposes a `value` to getFacetValues too now, which is the same as the name/label, except escaped. We can use this instead of `name` in all relevant widgets.

relies on https://github.com/algolia/algoliasearch-helper-js/pull/889 and https://github.com/algolia/algoliasearch-helper-js/pull/900 to show the escaped value (leading `-` gets transformed into `\-`

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Facet values that start with `-` are automatically escaped, but you can still refine on a literal value starting with `-`

FX-1135

same as https://github.com/algolia/instantsearch.js/pull/5039