### PR TITLE
fix(multi-index): correctly set `searching` prop in multi-index result states

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createInstantSearchManager.derived.js
@@ -627,4 +627,72 @@ describe('createInstantSearchManager with multi index', () => {
       })
     );
   });
+
+  it('sets state with correct value for `searching` property', async () => {
+    // <InstantSearch indexName="first">
+    //   <Index indexName="first" />
+    //   <Index indexName="second" />
+    //   <Index indexName="third" />
+    // </InstantSearch>;
+
+    const searchClient = createSearchClient({});
+
+    const ism = createInstantSearchManager({
+      indexName: 'first',
+      initialState: {},
+      searchParameters: {},
+      searchClient,
+    });
+
+    // <SearchBox defaultRefinement="first query 1" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: (params) => params.setQuery('first query 1'),
+      props: {},
+    });
+
+    // <Index indexName="first" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: (x) => x.setIndex('first'),
+      props: {
+        indexName: 'first',
+        indexId: 'first',
+      },
+    });
+
+    // <Index indexName="second" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: (x) => x.setIndex('second'),
+      props: {
+        indexName: 'second',
+        indexId: 'second',
+      },
+    });
+
+    // <Index indexName="third" />
+    ism.widgetsManager.registerWidget({
+      getSearchParameters: (x) => x.setIndex('third'),
+      props: {
+        indexName: 'third',
+        indexId: 'third',
+      },
+    });
+
+    const setStateSpy = jest.spyOn(ism.store, 'setState');
+
+    await wait(0);
+
+    expect(setStateSpy.mock.calls).toHaveLength(4);
+    expect(setStateSpy.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ searching: true })
+    );
+    expect(setStateSpy.mock.calls[1][0]).toEqual(
+      expect.objectContaining({ searching: true })
+    );
+    expect(setStateSpy.mock.calls[2][0]).toEqual(
+      expect.objectContaining({ searching: true })
+    );
+    expect(setStateSpy.mock.calls[3][0]).toEqual(
+      expect.objectContaining({ searching: false })
+    );
+  });
 });

--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -96,6 +96,7 @@ export default function createInstantSearchManager({
   let skip = false;
   let stalledSearchTimer = null;
   let initialSearchParameters = helper.state;
+  let searchCounter;
 
   const widgetsManager = createWidgetsManager(onWidgetsUpdate);
 
@@ -215,6 +216,8 @@ export default function createInstantSearchManager({
         helper.state
       );
 
+      searchCounter = derivedParameters.length + 1;
+
       // We have to call `slice` because the method `detach` on the derived
       // helpers mutates the value `derivedHelpers`. The `forEach` loop does
       // not iterate on each value and we're not able to correctly clear the
@@ -253,6 +256,8 @@ export default function createInstantSearchManager({
 
   function handleSearchSuccess({ indexId }) {
     return (event) => {
+      searchCounter--;
+
       const state = store.getState();
       const isDerivedHelpersEmpty = !helper.derivedHelpers.length;
 
@@ -283,7 +288,7 @@ export default function createInstantSearchManager({
         ...partialState,
         results,
         isSearchStalled: nextIsSearchStalled,
-        searching: false,
+        searching: searchCounter > 0,
         error: null,
       });
     };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Currently, search results update the state with the `searching` prop set inconditionnally to `false`, which don't represent the reality of multi-index searches. This PR counts the number of expected search results to set the property to its right value.

See details and sandbox in issue https://github.com/algolia/react-instantsearch/issues/3407.

**Result**

The `searching` prop is set to `true` for all but the last expected request.