### PR TITLE
fix(facets): show raw value in currentRefinements

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectHierarchicalMenu.js
@@ -675,47 +675,68 @@ describe('connectHierarchicalMenu', () => {
       );
     });
 
-    it('registers its id in metadata', () => {
-      const metadata = connect.getMetadata(
-        { attributes: ['ok'], contextValue },
-        {}
-      );
-      expect(metadata).toEqual({ items: [], index: 'index', id: 'ok' });
-    });
-
-    it('registers its filter in metadata', () => {
-      const metadata = connect.getMetadata(
-        { attributes: ['ok'], contextValue },
-        { hierarchicalMenu: { ok: 'wat' } }
-      );
-      expect(metadata).toEqual({
-        id: 'ok',
-        index: 'index',
-        items: [
-          {
-            label: 'ok: wat',
-            attribute: 'ok',
-            currentRefinement: 'wat',
-            // Ignore clear, we test it later
-            value: metadata.items[0].value,
-          },
-        ],
-      });
-    });
-
-    it('items value function should clear it from the search state', () => {
-      const metadata = connect.getMetadata(
-        { attributes: ['one'], contextValue },
-        { hierarchicalMenu: { one: 'one', two: 'two' } }
-      );
-
-      const searchState = metadata.items[0].value({
-        hierarchicalMenu: { one: 'one', two: 'two' },
+    describe('getMetaData', () => {
+      it('registers its id in metadata', () => {
+        const metadata = connect.getMetadata(
+          { attributes: ['ok'], contextValue },
+          {}
+        );
+        expect(metadata).toEqual({ items: [], index: 'index', id: 'ok' });
       });
 
-      expect(searchState).toEqual({
-        page: 1,
-        hierarchicalMenu: { one: '', two: 'two' },
+      it('registers its filter in metadata', () => {
+        const metadata = connect.getMetadata(
+          { attributes: ['ok'], contextValue },
+          { hierarchicalMenu: { ok: 'wat' } }
+        );
+        expect(metadata).toEqual({
+          id: 'ok',
+          index: 'index',
+          items: [
+            {
+              label: 'ok: wat',
+              attribute: 'ok',
+              currentRefinement: 'wat',
+              // Ignore clear, we test it later
+              value: metadata.items[0].value,
+            },
+          ],
+        });
+      });
+
+      it('registers escaped filter in metadata', () => {
+        const metadata = connect.getMetadata(
+          { attributes: ['ok'], contextValue },
+          { hierarchicalMenu: { ok: '\\-wat' } }
+        );
+        expect(metadata).toEqual({
+          id: 'ok',
+          index: 'index',
+          items: [
+            {
+              label: 'ok: -wat',
+              attribute: 'ok',
+              currentRefinement: '\\-wat',
+              value: metadata.items[0].value,
+            },
+          ],
+        });
+      });
+
+      it('items value function should clear it from the search state', () => {
+        const metadata = connect.getMetadata(
+          { attributes: ['one'], contextValue },
+          { hierarchicalMenu: { one: 'one', two: 'two' } }
+        );
+
+        const searchState = metadata.items[0].value({
+          hierarchicalMenu: { one: 'one', two: 'two' },
+        });
+
+        expect(searchState).toEqual({
+          page: 1,
+          hierarchicalMenu: { one: '', two: 'two' },
+        });
       });
     });
 

--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectRefinementList.js
@@ -452,64 +452,95 @@ describe('connectRefinementList', () => {
       );
     });
 
-    it('registers its id in metadata', () => {
-      const metadata = connect.getMetadata(
-        { attribute: 'ok', contextValue },
-        {}
-      );
-      expect(metadata).toEqual({ id: 'ok', index: 'index', items: [] });
-    });
-
-    it('registers its filter in metadata', () => {
-      const metadata = connect.getMetadata(
-        { attribute: 'wot', contextValue },
-        { refinementList: { wot: ['wat', 'wut'] } }
-      );
-      expect(metadata).toEqual({
-        id: 'wot',
-        index: 'index',
-        items: [
-          {
-            label: 'wot: ',
-            attribute: 'wot',
-            currentRefinement: ['wat', 'wut'],
-            value: metadata.items[0].value,
-            items: [
-              {
-                label: 'wat',
-                value: metadata.items[0].items[0].value,
-              },
-              {
-                label: 'wut',
-                value: metadata.items[0].items[1].value,
-              },
-            ],
-            // Ignore value, we test it later
-          },
-        ],
-      });
-    });
-
-    it('items value function should clear it from the search state', () => {
-      const metadata = connect.getMetadata(
-        { attribute: 'one', contextValue },
-        { refinementList: { one: ['one1', 'one2'], two: ['two'] } }
-      );
-
-      let searchState = metadata.items[0].items[0].value({
-        refinementList: { one: ['one1', 'one2'], two: ['two'] },
+    describe('getMetadata', () => {
+      it('registers its id in metadata', () => {
+        const metadata = connect.getMetadata(
+          { attribute: 'ok', contextValue },
+          {}
+        );
+        expect(metadata).toEqual({ id: 'ok', index: 'index', items: [] });
       });
 
-      expect(searchState).toEqual({
-        page: 1,
-        refinementList: { one: ['one2'], two: ['two'] },
+      it('registers its filter in metadata', () => {
+        const metadata = connect.getMetadata(
+          { attribute: 'wot', contextValue },
+          { refinementList: { wot: ['wat', 'wut'] } }
+        );
+        expect(metadata).toEqual({
+          id: 'wot',
+          index: 'index',
+          items: [
+            {
+              label: 'wot: ',
+              attribute: 'wot',
+              currentRefinement: ['wat', 'wut'],
+              value: metadata.items[0].value,
+              items: [
+                {
+                  label: 'wat',
+                  value: metadata.items[0].items[0].value,
+                },
+                {
+                  label: 'wut',
+                  value: metadata.items[0].items[1].value,
+                },
+              ],
+              // Ignore value, we test it later
+            },
+          ],
+        });
       });
 
-      searchState = metadata.items[0].items[1].value(searchState);
+      it('registers escaped filterd in metadata', () => {
+        const metadata = connect.getMetadata(
+          { attribute: 'wot', contextValue },
+          { refinementList: { wot: ['\\-wat', 'wut'] } }
+        );
+        expect(metadata).toEqual({
+          id: 'wot',
+          index: 'index',
+          items: [
+            {
+              label: 'wot: ',
+              attribute: 'wot',
+              currentRefinement: ['\\-wat', 'wut'],
+              value: metadata.items[0].value,
+              items: [
+                {
+                  label: '-wat',
+                  value: metadata.items[0].items[0].value,
+                },
+                {
+                  label: 'wut',
+                  value: metadata.items[0].items[1].value,
+                },
+              ],
+            },
+          ],
+        });
+      });
 
-      expect(searchState).toEqual({
-        page: 1,
-        refinementList: { one: '', two: ['two'] },
+      it('items value function should clear it from the search state', () => {
+        const metadata = connect.getMetadata(
+          { attribute: 'one', contextValue },
+          { refinementList: { one: ['one1', 'one2'], two: ['two'] } }
+        );
+
+        let searchState = metadata.items[0].items[0].value({
+          refinementList: { one: ['one1', 'one2'], two: ['two'] },
+        });
+
+        expect(searchState).toEqual({
+          page: 1,
+          refinementList: { one: ['one2'], two: ['two'] },
+        });
+
+        searchState = metadata.items[0].items[1].value(searchState);
+
+        expect(searchState).toEqual({
+          page: 1,
+          refinementList: { one: '', two: ['two'] },
+        });
       });
     });
 

--- a/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectHierarchicalMenu.js
@@ -8,6 +8,7 @@ import {
   getCurrentRefinementValue,
   getResults,
 } from '../core/indexUtils';
+import { unescapeFacetValue } from '../core/utils';
 
 export const getId = (props) => props.attributes[0];
 
@@ -286,7 +287,7 @@ export default createConnector({
       ? []
       : [
           {
-            label: `${rootAttribute}: ${currentRefinement}`,
+            label: `${rootAttribute}: ${unescapeFacetValue(currentRefinement)}`,
             attribute: rootAttribute,
             value: (nextState) =>
               refine(props, nextState, '', {

--- a/packages/react-instantsearch-core/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectMenu.js
@@ -7,6 +7,7 @@ import {
   getCurrentRefinementValue,
   getResults,
 } from '../core/indexUtils';
+import { unescapeFacetValue } from '../core/utils';
 
 const namespace = 'menu';
 
@@ -245,7 +246,9 @@ export default createConnector({
           ? []
           : [
               {
-                label: `${props.attribute}: ${currentRefinement}`,
+                label: `${props.attribute}: ${unescapeFacetValue(
+                  currentRefinement
+                )}`,
                 attribute: props.attribute,
                 value: (nextState) =>
                   refine(props, nextState, '', {

--- a/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch-core/src/connectors/connectRefinementList.js
@@ -7,6 +7,7 @@ import {
   getCurrentRefinementValue,
   getResults,
 } from '../core/indexUtils';
+import { unescapeFacetValue } from '../core/utils';
 
 const namespace = 'refinementList';
 
@@ -266,7 +267,7 @@ export default createConnector({
                 value: (nextState) => refine(props, nextState, [], context),
                 items: getCurrentRefinement(props, searchState, context).map(
                   (item) => ({
-                    label: `${item}`,
+                    label: unescapeFacetValue(`${item}`),
                     value: (nextState) => {
                       const nextSelectedItems = getCurrentRefinement(
                         props,

--- a/packages/react-instantsearch-core/src/core/utils.ts
+++ b/packages/react-instantsearch-core/src/core/utils.ts
@@ -144,3 +144,7 @@ export const getPropertyByPath = (object: object, path: string[] | string) =>
 export function getObjectType(object: unknown): string {
   return Object.prototype.toString.call(object).slice(8, -1);
 }
+
+export function unescapeFacetValue(value: string): string {
+  return value.replace(/^\\-/, '-');
+}


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This is a follow-up to #3412, making sure that the escaped value doesn't show up for CurrentRefinements


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

CurrentRefinements does not show `\-value`, but `-value`