### PR TITLE
fix(hooks-dom): make components class names consistent with InstantSearch.js

### DIFF
--- a/packages/react-instantsearch-hooks-dom/src/ui/Breadcrumb.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Breadcrumb.tsx
@@ -20,7 +20,7 @@ export type BreadcrumbClassNames = {
   /**
    * Class names to apply to the root element when there are no refinements possible
    */
-  rootNoRefinement: string;
+  noRefinementRoot: string;
   /**
    * Class names to apply to the list element
    */
@@ -32,7 +32,7 @@ export type BreadcrumbClassNames = {
   /**
    * Class names to apply to the selected item
    */
-  itemSelected: string;
+  selectedItem: string;
   /**
    * Class names to apply to the separator between items
    */
@@ -82,7 +82,7 @@ export function Breadcrumb({
         'ais-Breadcrumb',
         classNames.root,
         !hasItems &&
-          cx('ais-Breadcrumb--noRefinement', classNames.rootNoRefinement),
+          cx('ais-Breadcrumb--noRefinement', classNames.noRefinementRoot),
         props.className
       )}
     >
@@ -92,7 +92,7 @@ export function Breadcrumb({
             'ais-Breadcrumb-item',
             classNames.item,
             !hasItems &&
-              cx('ais-Breadcrumb-item--selected', classNames.itemSelected)
+              cx('ais-Breadcrumb-item--selected', classNames.selectedItem)
           )}
         >
           <a
@@ -114,7 +114,7 @@ export function Breadcrumb({
                 'ais-Breadcrumb-item',
                 classNames.item,
                 isLast &&
-                  cx('ais-Breadcrumb-item--selected', classNames.itemSelected)
+                  cx('ais-Breadcrumb-item--selected', classNames.selectedItem)
               )}
             >
               <span

--- a/packages/react-instantsearch-hooks-dom/src/ui/ClearRefinements.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/ClearRefinements.tsx
@@ -30,7 +30,7 @@ export type ClearRefinementsClassNames = {
   /**
    * Class names to apply to the button when it's disabled
    */
-  buttonDisabled: string;
+  disabledButton: string;
 };
 
 export function ClearRefinements({
@@ -54,7 +54,7 @@ export function ClearRefinements({
           disabled &&
             cx(
               'ais-ClearRefinements-button--disabled',
-              classNames.buttonDisabled
+              classNames.disabledButton
             )
         )}
       >

--- a/packages/react-instantsearch-hooks-dom/src/ui/CurrentRefinements.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/CurrentRefinements.tsx
@@ -15,6 +15,7 @@ export type CurrentRefinementsProps = React.HTMLAttributes<HTMLDivElement> & {
       Record<string, unknown>
   >;
   onRemove?(refinement: CurrentRefinementsConnectorParamsRefinement): void;
+  hasRefinements?: boolean;
 };
 
 export type CurrentRefinementsClassNames = {
@@ -23,9 +24,17 @@ export type CurrentRefinementsClassNames = {
    */
   root: string;
   /**
+   * Class names to apply to the root element when there are no refinements possible
+   */
+  noRefinementRoot: string;
+  /**
    * Class names to apply to the list element
    */
   list: string;
+  /**
+   * Class names to apply to the list element when there are no refinements possible
+   */
+  listNoRefinement: string;
   /**
    * Class names to apply to each refinement
    */
@@ -52,14 +61,34 @@ export function CurrentRefinements({
   classNames = {},
   items = [],
   onRemove = () => {},
+  hasRefinements = false,
   ...props
 }: CurrentRefinementsProps) {
   return (
     <div
       {...props}
-      className={cx('ais-CurrentRefinements', classNames.root, props.className)}
+      className={cx(
+        'ais-CurrentRefinements',
+        classNames.root,
+        !hasRefinements &&
+          cx(
+            'ais-CurrentRefinements--noRefinement',
+            classNames.noRefinementRoot
+          ),
+        props.className
+      )}
     >
-      <ul className={cx('ais-CurrentRefinements-list', classNames.list)}>
+      <ul
+        className={cx(
+          'ais-CurrentRefinements-list',
+          classNames.list,
+          !hasRefinements &&
+            cx(
+              'ais-CurrentRefinements-list--noRefinement',
+              classNames.listNoRefinement
+            )
+        )}
+      >
         {items.map((item) => (
           <li
             key={item.label}

--- a/packages/react-instantsearch-hooks-dom/src/ui/CurrentRefinements.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/CurrentRefinements.tsx
@@ -34,7 +34,7 @@ export type CurrentRefinementsClassNames = {
   /**
    * Class names to apply to the list element when there are no refinements possible
    */
-  listNoRefinement: string;
+  noRefinementList: string;
   /**
    * Class names to apply to each refinement
    */
@@ -85,7 +85,7 @@ export function CurrentRefinements({
           !hasRefinements &&
             cx(
               'ais-CurrentRefinements-list--noRefinement',
-              classNames.listNoRefinement
+              classNames.noRefinementList
             )
         )}
       >

--- a/packages/react-instantsearch-hooks-dom/src/ui/CurrentRefinements.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/CurrentRefinements.tsx
@@ -15,7 +15,6 @@ export type CurrentRefinementsProps = React.HTMLAttributes<HTMLDivElement> & {
       Record<string, unknown>
   >;
   onRemove?(refinement: CurrentRefinementsConnectorParamsRefinement): void;
-  hasRefinements?: boolean;
 };
 
 export type CurrentRefinementsClassNames = {
@@ -24,17 +23,9 @@ export type CurrentRefinementsClassNames = {
    */
   root: string;
   /**
-   * Class names to apply to the root element when there are no refinements possible
-   */
-  noRefinementRoot: string;
-  /**
    * Class names to apply to the list element
    */
   list: string;
-  /**
-   * Class names to apply to the list element when there are no refinements possible
-   */
-  listNoRefinement: string;
   /**
    * Class names to apply to each refinement
    */
@@ -61,34 +52,14 @@ export function CurrentRefinements({
   classNames = {},
   items = [],
   onRemove = () => {},
-  hasRefinements = false,
   ...props
 }: CurrentRefinementsProps) {
   return (
     <div
       {...props}
-      className={cx(
-        'ais-CurrentRefinements',
-        classNames.root,
-        !hasRefinements &&
-          cx(
-            'ais-CurrentRefinements--noRefinement',
-            classNames.noRefinementRoot
-          ),
-        props.className
-      )}
+      className={cx('ais-CurrentRefinements', classNames.root, props.className)}
     >
-      <ul
-        className={cx(
-          'ais-CurrentRefinements-list',
-          classNames.list,
-          !hasRefinements &&
-            cx(
-              'ais-CurrentRefinements-list--noRefinement',
-              classNames.listNoRefinement
-            )
-        )}
-      >
+      <ul className={cx('ais-CurrentRefinements-list', classNames.list)}>
         {items.map((item) => (
           <li
             key={item.label}

--- a/packages/react-instantsearch-hooks-dom/src/ui/CurrentRefinements.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/CurrentRefinements.tsx
@@ -26,7 +26,7 @@ export type CurrentRefinementsClassNames = {
   /**
    * Class names to apply to the root element when there are no refinements possible
    */
-  rootNoRefinement: string;
+  noRefinementRoot: string;
   /**
    * Class names to apply to the list element
    */
@@ -73,7 +73,7 @@ export function CurrentRefinements({
         !hasRefinements &&
           cx(
             'ais-CurrentRefinements--noRefinement',
-            classNames.rootNoRefinement
+            classNames.noRefinementRoot
           ),
         props.className
       )}

--- a/packages/react-instantsearch-hooks-dom/src/ui/HierarchicalMenu.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/HierarchicalMenu.tsx
@@ -20,7 +20,7 @@ type HierarchicalMenuClassNames = {
    */
   list: string;
   /**
-   * Class names to apply to the child list element
+   * Class names to apply to each child list element
    */
   childList: string;
   /**

--- a/packages/react-instantsearch-hooks-dom/src/ui/HierarchicalMenu.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/HierarchicalMenu.tsx
@@ -14,7 +14,7 @@ type HierarchicalMenuClassNames = {
   /**
    * Class names to apply to the root element when there are no refinements possible
    */
-  rootNoRefinement: string;
+  noRefinementRoot: string;
   /**
    * Class names to apply to the list element
    */
@@ -26,7 +26,7 @@ type HierarchicalMenuClassNames = {
   /**
    * Class names to apply to the selected item
    */
-  itemSelected: string;
+  selectedItem: string;
   /**
    * Class names to apply to each link element
    */
@@ -46,7 +46,7 @@ type HierarchicalMenuClassNames = {
   /**
    * Class names to apply to the "Show more" button if it's disabled
    */
-  showMoreDisabled: string;
+  disabledShowMore: string;
 };
 
 type HierarchicalListProps = Pick<
@@ -81,7 +81,7 @@ function HierarchicalList({
             'ais-HierarchicalMenu-item',
             classNames.item,
             item.isRefined &&
-              cx('ais-HierarchicalMenu-item--selected', classNames.itemSelected)
+              cx('ais-HierarchicalMenu-item--selected', classNames.selectedItem)
           )}
         >
           <a
@@ -139,7 +139,7 @@ export function HierarchicalMenu({
         'ais-HierarchicalMenu',
         classNames.root,
         !hasItems &&
-          cx('ais-HierarchicalMenu--noRefinement', classNames.rootNoRefinement),
+          cx('ais-HierarchicalMenu--noRefinement', classNames.noRefinementRoot),
         props.className
       )}
     >
@@ -157,7 +157,7 @@ export function HierarchicalMenu({
             !canToggleShowMore &&
               cx(
                 'ais-HierarchicalMenu-showMore--disabled',
-                classNames.showMoreDisabled
+                classNames.disabledShowMore
               )
           )}
           disabled={!canToggleShowMore}

--- a/packages/react-instantsearch-hooks-dom/src/ui/HierarchicalMenu.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/HierarchicalMenu.tsx
@@ -20,6 +20,10 @@ type HierarchicalMenuClassNames = {
    */
   list: string;
   /**
+   * Class names to apply to the child list element
+   */
+  childList: string;
+  /**
    * Class names to apply to each item element
    */
   item: string;
@@ -27,6 +31,10 @@ type HierarchicalMenuClassNames = {
    * Class names to apply to the selected item
    */
   selectedItem: string;
+  /**
+   * Class names to apply to the parent item of the list
+   */
+  parentItem: string;
   /**
    * Class names to apply to each link element
    */
@@ -53,6 +61,7 @@ type HierarchicalListProps = Pick<
   ReturnType<typeof useHierarchicalMenu>,
   'items' | 'createURL'
 > & {
+  className?: string;
   classNames?: Partial<HierarchicalMenuClassNames>;
   onNavigate: (value: string) => void;
 };
@@ -67,19 +76,22 @@ export type HierarchicalMenuProps = React.HTMLAttributes<HTMLDivElement> &
   };
 
 function HierarchicalList({
+  className,
   classNames = {},
   items,
   createURL,
   onNavigate,
 }: HierarchicalListProps) {
   return (
-    <ul className={cx('ais-HierarchicalMenu-list', classNames.list)}>
+    <ul className={cx('ais-HierarchicalMenu-list', classNames.list, className)}>
       {items.map((item) => (
         <li
           key={item.value}
           className={cx(
             'ais-HierarchicalMenu-item',
             classNames.item,
+            Boolean(item.data) &&
+              cx('ais-HierarchicalMenu-item--parent', classNames.parentItem),
             item.isRefined &&
               cx('ais-HierarchicalMenu-item--selected', classNames.selectedItem)
           )}
@@ -108,6 +120,10 @@ function HierarchicalList({
           </a>
           {Boolean(item.data) && (
             <HierarchicalList
+              className={cx(
+                'ais-HierarchicalMenu-list--child',
+                classNames.childList
+              )}
               classNames={classNames}
               items={item.data!}
               onNavigate={onNavigate}

--- a/packages/react-instantsearch-hooks-dom/src/ui/HierarchicalMenu.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/HierarchicalMenu.tsx
@@ -90,7 +90,7 @@ function HierarchicalList({
           className={cx(
             'ais-HierarchicalMenu-item',
             classNames.item,
-            Boolean(item.data) &&
+            item.data &&
               cx('ais-HierarchicalMenu-item--parent', classNames.parentItem),
             item.isRefined &&
               cx('ais-HierarchicalMenu-item--selected', classNames.selectedItem)
@@ -118,7 +118,7 @@ function HierarchicalList({
               {item.count}
             </span>
           </a>
-          {Boolean(item.data) && (
+          {item.data && (
             <HierarchicalList
               className={cx(
                 'ais-HierarchicalMenu-list--child',

--- a/packages/react-instantsearch-hooks-dom/src/ui/Hits.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Hits.tsx
@@ -28,7 +28,7 @@ export type HitsClassNames = {
    */
   list: string;
   /**
-   * Class names to apply to the individual hit element
+   * Class names to apply to each item element
    */
   item: string;
 };

--- a/packages/react-instantsearch-hooks-dom/src/ui/Hits.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Hits.tsx
@@ -24,6 +24,10 @@ export type HitsClassNames = {
    */
   root: string;
   /**
+   * Class names to apply to the root element without results
+   */
+  emptyRoot: string;
+  /**
    * Class names to apply to the list element
    */
   list: string;
@@ -42,7 +46,12 @@ export function Hits<THit extends Hit>({
   return (
     <div
       {...props}
-      className={cx('ais-Hits', classNames.root, props.className)}
+      className={cx(
+        'ais-Hits',
+        classNames.root,
+        hits.length === 0 && cx('ais-Hits--empty', classNames.emptyRoot),
+        props.className
+      )}
     >
       <ol className={cx('ais-Hits-list', classNames.list)}>
         {hits.map((hit) => (

--- a/packages/react-instantsearch-hooks-dom/src/ui/InfiniteHits.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/InfiniteHits.tsx
@@ -21,6 +21,10 @@ export type InfiniteHitsClassNames = {
    */
   root: string;
   /**
+   * Class names to apply to the root element without results
+   */
+  emptyRoot: string;
+  /**
    * Class names to apply to the "load previous" button
    */
   loadPrevious: string;
@@ -73,7 +77,13 @@ export function InfiniteHits<THit extends Hit>({
   return (
     <div
       {...props}
-      className={cx('ais-InfiniteHits', classNames.root, props.className)}
+      className={cx(
+        'ais-InfiniteHits',
+        classNames.root,
+        hits.length === 0 &&
+          cx('ais-InfiniteHits--empty', classNames.emptyRoot),
+        props.className
+      )}
     >
       {onShowPrevious && (
         <button
@@ -82,8 +92,8 @@ export function InfiniteHits<THit extends Hit>({
             classNames.loadPrevious,
             isFirstPage &&
               cx(
-                classNames.disabledLoadPrevious,
-                'ais-InfiniteHits-loadPrevious--disabled'
+                'ais-InfiniteHits-loadPrevious--disabled',
+                classNames.disabledLoadPrevious
               )
           )}
           onClick={onShowPrevious}

--- a/packages/react-instantsearch-hooks-dom/src/ui/InfiniteHits.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/InfiniteHits.tsx
@@ -27,7 +27,7 @@ export type InfiniteHitsClassNames = {
   /**
    * Class names to apply to the "load previous" button when it's disabled
    */
-  loadPreviousDisabled: string;
+  disabledLoadPrevious: string;
   /**
    * Class names to apply to the "load more" button
    */
@@ -35,7 +35,7 @@ export type InfiniteHitsClassNames = {
   /**
    * Class names to apply to the "load more" button when it's disabled
    */
-  loadMoreDisabled: string;
+  disabledLoadMore: string;
   /**
    * Class names to apply to the list element
    */
@@ -82,7 +82,7 @@ export function InfiniteHits<THit extends Hit>({
             classNames.loadPrevious,
             isFirstPage &&
               cx(
-                classNames.loadPreviousDisabled,
+                classNames.disabledLoadPrevious,
                 'ais-InfiniteHits-loadPrevious--disabled'
               )
           )}
@@ -109,7 +109,7 @@ export function InfiniteHits<THit extends Hit>({
           isLastPage &&
             cx(
               'ais-InfiniteHits-loadMore--disabled',
-              classNames.loadMoreDisabled
+              classNames.disabledLoadMore
             )
         )}
         onClick={onShowMore}

--- a/packages/react-instantsearch-hooks-dom/src/ui/Menu.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Menu.tsx
@@ -23,6 +23,10 @@ export type MenuCSSClasses = {
    */
   root: string;
   /**
+   * Class names to apply to the root element when there are no refinements possible
+   */
+  noRefinementRoot: string;
+  /**
    * Class names to apply to the list element
    */
   list: string;
@@ -70,7 +74,13 @@ export function Menu({
   return (
     <div
       {...props}
-      className={cx('ais-Menu', classNames.root, props.className)}
+      className={cx(
+        'ais-Menu',
+        classNames.root,
+        items.length === 0 &&
+          cx('ais-Menu--noRefinement', classNames.noRefinementRoot),
+        props.className
+      )}
     >
       <ul className={cx('ais-Menu-list', classNames.list)}>
         {items.map((item) => (

--- a/packages/react-instantsearch-hooks-dom/src/ui/Menu.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Menu.tsx
@@ -33,7 +33,7 @@ export type MenuCSSClasses = {
   /**
    * Class names to apply to each selected item element
    */
-  itemSelected: string;
+  selectedItem: string;
   /**
    * Class names to apply to each link element
    */
@@ -53,7 +53,7 @@ export type MenuCSSClasses = {
   /**
    * Class names to apply to the "Show more" button if it's disabled
    */
-  showMoreDisabled: string;
+  disabledShowMore: string;
 };
 
 export function Menu({
@@ -80,7 +80,7 @@ export function Menu({
               'ais-Menu-item',
               classNames.item,
               item.isRefined &&
-                cx('ais-Menu-item--selected', classNames.itemSelected)
+                cx('ais-Menu-item--selected', classNames.selectedItem)
             )}
           >
             <a
@@ -107,7 +107,7 @@ export function Menu({
             'ais-Menu-showMore',
             classNames.showMore,
             !canToggleShowMore &&
-              cx('ais-Menu-showMore--disabled', classNames.showMoreDisabled)
+              cx('ais-Menu-showMore--disabled', classNames.disabledShowMore)
           )}
           disabled={!canToggleShowMore}
           onClick={onToggleShowMore}

--- a/packages/react-instantsearch-hooks-dom/src/ui/Pagination.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/Pagination.tsx
@@ -69,9 +69,9 @@ export type PaginationClassNames = {
    */
   root: string;
   /**
-   * Class names to apply to the root element, when there's no refinement possible
+   * Class names to apply to the root element when there are no refinements possible
    */
-  rootNoRefinement: string;
+  noRefinementRoot: string;
   /**
    * Class names to apply to the list element
    */
@@ -83,33 +83,33 @@ export type PaginationClassNames = {
   /**
    * Class names to apply to the first page element
    */
-  itemFirstPage: string;
+  firstPageItem: string;
   /**
    * Class names to apply to the previous page element
    */
-  itemPreviousPage: string;
+  previousPageItem: string;
   /**
    * Class names to apply to each page element
    */
-  itemPage: string;
+  pageItem: string;
   /**
    * Class names to apply to a selected page element
    */
-  itemSelected: string;
+  selectedItem: string;
   /**
    * Class names to apply to a disabled page element
    */
-  itemDisabled: string;
+  disabledItem: string;
   /**
    * Class names to apply to the next page element
    */
-  itemNextPage: string;
+  nextPageItem: string;
   /**
    * Class names to apply to the last page element
    */
-  itemLastPage: string;
+  lastPageItem: string;
   /**
-   * Class names to apply to the link element
+   * Class names to apply to each link element
    */
   link: string;
 };
@@ -142,7 +142,7 @@ export function Pagination({
         'ais-Pagination',
         classNames.root,
         nbPages <= 1 &&
-          cx('ais-Pagination--noRefinement', classNames.rootNoRefinement),
+          cx('ais-Pagination--noRefinement', classNames.noRefinementRoot),
         props.className
       )}
     >
@@ -152,7 +152,7 @@ export function Pagination({
             isDisabled={isFirstPage}
             className={cx(
               'ais-Pagination-item--firstPage',
-              classNames.itemFirstPage
+              classNames.firstPageItem
             )}
             classNames={classNames}
             aria-label={translations.ariaFirst}
@@ -167,7 +167,7 @@ export function Pagination({
             isDisabled={isFirstPage}
             className={cx(
               'ais-Pagination-item--previousPage',
-              classNames.itemPreviousPage
+              classNames.previousPageItem
             )}
             classNames={classNames}
             aria-label={translations.ariaPrevious}
@@ -184,9 +184,9 @@ export function Pagination({
               isDisabled={false}
               className={cx(
                 'ais-Pagination-item--page',
-                classNames.itemPage,
+                classNames.pageItem,
                 page === currentPage &&
-                  cx('ais-Pagination-item--selected', classNames.itemSelected)
+                  cx('ais-Pagination-item--selected', classNames.selectedItem)
               )}
               classNames={classNames}
               aria-label={translations.ariaPage(page + 1)}
@@ -202,7 +202,7 @@ export function Pagination({
             isDisabled={isLastPage}
             className={cx(
               'ais-Pagination-item--nextPage',
-              classNames.itemNextPage
+              classNames.nextPageItem
             )}
             classNames={classNames}
             aria-label={translations.ariaNext}
@@ -217,7 +217,7 @@ export function Pagination({
             isDisabled={isLastPage}
             className={cx(
               'ais-Pagination-item--lastPage',
-              classNames.itemLastPage
+              classNames.lastPageItem
             )}
             classNames={classNames}
             aria-label={translations.ariaLast}
@@ -258,7 +258,7 @@ function PaginationItem({
           'ais-Pagination-item',
           classNames.item,
           'ais-Pagination-item--disabled',
-          classNames.itemDisabled,
+          classNames.disabledItem,
           className
         )}
       >

--- a/packages/react-instantsearch-hooks-dom/src/ui/RangeInput.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/RangeInput.tsx
@@ -26,13 +26,13 @@ export type RangeInputClassNames = {
   /**
    * Class names to apply to the root element when there are no refinements possible
    */
-  rootNoRefinement: string;
+  noRefinementRoot: string;
   /**
    * Class names to apply to the form element
    */
   form: string;
   /**
-   * Class name to apply to each label element
+   * Class names to apply to each label element
    */
   label: string;
   /**
@@ -107,7 +107,7 @@ export function RangeInput({
       className={cx(
         cx('ais-RangeInput', classNames.root),
         disabled &&
-          cx('ais-RangeInput-noRefinement', classNames.rootNoRefinement),
+          cx('ais-RangeInput--noRefinement', classNames.noRefinementRoot),
         props.className
       )}
     >

--- a/packages/react-instantsearch-hooks-dom/src/ui/RefinementList.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/RefinementList.tsx
@@ -44,7 +44,7 @@ export type RefinementListClassNames = {
   /**
    * Class names to apply to each selected item element
    */
-  itemSelected: string;
+  selectedItem: string;
   /**
    * Class names to apply to each label element
    */
@@ -68,7 +68,7 @@ export type RefinementListClassNames = {
   /**
    * Class names to apply to the "Show more" button if it's disabled
    */
-  showMoreDisabled: string;
+  disabledShowMore: string;
 };
 
 export function RefinementList({
@@ -114,7 +114,7 @@ export function RefinementList({
                 item.isRefined &&
                   cx(
                     'ais-RefinementList-item--selected',
-                    classNames.itemSelected
+                    classNames.selectedItem
                   )
               )}
             >
@@ -167,7 +167,7 @@ export function RefinementList({
             !canToggleShowMore &&
               cx(
                 'ais-RefinementList-showMore--disabled',
-                classNames.showMoreDisabled
+                classNames.disabledShowMore
               )
           )}
           disabled={!canToggleShowMore}

--- a/packages/react-instantsearch-hooks-dom/src/ui/RefinementList.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/RefinementList.tsx
@@ -8,6 +8,7 @@ import { ShowMoreButton } from './ShowMoreButton';
 import type { RefinementListItem } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 
 export type RefinementListProps = React.HTMLAttributes<HTMLDivElement> & {
+  canRefine: boolean;
   items: RefinementListItem[];
   onRefine(item: RefinementListItem): void;
   query: string;
@@ -76,6 +77,7 @@ export type RefinementListClassNames = {
 };
 
 export function RefinementList({
+  canRefine,
   items,
   onRefine,
   query,
@@ -95,7 +97,7 @@ export function RefinementList({
       className={cx(
         'ais-RefinementList',
         classNames.root,
-        items.length === 0 &&
+        !canRefine &&
           cx('ais-RefinementList--noRefinement', classNames.noRefinementRoot),
         className
       )}

--- a/packages/react-instantsearch-hooks-dom/src/ui/RefinementList.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/RefinementList.tsx
@@ -26,6 +26,10 @@ export type RefinementListClassNames = {
    */
   root: string;
   /**
+   * Class names to apply to the root element when there are no refinements possible
+   */
+  noRefinementRoot: string;
+  /**
    * Class names to apply to the search box wrapper element
    */
   searchBox: string;
@@ -88,7 +92,13 @@ export function RefinementList({
   return (
     <div
       {...props}
-      className={cx('ais-RefinementList', classNames.root, className)}
+      className={cx(
+        'ais-RefinementList',
+        classNames.root,
+        items.length === 0 &&
+          cx('ais-RefinementList--noRefinement', classNames.noRefinementRoot),
+        className
+      )}
     >
       {searchBox && (
         <div

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Breadcrumb.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Breadcrumb.test.tsx
@@ -197,10 +197,10 @@ describe('Breadcrumb', () => {
       className: 'MyCustomBreadcrumb',
       classNames: {
         root: 'ROOT',
-        rootNoRefinement: 'ROOTNOREFINEMENT',
+        noRefinementRoot: 'ROOTNOREFINEMENT',
         list: 'LIST',
         item: 'ITEM',
-        itemSelected: 'ITEMSELECTED',
+        selectedItem: 'ITEMSELECTED',
         separator: 'SEPARATOR',
         link: 'LINK',
       },

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Breadcrumb.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Breadcrumb.test.tsx
@@ -197,10 +197,10 @@ describe('Breadcrumb', () => {
       className: 'MyCustomBreadcrumb',
       classNames: {
         root: 'ROOT',
-        noRefinementRoot: 'ROOTNOREFINEMENT',
+        noRefinementRoot: 'NOREFINEMENTROOT',
         list: 'LIST',
         item: 'ITEM',
-        selectedItem: 'ITEMSELECTED',
+        selectedItem: 'SELECTEDITEM',
         separator: 'SEPARATOR',
         link: 'LINK',
       },
@@ -242,7 +242,7 @@ describe('Breadcrumb', () => {
               </a>
             </li>
             <li
-              class="ais-Breadcrumb-item ITEM ais-Breadcrumb-item--selected ITEMSELECTED"
+              class="ais-Breadcrumb-item ITEM ais-Breadcrumb-item--selected SELECTEDITEM"
             >
               <span
                 aria-hidden="true"

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/ClearRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/ClearRefinements.test.tsx
@@ -147,7 +147,7 @@ describe('ClearRefinements', () => {
         classNames={{
           root: 'ROOT',
           button: 'BUTTON',
-          disabledButton: 'DISABLED',
+          disabledButton: 'DISABLEDBUTTON',
         }}
       />
     );
@@ -158,7 +158,7 @@ describe('ClearRefinements', () => {
           class="ais-ClearRefinements ROOT"
         >
           <button
-            class="ais-ClearRefinements-button BUTTON ais-ClearRefinements-button--disabled DISABLED"
+            class="ais-ClearRefinements-button BUTTON ais-ClearRefinements-button--disabled DISABLEDBUTTON"
             disabled=""
           >
             Clear refinements

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/ClearRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/ClearRefinements.test.tsx
@@ -147,7 +147,7 @@ describe('ClearRefinements', () => {
         classNames={{
           root: 'ROOT',
           button: 'BUTTON',
-          buttonDisabled: 'DISABLED',
+          disabledButton: 'DISABLED',
         }}
       />
     );

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/CurrentRefinements.test.tsx
@@ -11,10 +11,10 @@ describe('CurrentRefinements', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement"
+          class="ais-CurrentRefinements"
         >
           <ul
-            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
+            class="ais-CurrentRefinements-list"
           />
         </div>
       </div>
@@ -45,7 +45,6 @@ describe('CurrentRefinements', () => {
             ],
           },
         ]}
-        hasRefinements={true}
         onRemove={onRemove}
       />
     );
@@ -138,10 +137,10 @@ describe('CurrentRefinements', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement MyCurrentRefinements"
+          class="ais-CurrentRefinements MyCurrentRefinements"
         >
           <ul
-            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
+            class="ais-CurrentRefinements-list"
           />
         </div>
       </div>
@@ -160,11 +159,11 @@ describe('CurrentRefinements', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement"
+          class="ais-CurrentRefinements"
           title="Some custom title"
         >
           <ul
-            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
+            class="ais-CurrentRefinements-list"
           />
         </div>
       </div>
@@ -177,9 +176,7 @@ describe('CurrentRefinements', () => {
         <CurrentRefinements
           classNames={{
             root: 'ROOT',
-            noRefinementRoot: 'ROOTNOREFINEMENT',
             list: 'LIST',
-            listNoRefinement: 'LISTNOREFINEMENT',
             item: 'ITEM',
             label: 'LABEL',
             category: 'CATEGORY',
@@ -192,10 +189,10 @@ describe('CurrentRefinements', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement ROOTNOREFINEMENT"
+            class="ais-CurrentRefinements ROOT"
           >
             <ul
-              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement LISTNOREFINEMENT"
+              class="ais-CurrentRefinements-list LIST"
             />
           </div>
         </div>
@@ -220,9 +217,7 @@ describe('CurrentRefinements', () => {
           ]}
           classNames={{
             root: 'ROOT',
-            noRefinementRoot: 'ROOTNOREFINEMENT',
             list: 'LIST',
-            listNoRefinement: 'LISTNOREFINEMENT',
             item: 'ITEM',
             label: 'LABEL',
             category: 'CATEGORY',
@@ -235,10 +230,10 @@ describe('CurrentRefinements', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement ROOTNOREFINEMENT"
+            class="ais-CurrentRefinements ROOT"
           >
             <ul
-              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement LISTNOREFINEMENT"
+              class="ais-CurrentRefinements-list LIST"
             >
               <li
                 class="ais-CurrentRefinements-item ITEM"

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/CurrentRefinements.test.tsx
@@ -11,10 +11,10 @@ describe('CurrentRefinements', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-CurrentRefinements"
+          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement"
         >
           <ul
-            class="ais-CurrentRefinements-list"
+            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
           />
         </div>
       </div>
@@ -45,6 +45,7 @@ describe('CurrentRefinements', () => {
             ],
           },
         ]}
+        hasRefinements={true}
         onRemove={onRemove}
       />
     );
@@ -137,10 +138,10 @@ describe('CurrentRefinements', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-CurrentRefinements MyCurrentRefinements"
+          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement MyCurrentRefinements"
         >
           <ul
-            class="ais-CurrentRefinements-list"
+            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
           />
         </div>
       </div>
@@ -159,11 +160,11 @@ describe('CurrentRefinements', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-CurrentRefinements"
+          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement"
           title="Some custom title"
         >
           <ul
-            class="ais-CurrentRefinements-list"
+            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
           />
         </div>
       </div>
@@ -176,7 +177,9 @@ describe('CurrentRefinements', () => {
         <CurrentRefinements
           classNames={{
             root: 'ROOT',
+            noRefinementRoot: 'ROOTNOREFINEMENT',
             list: 'LIST',
+            listNoRefinement: 'LISTNOREFINEMENT',
             item: 'ITEM',
             label: 'LABEL',
             category: 'CATEGORY',
@@ -189,10 +192,10 @@ describe('CurrentRefinements', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-CurrentRefinements ROOT"
+            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement ROOTNOREFINEMENT"
           >
             <ul
-              class="ais-CurrentRefinements-list LIST"
+              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement LISTNOREFINEMENT"
             />
           </div>
         </div>
@@ -217,7 +220,9 @@ describe('CurrentRefinements', () => {
           ]}
           classNames={{
             root: 'ROOT',
+            noRefinementRoot: 'ROOTNOREFINEMENT',
             list: 'LIST',
+            listNoRefinement: 'LISTNOREFINEMENT',
             item: 'ITEM',
             label: 'LABEL',
             category: 'CATEGORY',
@@ -230,10 +235,10 @@ describe('CurrentRefinements', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-CurrentRefinements ROOT"
+            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement ROOTNOREFINEMENT"
           >
             <ul
-              class="ais-CurrentRefinements-list LIST"
+              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement LISTNOREFINEMENT"
             >
               <li
                 class="ais-CurrentRefinements-item ITEM"

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/CurrentRefinements.test.tsx
@@ -177,7 +177,7 @@ describe('CurrentRefinements', () => {
         <CurrentRefinements
           classNames={{
             root: 'ROOT',
-            rootNoRefinement: 'ROOTNOREFINEMENT',
+            noRefinementRoot: 'ROOTNOREFINEMENT',
             list: 'LIST',
             listNoRefinement: 'LISTNOREFINEMENT',
             item: 'ITEM',
@@ -220,7 +220,7 @@ describe('CurrentRefinements', () => {
           ]}
           classNames={{
             root: 'ROOT',
-            rootNoRefinement: 'ROOTNOREFINEMENT',
+            noRefinementRoot: 'ROOTNOREFINEMENT',
             list: 'LIST',
             listNoRefinement: 'LISTNOREFINEMENT',
             item: 'ITEM',

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/CurrentRefinements.test.tsx
@@ -177,9 +177,9 @@ describe('CurrentRefinements', () => {
         <CurrentRefinements
           classNames={{
             root: 'ROOT',
-            noRefinementRoot: 'ROOTNOREFINEMENT',
+            noRefinementRoot: 'NOREFINEMENTROOT',
             list: 'LIST',
-            listNoRefinement: 'LISTNOREFINEMENT',
+            noRefinementList: 'NOREFINEMENTLIST',
             item: 'ITEM',
             label: 'LABEL',
             category: 'CATEGORY',
@@ -192,10 +192,10 @@ describe('CurrentRefinements', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement ROOTNOREFINEMENT"
+            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement NOREFINEMENTROOT"
           >
             <ul
-              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement LISTNOREFINEMENT"
+              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement NOREFINEMENTLIST"
             />
           </div>
         </div>
@@ -220,9 +220,9 @@ describe('CurrentRefinements', () => {
           ]}
           classNames={{
             root: 'ROOT',
-            noRefinementRoot: 'ROOTNOREFINEMENT',
+            noRefinementRoot: 'NOREFINEMENTROOT',
             list: 'LIST',
-            listNoRefinement: 'LISTNOREFINEMENT',
+            noRefinementList: 'NOREFINEMENTLIST',
             item: 'ITEM',
             label: 'LABEL',
             category: 'CATEGORY',
@@ -235,10 +235,10 @@ describe('CurrentRefinements', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement ROOTNOREFINEMENT"
+            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement NOREFINEMENTROOT"
           >
             <ul
-              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement LISTNOREFINEMENT"
+              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement NOREFINEMENTLIST"
             >
               <li
                 class="ais-CurrentRefinements-item ITEM"

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/HierarchicalMenu.test.tsx
@@ -296,15 +296,15 @@ describe('HierarchicalMenu', () => {
       canToggleShowMore: false,
       classNames: {
         root: 'ROOT',
-        rootNoRefinement: 'ROOTNOREFINEMENT',
+        noRefinementRoot: 'ROOTNOREFINEMENT',
         list: 'LIST',
         item: 'ITEM',
-        itemSelected: 'ITEMSELECTED',
+        selectedItem: 'ITEMSELECTED',
         link: 'LINK',
         label: 'LABEL',
         count: 'COUNT',
         showMore: 'SHOWMORE',
-        showMoreDisabled: 'SHOWMOREDISABLED',
+        disabledShowMore: 'SHOWMOREDISABLED',
       },
     });
     const { container } = render(<HierarchicalMenu {...props} />);

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/HierarchicalMenu.test.tsx
@@ -296,17 +296,17 @@ describe('HierarchicalMenu', () => {
       canToggleShowMore: false,
       classNames: {
         root: 'ROOT',
-        noRefinementRoot: 'ROOTNOREFINEMENT',
+        noRefinementRoot: 'NOREFINEMENTROOT',
         list: 'LIST',
         childList: 'CHILDLIST',
         item: 'ITEM',
-        selectedItem: 'ITEMSELECTED',
+        selectedItem: 'SELECTEDITEM',
         parentItem: 'PARENTITEM',
         link: 'LINK',
         label: 'LABEL',
         count: 'COUNT',
         showMore: 'SHOWMORE',
-        disabledShowMore: 'SHOWMOREDISABLED',
+        disabledShowMore: 'DISABLEDSHOWMORE',
       },
     });
     const { container } = render(<HierarchicalMenu {...props} />);
@@ -320,7 +320,7 @@ describe('HierarchicalMenu', () => {
             class="ais-HierarchicalMenu-list LIST"
           >
             <li
-              class="ais-HierarchicalMenu-item ITEM ais-HierarchicalMenu-item--parent PARENTITEM ais-HierarchicalMenu-item--selected ITEMSELECTED"
+              class="ais-HierarchicalMenu-item ITEM ais-HierarchicalMenu-item--parent PARENTITEM ais-HierarchicalMenu-item--selected SELECTEDITEM"
             >
               <a
                 class="ais-HierarchicalMenu-link LINK"
@@ -401,7 +401,7 @@ describe('HierarchicalMenu', () => {
             </li>
           </ul>
           <button
-            class="ais-HierarchicalMenu-showMore SHOWMORE ais-HierarchicalMenu-showMore--disabled SHOWMOREDISABLED"
+            class="ais-HierarchicalMenu-showMore SHOWMORE ais-HierarchicalMenu-showMore--disabled DISABLEDSHOWMORE"
             disabled=""
           >
             Show more

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/HierarchicalMenu.test.tsx
@@ -64,7 +64,7 @@ describe('HierarchicalMenu', () => {
             class="ais-HierarchicalMenu-list"
           >
             <li
-              class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
+              class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent ais-HierarchicalMenu-item--selected"
             >
               <a
                 class="ais-HierarchicalMenu-link"
@@ -82,7 +82,7 @@ describe('HierarchicalMenu', () => {
                 </span>
               </a>
               <ul
-                class="ais-HierarchicalMenu-list"
+                class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child"
               >
                 <li
                   class="ais-HierarchicalMenu-item"
@@ -175,7 +175,7 @@ describe('HierarchicalMenu', () => {
               class="ais-HierarchicalMenu-list"
             >
               <li
-                class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
+                class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent ais-HierarchicalMenu-item--selected"
               >
                 <a
                   class="ais-HierarchicalMenu-link"
@@ -193,7 +193,7 @@ describe('HierarchicalMenu', () => {
                   </span>
                 </a>
                 <ul
-                  class="ais-HierarchicalMenu-list"
+                  class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child"
                 >
                   <li
                     class="ais-HierarchicalMenu-item"
@@ -298,8 +298,10 @@ describe('HierarchicalMenu', () => {
         root: 'ROOT',
         noRefinementRoot: 'ROOTNOREFINEMENT',
         list: 'LIST',
+        childList: 'CHILDLIST',
         item: 'ITEM',
         selectedItem: 'ITEMSELECTED',
+        parentItem: 'PARENTITEM',
         link: 'LINK',
         label: 'LABEL',
         count: 'COUNT',
@@ -318,7 +320,7 @@ describe('HierarchicalMenu', () => {
             class="ais-HierarchicalMenu-list LIST"
           >
             <li
-              class="ais-HierarchicalMenu-item ITEM ais-HierarchicalMenu-item--selected ITEMSELECTED"
+              class="ais-HierarchicalMenu-item ITEM ais-HierarchicalMenu-item--parent PARENTITEM ais-HierarchicalMenu-item--selected ITEMSELECTED"
             >
               <a
                 class="ais-HierarchicalMenu-link LINK"
@@ -336,7 +338,7 @@ describe('HierarchicalMenu', () => {
                 </span>
               </a>
               <ul
-                class="ais-HierarchicalMenu-list LIST"
+                class="ais-HierarchicalMenu-list LIST ais-HierarchicalMenu-list--child CHILDLIST"
               >
                 <li
                   class="ais-HierarchicalMenu-item ITEM"

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Hits.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Hits.test.tsx
@@ -158,6 +158,32 @@ describe('Hits', () => {
     `);
   });
 
+  test('allows custom class names (empty)', () => {
+    const props = createProps({ hits: [] });
+    const { container } = render(
+      <Hits
+        {...props}
+        classNames={{
+          root: 'ROOT',
+          emptyRoot: 'EMPTYROOT',
+          list: 'LIST',
+        }}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Hits ROOT ais-Hits--empty EMPTYROOT"
+        >
+          <ol
+            class="ais-Hits-list LIST"
+          />
+        </div>
+      </div>
+    `);
+  });
+
   test('renders with custom div props', () => {
     const props = createProps({ hidden: true });
 

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/InfiniteHits.test.tsx
@@ -114,7 +114,7 @@ describe('InfiniteHits', () => {
           class="ais-InfiniteHits ROOT"
         >
           <button
-            class="ais-InfiniteHits-loadPrevious LOADPREVIOUS LOADPREVIOUSDISABLED ais-InfiniteHits-loadPrevious--disabled"
+            class="ais-InfiniteHits-loadPrevious LOADPREVIOUS ais-InfiniteHits-loadPrevious--disabled LOADPREVIOUSDISABLED"
             disabled=""
           >
             Show previous results
@@ -145,6 +145,45 @@ describe('InfiniteHits', () => {
           </ol>
           <button
             class="ais-InfiniteHits-loadMore LOADMORE"
+          >
+            Show more results
+          </button>
+        </div>
+      </div>
+    `);
+  });
+
+  test('accepts custom class names (empty)', () => {
+    const props = createProps({ hits: [] as Hit[], isLastPage: true });
+    const { container } = render(
+      <InfiniteHits
+        {...props}
+        classNames={{
+          root: 'ROOT',
+          emptyRoot: 'EMPTYROOT',
+          loadMore: 'LOADMORE',
+          disabledLoadMore: 'DISABLEDLOADMORE',
+        }}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-InfiniteHits ROOT ais-InfiniteHits--empty EMPTYROOT"
+        >
+          <button
+            class="ais-InfiniteHits-loadPrevious ais-InfiniteHits-loadPrevious--disabled"
+            disabled=""
+          >
+            Show previous results
+          </button>
+          <ol
+            class="ais-InfiniteHits-list"
+          />
+          <button
+            class="ais-InfiniteHits-loadMore LOADMORE ais-InfiniteHits-loadMore--disabled DISABLEDLOADMORE"
+            disabled=""
           >
             Show more results
           </button>

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/InfiniteHits.test.tsx
@@ -99,9 +99,9 @@ describe('InfiniteHits', () => {
         classNames={{
           root: 'ROOT',
           loadPrevious: 'LOADPREVIOUS',
-          loadPreviousDisabled: 'LOADPREVIOUSDISABLED',
+          disabledLoadPrevious: 'LOADPREVIOUSDISABLED',
           loadMore: 'LOADMORE',
-          loadMoreDisabled: 'LOADMOREDISABLED',
+          disabledLoadMore: 'LOADMOREDISABLED',
           list: 'LIST',
           item: 'ITEM',
         }}

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Menu.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Menu.test.tsx
@@ -193,12 +193,12 @@ describe('Menu', () => {
         root: 'ROOT',
         list: 'LIST',
         item: 'ITEM',
-        itemSelected: 'ITEMSELECTED',
+        selectedItem: 'ITEMSELECTED',
         label: 'LABEL',
         link: 'LINK',
         count: 'COUNT',
         showMore: 'SHOWMORE',
-        showMoreDisabled: 'SHOWMOREDISABLED',
+        disabledShowMore: 'SHOWMOREDISABLED',
       },
     });
     const { container } = render(<Menu {...props} />);

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Menu.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Menu.test.tsx
@@ -193,12 +193,12 @@ describe('Menu', () => {
         root: 'ROOT',
         list: 'LIST',
         item: 'ITEM',
-        selectedItem: 'ITEMSELECTED',
+        selectedItem: 'SELECTEDITEM',
         label: 'LABEL',
         link: 'LINK',
         count: 'COUNT',
         showMore: 'SHOWMORE',
-        disabledShowMore: 'SHOWMOREDISABLED',
+        disabledShowMore: 'DISABLEDSHOWMORE',
       },
     });
     const { container } = render(<Menu {...props} />);
@@ -212,7 +212,7 @@ describe('Menu', () => {
             class="ais-Menu-list LIST"
           >
             <li
-              class="ais-Menu-item ITEM ais-Menu-item--selected ITEMSELECTED"
+              class="ais-Menu-item ITEM ais-Menu-item--selected SELECTEDITEM"
             >
               <a
                 class="ais-Menu-link LINK"
@@ -251,7 +251,7 @@ describe('Menu', () => {
             </li>
           </ul>
           <button
-            class="ais-Menu-showMore SHOWMORE ais-Menu-showMore--disabled SHOWMOREDISABLED"
+            class="ais-Menu-showMore SHOWMORE ais-Menu-showMore--disabled DISABLEDSHOWMORE"
             disabled=""
           >
             Show more

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Menu.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Menu.test.tsx
@@ -261,6 +261,28 @@ describe('Menu', () => {
     `);
   });
 
+  test('allows custom class names (empty)', () => {
+    const props = createProps({ items: [] });
+    const { container } = render(
+      <Menu
+        {...props}
+        classNames={{ root: 'ROOT', noRefinementRoot: 'NOREFINEMENTROOT' }}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Menu ROOT ais-Menu--noRefinement NOREFINEMENTROOT"
+        >
+          <ul
+            class="ais-Menu-list"
+          />
+        </div>
+      </div>
+    `);
+  });
+
   test('forwards `div` props to the root element', () => {
     const props = createProps({ title: 'Some custom title' });
     const { container } = render(<Menu {...props} />);

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
@@ -1037,16 +1037,16 @@ describe('Pagination', () => {
         {...props}
         classNames={{
           root: 'ROOT',
-          rootNoRefinement: 'ROOTNOREFINEMENT',
+          noRefinementRoot: 'ROOTNOREFINEMENT',
           list: 'LIST',
           item: 'ITEM',
-          itemFirstPage: 'ITEMFIRSTPAGE',
-          itemPreviousPage: 'ITEMPREVIOUSPAGE',
-          itemPage: 'ITEMPAGE',
-          itemSelected: 'ITEMSELECTED',
-          itemDisabled: 'ITEMDISABLED',
-          itemNextPage: 'ITEMNEXTPAGE',
-          itemLastPage: 'ITEMLASTPAGE',
+          firstPageItem: 'ITEMFIRSTPAGE',
+          previousPageItem: 'ITEMPREVIOUSPAGE',
+          pageItem: 'ITEMPAGE',
+          selectedItem: 'ITEMSELECTED',
+          disabledItem: 'ITEMDISABLED',
+          nextPageItem: 'ITEMNEXTPAGE',
+          lastPageItem: 'ITEMLASTPAGE',
           link: 'LINK',
         }}
       />

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/Pagination.test.tsx
@@ -1037,16 +1037,16 @@ describe('Pagination', () => {
         {...props}
         classNames={{
           root: 'ROOT',
-          noRefinementRoot: 'ROOTNOREFINEMENT',
+          noRefinementRoot: 'NOREFINEMENTROOT',
           list: 'LIST',
           item: 'ITEM',
-          firstPageItem: 'ITEMFIRSTPAGE',
-          previousPageItem: 'ITEMPREVIOUSPAGE',
-          pageItem: 'ITEMPAGE',
-          selectedItem: 'ITEMSELECTED',
-          disabledItem: 'ITEMDISABLED',
-          nextPageItem: 'ITEMNEXTPAGE',
-          lastPageItem: 'ITEMLASTPAGE',
+          firstPageItem: 'FIRSTPAGEITEM',
+          previousPageItem: 'PREVIOUSPAGEITEM',
+          pageItem: 'PAGEITEM',
+          selectedItem: 'SELECTEDITEM',
+          disabledItem: 'DISABLEDITEM',
+          nextPageItem: 'NEXTPAGEITEM',
+          lastPageItem: 'LASTPAGEITEM',
           link: 'LINK',
         }}
       />
@@ -1061,7 +1061,7 @@ describe('Pagination', () => {
             class="ais-Pagination-list LIST"
           >
             <li
-              class="ais-Pagination-item ITEM ais-Pagination-item--disabled ITEMDISABLED ais-Pagination-item--firstPage ITEMFIRSTPAGE"
+              class="ais-Pagination-item ITEM ais-Pagination-item--disabled DISABLEDITEM ais-Pagination-item--firstPage FIRSTPAGEITEM"
             >
               <span
                 aria-label="First"
@@ -1071,7 +1071,7 @@ describe('Pagination', () => {
               </span>
             </li>
             <li
-              class="ais-Pagination-item ITEM ais-Pagination-item--disabled ITEMDISABLED ais-Pagination-item--previousPage ITEMPREVIOUSPAGE"
+              class="ais-Pagination-item ITEM ais-Pagination-item--disabled DISABLEDITEM ais-Pagination-item--previousPage PREVIOUSPAGEITEM"
             >
               <span
                 aria-label="Previous"
@@ -1081,7 +1081,7 @@ describe('Pagination', () => {
               </span>
             </li>
             <li
-              class="ais-Pagination-item ITEM ais-Pagination-item--page ITEMPAGE ais-Pagination-item--selected ITEMSELECTED"
+              class="ais-Pagination-item ITEM ais-Pagination-item--page PAGEITEM ais-Pagination-item--selected SELECTEDITEM"
             >
               <a
                 aria-label="Page 1"
@@ -1092,7 +1092,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item ITEM ais-Pagination-item--page ITEMPAGE"
+              class="ais-Pagination-item ITEM ais-Pagination-item--page PAGEITEM"
             >
               <a
                 aria-label="Page 2"
@@ -1103,7 +1103,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item ITEM ais-Pagination-item--nextPage ITEMNEXTPAGE"
+              class="ais-Pagination-item ITEM ais-Pagination-item--nextPage NEXTPAGEITEM"
             >
               <a
                 aria-label="Next"
@@ -1114,7 +1114,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item ITEM ais-Pagination-item--lastPage ITEMLASTPAGE"
+              class="ais-Pagination-item ITEM ais-Pagination-item--lastPage LASTPAGEITEM"
             >
               <a
                 aria-label="Last"

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RangeInput.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RangeInput.test.tsx
@@ -177,7 +177,7 @@ describe('RangeInput', () => {
       disabled: true,
       classNames: {
         root: 'ROOT',
-        noRefinementRoot: 'ROOTNOREFINEMENT',
+        noRefinementRoot: 'NOREFINEMENTROOT',
         form: 'FORM',
         label: 'LABEL',
         input: 'INPUT',
@@ -193,7 +193,7 @@ describe('RangeInput', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-RangeInput ROOT ais-RangeInput--noRefinement ROOTNOREFINEMENT"
+          class="ais-RangeInput ROOT ais-RangeInput--noRefinement NOREFINEMENTROOT"
         >
           <form
             class="ais-RangeInput-form FORM"

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RangeInput.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RangeInput.test.tsx
@@ -177,7 +177,7 @@ describe('RangeInput', () => {
       disabled: true,
       classNames: {
         root: 'ROOT',
-        rootNoRefinement: 'ROOTNOREFINEMENT',
+        noRefinementRoot: 'ROOTNOREFINEMENT',
         form: 'FORM',
         label: 'LABEL',
         input: 'INPUT',
@@ -193,7 +193,7 @@ describe('RangeInput', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-RangeInput ROOT ais-RangeInput-noRefinement ROOTNOREFINEMENT"
+          class="ais-RangeInput ROOT ais-RangeInput--noRefinement ROOTNOREFINEMENT"
         >
           <form
             class="ais-RangeInput-form FORM"

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RefinementList.test.tsx
@@ -537,13 +537,13 @@ describe('RefinementList', () => {
         noResults: 'NORESULTS',
         list: 'LIST',
         item: 'ITEM',
-        selectedItem: 'ITEMSELECTED',
+        selectedItem: 'SELECTEDITEM',
         label: 'LABEL',
         checkbox: 'CHECKBOX',
         labelText: 'LABELTEXT',
         count: 'COUNT',
         showMore: 'SHOWMORE',
-        disabledShowMore: 'SHOWMOREDISABLED',
+        disabledShowMore: 'DISABLEDSHOWMORE',
       },
     });
     const { container } = render(<RefinementList {...props} />);
@@ -557,7 +557,7 @@ describe('RefinementList', () => {
             class="ais-RefinementList-list LIST"
           >
             <li
-              class="ais-RefinementList-item ITEM ais-RefinementList-item--selected ITEMSELECTED"
+              class="ais-RefinementList-item ITEM ais-RefinementList-item--selected SELECTEDITEM"
             >
               <label
                 class="ais-RefinementList-label LABEL"
@@ -605,7 +605,7 @@ describe('RefinementList', () => {
             </li>
           </ul>
           <button
-            class="ais-RefinementList-showMore SHOWMORE ais-RefinementList-showMore--disabled SHOWMOREDISABLED"
+            class="ais-RefinementList-showMore SHOWMORE ais-RefinementList-showMore--disabled DISABLEDSHOWMORE"
             disabled=""
           >
             Show more

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RefinementList.test.tsx
@@ -10,6 +10,7 @@ import type { RefinementListProps } from '../RefinementList';
 describe('RefinementList', () => {
   function createProps(props: Partial<RefinementListProps>) {
     return {
+      canRefine: true,
       items: [
         {
           value: 'Insignia™',
@@ -615,7 +616,11 @@ describe('RefinementList', () => {
   });
 
   test('allows custom class names (empty)', () => {
-    const props = createProps({ items: [], noResults: 'No results.' });
+    const props = createProps({
+      canRefine: false,
+      items: undefined,
+      noResults: 'No results.',
+    });
     const { container } = render(
       <RefinementList
         {...props}

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RefinementList.test.tsx
@@ -536,13 +536,13 @@ describe('RefinementList', () => {
         noResults: 'NORESULTS',
         list: 'LIST',
         item: 'ITEM',
-        itemSelected: 'ITEMSELECTED',
+        selectedItem: 'ITEMSELECTED',
         label: 'LABEL',
         checkbox: 'CHECKBOX',
         labelText: 'LABELTEXT',
         count: 'COUNT',
         showMore: 'SHOWMORE',
-        showMoreDisabled: 'SHOWMOREDISABLED',
+        disabledShowMore: 'SHOWMOREDISABLED',
       },
     });
     const { container } = render(<RefinementList {...props} />);

--- a/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/ui/__tests__/RefinementList.test.tsx
@@ -125,69 +125,69 @@ describe('RefinementList', () => {
       const { container } = render(<RefinementList {...props} />);
 
       expect(container).toMatchInlineSnapshot(`
-      <div>
-        <div
-          class="ais-RefinementList"
-        >
-          <ul
-            class="ais-RefinementList-list"
-          >
-            <li
-              class="ais-RefinementList-item ais-RefinementList-item--selected"
-            >
-              <label
-                class="ais-RefinementList-label"
-              >
-                <input
-                  checked=""
-                  class="ais-RefinementList-checkbox"
-                  type="checkbox"
-                  value="Insignia™"
-                />
-                <span
-                  class="ais-RefinementList-labelText"
+              <div>
+                <div
+                  class="ais-RefinementList"
                 >
-                  Insignia™
-                </span>
-                <span
-                  class="ais-RefinementList-count"
-                >
-                  746
-                </span>
-              </label>
-            </li>
-            <li
-              class="ais-RefinementList-item"
-            >
-              <label
-                class="ais-RefinementList-label"
-              >
-                <input
-                  class="ais-RefinementList-checkbox"
-                  type="checkbox"
-                  value="Samsung"
-                />
-                <span
-                  class="ais-RefinementList-labelText"
-                >
-                  Samsung
-                </span>
-                <span
-                  class="ais-RefinementList-count"
-                >
-                  633
-                </span>
-              </label>
-            </li>
-          </ul>
-          <button
-            class="ais-RefinementList-showMore"
-          >
-            Show more
-          </button>
-        </div>
-      </div>
-    `);
+                  <ul
+                    class="ais-RefinementList-list"
+                  >
+                    <li
+                      class="ais-RefinementList-item ais-RefinementList-item--selected"
+                    >
+                      <label
+                        class="ais-RefinementList-label"
+                      >
+                        <input
+                          checked=""
+                          class="ais-RefinementList-checkbox"
+                          type="checkbox"
+                          value="Insignia™"
+                        />
+                        <span
+                          class="ais-RefinementList-labelText"
+                        >
+                          Insignia™
+                        </span>
+                        <span
+                          class="ais-RefinementList-count"
+                        >
+                          746
+                        </span>
+                      </label>
+                    </li>
+                    <li
+                      class="ais-RefinementList-item"
+                    >
+                      <label
+                        class="ais-RefinementList-label"
+                      >
+                        <input
+                          class="ais-RefinementList-checkbox"
+                          type="checkbox"
+                          value="Samsung"
+                        />
+                        <span
+                          class="ais-RefinementList-labelText"
+                        >
+                          Samsung
+                        </span>
+                        <span
+                          class="ais-RefinementList-count"
+                        >
+                          633
+                        </span>
+                      </label>
+                    </li>
+                  </ul>
+                  <button
+                    class="ais-RefinementList-showMore"
+                  >
+                    Show more
+                  </button>
+                </div>
+              </div>
+          `);
     });
 
     test('calls onToggleShowMore', () => {
@@ -609,6 +609,34 @@ describe('RefinementList', () => {
           >
             Show more
           </button>
+        </div>
+      </div>
+    `);
+  });
+
+  test('allows custom class names (empty)', () => {
+    const props = createProps({ items: [], noResults: 'No results.' });
+    const { container } = render(
+      <RefinementList
+        {...props}
+        classNames={{
+          root: 'ROOT',
+          noRefinementRoot: 'NOREFINEMENTROOT',
+          noResults: 'NORESULTS',
+        }}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-RefinementList ROOT ais-RefinementList--noRefinement NOREFINEMENTROOT"
+        >
+          <div
+            class="ais-RefinementList-noResults NORESULTS"
+          >
+            No results.
+          </div>
         </div>
       </div>
     `);

--- a/packages/react-instantsearch-hooks-dom/src/widgets/CurrentRefinements.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/CurrentRefinements.tsx
@@ -8,7 +8,7 @@ import type { UseCurrentRefinementsProps } from 'react-instantsearch-hooks';
 
 export type CurrentRefinementsProps = Omit<
   CurrentRefinementsUiComponentProps,
-  'disabled' | 'onClick' | 'items'
+  'disabled' | 'onClick' | 'items' | 'hasRefinements'
 > &
   UseCurrentRefinementsProps;
 
@@ -18,7 +18,7 @@ export function CurrentRefinements({
   transformItems,
   ...props
 }: CurrentRefinementsProps) {
-  const { items, refine } = useCurrentRefinements(
+  const { items, refine, canRefine } = useCurrentRefinements(
     {
       includedAttributes,
       excludedAttributes,
@@ -30,6 +30,11 @@ export function CurrentRefinements({
   );
 
   return (
-    <CurrentRefinementsUiComponent {...props} items={items} onRemove={refine} />
+    <CurrentRefinementsUiComponent
+      {...props}
+      hasRefinements={canRefine}
+      items={items}
+      onRemove={refine}
+    />
   );
 }

--- a/packages/react-instantsearch-hooks-dom/src/widgets/CurrentRefinements.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/CurrentRefinements.tsx
@@ -8,7 +8,7 @@ import type { UseCurrentRefinementsProps } from 'react-instantsearch-hooks';
 
 export type CurrentRefinementsProps = Omit<
   CurrentRefinementsUiComponentProps,
-  'disabled' | 'onClick' | 'items' | 'hasRefinements'
+  'disabled' | 'onClick' | 'items'
 > &
   UseCurrentRefinementsProps;
 
@@ -18,7 +18,7 @@ export function CurrentRefinements({
   transformItems,
   ...props
 }: CurrentRefinementsProps) {
-  const { items, refine, canRefine } = useCurrentRefinements(
+  const { items, refine } = useCurrentRefinements(
     {
       includedAttributes,
       excludedAttributes,
@@ -30,11 +30,6 @@ export function CurrentRefinements({
   );
 
   return (
-    <CurrentRefinementsUiComponent
-      {...props}
-      hasRefinements={canRefine}
-      items={items}
-      onRemove={refine}
-    />
+    <CurrentRefinementsUiComponent {...props} items={items} onRemove={refine} />
   );
 }

--- a/packages/react-instantsearch-hooks-dom/src/widgets/RefinementList.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/RefinementList.tsx
@@ -11,6 +11,7 @@ import type { UseRefinementListProps } from 'react-instantsearch-hooks';
 
 export type RefinementListProps = Omit<
   RefinementListUiComponentProps,
+  | 'canRefine'
   | 'items'
   | 'onRefine'
   | 'query'
@@ -37,6 +38,7 @@ export function RefinementList({
   ...props
 }: RefinementListProps) {
   const {
+    canRefine,
     canToggleShowMore,
     isFromSearch,
     isShowingMore,
@@ -93,6 +95,7 @@ export function RefinementList({
   return (
     <RefinementListUiComponent
       {...props}
+      canRefine={canRefine}
       items={items}
       onRefine={onRefine}
       query={query}

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/ClearRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/ClearRefinements.test.tsx
@@ -437,7 +437,7 @@ describe('ClearRefinements', () => {
           classNames={{
             root: 'ROOT',
             button: 'BUTTON',
-            buttonDisabled: 'DISABLED',
+            disabledButton: 'DISABLED',
           }}
         />
       </InstantSearchHooksTestWrapper>

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/CurrentRefinements.test.tsx
@@ -114,6 +114,28 @@ describe('CurrentRefinements', () => {
     `);
   });
 
+  test('renders with a specific set of class names when there are no refinements', async () => {
+    const { container } = render(
+      <InstantSearchHooksTestWrapper>
+        <CurrentRefinements />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await wait(0);
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement"
+        >
+          <ul
+            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
+          />
+        </div>
+      </div>
+    `);
+  });
+
   test('clears a refinement', async () => {
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
@@ -607,7 +629,9 @@ describe('CurrentRefinements', () => {
             className="MyCurrentRefinements"
             classNames={{
               root: 'ROOT',
+              noRefinementRoot: 'ROOTNOREFINEMENT',
               list: 'LIST',
+              listNoRefinement: 'LISTNOREFINEMENT',
               item: 'ITEM',
               label: 'LABEL',
               category: 'CATEGORY',
@@ -623,14 +647,14 @@ describe('CurrentRefinements', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-CurrentRefinements ROOT MyCurrentRefinements"
+            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement ROOTNOREFINEMENT MyCurrentRefinements"
           >
             <ul
-              class="ais-CurrentRefinements-list LIST"
+              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement LISTNOREFINEMENT"
             />
           </div>
         </div>
-      `);
+    `);
     }
 
     {
@@ -649,7 +673,9 @@ describe('CurrentRefinements', () => {
             className="MyCurrentRefinements"
             classNames={{
               root: 'ROOT',
+              noRefinementRoot: 'ROOTNOREFINEMENT',
               list: 'LIST',
+              listNoRefinement: 'LISTNOREFINEMENT',
               item: 'ITEM',
               label: 'LABEL',
               category: 'CATEGORY',
@@ -721,11 +747,11 @@ describe('CurrentRefinements', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-CurrentRefinements MyCurrentRefinements"
+          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement MyCurrentRefinements"
           title="Some custom title"
         >
           <ul
-            class="ais-CurrentRefinements-list"
+            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
           />
         </div>
       </div>

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/CurrentRefinements.test.tsx
@@ -629,7 +629,7 @@ describe('CurrentRefinements', () => {
             className="MyCurrentRefinements"
             classNames={{
               root: 'ROOT',
-              rootNoRefinement: 'ROOTNOREFINEMENT',
+              noRefinementRoot: 'ROOTNOREFINEMENT',
               list: 'LIST',
               listNoRefinement: 'LISTNOREFINEMENT',
               item: 'ITEM',
@@ -673,7 +673,7 @@ describe('CurrentRefinements', () => {
             className="MyCurrentRefinements"
             classNames={{
               root: 'ROOT',
-              rootNoRefinement: 'ROOTNOREFINEMENT',
+              noRefinementRoot: 'ROOTNOREFINEMENT',
               list: 'LIST',
               listNoRefinement: 'LISTNOREFINEMENT',
               item: 'ITEM',

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/CurrentRefinements.test.tsx
@@ -114,28 +114,6 @@ describe('CurrentRefinements', () => {
     `);
   });
 
-  test('renders with a specific set of class names when there are no refinements', async () => {
-    const { container } = render(
-      <InstantSearchHooksTestWrapper>
-        <CurrentRefinements />
-      </InstantSearchHooksTestWrapper>
-    );
-
-    await wait(0);
-
-    expect(container).toMatchInlineSnapshot(`
-      <div>
-        <div
-          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement"
-        >
-          <ul
-            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
-          />
-        </div>
-      </div>
-    `);
-  });
-
   test('clears a refinement', async () => {
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
@@ -629,9 +607,7 @@ describe('CurrentRefinements', () => {
             className="MyCurrentRefinements"
             classNames={{
               root: 'ROOT',
-              noRefinementRoot: 'ROOTNOREFINEMENT',
               list: 'LIST',
-              listNoRefinement: 'LISTNOREFINEMENT',
               item: 'ITEM',
               label: 'LABEL',
               category: 'CATEGORY',
@@ -647,14 +623,14 @@ describe('CurrentRefinements', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement ROOTNOREFINEMENT MyCurrentRefinements"
+            class="ais-CurrentRefinements ROOT MyCurrentRefinements"
           >
             <ul
-              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement LISTNOREFINEMENT"
+              class="ais-CurrentRefinements-list LIST"
             />
           </div>
         </div>
-    `);
+      `);
     }
 
     {
@@ -673,9 +649,7 @@ describe('CurrentRefinements', () => {
             className="MyCurrentRefinements"
             classNames={{
               root: 'ROOT',
-              noRefinementRoot: 'ROOTNOREFINEMENT',
               list: 'LIST',
-              listNoRefinement: 'LISTNOREFINEMENT',
               item: 'ITEM',
               label: 'LABEL',
               category: 'CATEGORY',
@@ -747,11 +721,11 @@ describe('CurrentRefinements', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement MyCurrentRefinements"
+          class="ais-CurrentRefinements MyCurrentRefinements"
           title="Some custom title"
         >
           <ul
-            class="ais-CurrentRefinements-list ais-CurrentRefinements-list--noRefinement"
+            class="ais-CurrentRefinements-list"
           />
         </div>
       </div>

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/CurrentRefinements.test.tsx
@@ -629,9 +629,9 @@ describe('CurrentRefinements', () => {
             className="MyCurrentRefinements"
             classNames={{
               root: 'ROOT',
-              noRefinementRoot: 'ROOTNOREFINEMENT',
+              noRefinementRoot: 'NOREFINEMENTROOT',
               list: 'LIST',
-              listNoRefinement: 'LISTNOREFINEMENT',
+              noRefinementList: 'NOREFINEMENTLIST',
               item: 'ITEM',
               label: 'LABEL',
               category: 'CATEGORY',
@@ -647,14 +647,14 @@ describe('CurrentRefinements', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement ROOTNOREFINEMENT MyCurrentRefinements"
+            class="ais-CurrentRefinements ROOT ais-CurrentRefinements--noRefinement NOREFINEMENTROOT MyCurrentRefinements"
           >
             <ul
-              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement LISTNOREFINEMENT"
+              class="ais-CurrentRefinements-list LIST ais-CurrentRefinements-list--noRefinement NOREFINEMENTLIST"
             />
           </div>
         </div>
-    `);
+      `);
     }
 
     {
@@ -673,9 +673,9 @@ describe('CurrentRefinements', () => {
             className="MyCurrentRefinements"
             classNames={{
               root: 'ROOT',
-              noRefinementRoot: 'ROOTNOREFINEMENT',
+              noRefinementRoot: 'NOREFINEMENTROOT',
               list: 'LIST',
-              listNoRefinement: 'LISTNOREFINEMENT',
+              noRefinementList: 'NOREFINEMENTLIST',
               item: 'ITEM',
               label: 'LABEL',
               category: 'CATEGORY',

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Hits.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Hits.test.tsx
@@ -20,7 +20,7 @@ describe('Hits', () => {
     await waitFor(() => {
       expect(container.querySelector('.ais-Hits')).toMatchInlineSnapshot(`
         <div
-          class="ais-Hits"
+          class="ais-Hits ais-Hits--empty"
         >
           <ol
             class="ais-Hits-list"
@@ -107,7 +107,7 @@ describe('Hits', () => {
     );
 
     expect(container.querySelector('.ais-Hits')!.className).toBe(
-      'ais-Hits custom'
+      'ais-Hits ais-Hits--empty custom'
     );
   });
 

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/InfiniteHits.test.tsx
@@ -295,7 +295,7 @@ describe('InfiniteHits', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-InfiniteHits"
+            class="ais-InfiniteHits ais-InfiniteHits--empty"
           >
             <ol
               class="ais-InfiniteHits-list"

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Pagination.test.tsx
@@ -2101,14 +2101,14 @@ describe('Pagination', () => {
           className="MyPagination"
           classNames={{
             root: 'ROOT',
-            noRefinementRoot: 'ROOTNOREFINEMENT',
+            noRefinementRoot: 'NOREFINEMENTROOT',
             list: 'LIST',
-            firstPageItem: 'ITEMFIRSTPAGE',
-            previousPageItem: 'ITEMPREVIOUSPAGE',
-            pageItem: 'ITEMPAGE',
-            selectedItem: 'ITEMSELECTED',
-            nextPageItem: 'ITEMNEXTPAGE',
-            lastPageItem: 'ITEMLASTPAGE',
+            firstPageItem: 'FIRSTPAGEITEM',
+            previousPageItem: 'PREVIOUSPAGEITEM',
+            pageItem: 'PAGEITEM',
+            selectedItem: 'SELECTEDITEM',
+            nextPageItem: 'NEXTPAGEITEM',
+            lastPageItem: 'LASTPAGEITEM',
           }}
         />
       </InstantSearchHooksTestWrapper>
@@ -2117,13 +2117,13 @@ describe('Pagination', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="ais-Pagination ROOT ais-Pagination--noRefinement ROOTNOREFINEMENT MyPagination"
+          class="ais-Pagination ROOT ais-Pagination--noRefinement NOREFINEMENTROOT MyPagination"
         >
           <ul
             class="ais-Pagination-list LIST"
           >
             <li
-              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage ITEMFIRSTPAGE"
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--firstPage FIRSTPAGEITEM"
             >
               <span
                 aria-label="First"
@@ -2133,7 +2133,7 @@ describe('Pagination', () => {
               </span>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage ITEMPREVIOUSPAGE"
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--previousPage PREVIOUSPAGEITEM"
             >
               <span
                 aria-label="Previous"
@@ -2143,7 +2143,7 @@ describe('Pagination', () => {
               </span>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--page ITEMPAGE ais-Pagination-item--selected ITEMSELECTED"
+              class="ais-Pagination-item ais-Pagination-item--page PAGEITEM ais-Pagination-item--selected SELECTEDITEM"
             >
               <a
                 aria-label="Page 1"
@@ -2154,7 +2154,7 @@ describe('Pagination', () => {
               </a>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage ITEMNEXTPAGE"
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--nextPage NEXTPAGEITEM"
             >
               <span
                 aria-label="Next"
@@ -2164,7 +2164,7 @@ describe('Pagination', () => {
               </span>
             </li>
             <li
-              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage ITEMLASTPAGE"
+              class="ais-Pagination-item ais-Pagination-item--disabled ais-Pagination-item--lastPage LASTPAGEITEM"
             >
               <span
                 aria-label="Last"

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/Pagination.test.tsx
@@ -2101,14 +2101,14 @@ describe('Pagination', () => {
           className="MyPagination"
           classNames={{
             root: 'ROOT',
-            rootNoRefinement: 'ROOTNOREFINEMENT',
+            noRefinementRoot: 'ROOTNOREFINEMENT',
             list: 'LIST',
-            itemFirstPage: 'ITEMFIRSTPAGE',
-            itemPreviousPage: 'ITEMPREVIOUSPAGE',
-            itemPage: 'ITEMPAGE',
-            itemSelected: 'ITEMSELECTED',
-            itemNextPage: 'ITEMNEXTPAGE',
-            itemLastPage: 'ITEMLASTPAGE',
+            firstPageItem: 'ITEMFIRSTPAGE',
+            previousPageItem: 'ITEMPREVIOUSPAGE',
+            pageItem: 'ITEMPAGE',
+            selectedItem: 'ITEMSELECTED',
+            nextPageItem: 'ITEMNEXTPAGE',
+            lastPageItem: 'ITEMLASTPAGE',
           }}
         />
       </InstantSearchHooksTestWrapper>

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/RefinementList.test.tsx
@@ -1134,7 +1134,7 @@ describe('RefinementList', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-RefinementList"
+            class="ais-RefinementList ais-RefinementList--noRefinement"
           >
             <div
               class="ais-RefinementList-searchBox"

--- a/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-dom/src/widgets/__tests__/RefinementList.test.tsx
@@ -1134,7 +1134,7 @@ describe('RefinementList', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-RefinementList ais-RefinementList--noRefinement"
+            class="ais-RefinementList"
           >
             <div
               class="ais-RefinementList-searchBox"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## **Summary**

This PR goes through all of our new Hooks DOM UI components to make sure their class names and values are in line with those in InstantSearch.js

## **Notes**

There is one case with `<CurrentRefinements>` where 2 class names (`noRefinementRoot` and `listNoRefinement`) don't exist either in IS.js or in the specs. Since they do exist in the current React InstantSearch version, I did not remove them.

I also did not replace the class descriptions with those from IS.js since we already reviewed them, but I made sure they are consistent with each other.

<details>
<summary>Extract for reference</summary>

`root`

| description | location |
| ----------- | -------- |
| Class names to apply to the root element | `BreadcrumbClassNames`, `ClearRefinementsClassNames`, `CurrentRefinementsClassNames`, `HitsClassNames`, `HitsPerPageClassNames`, `InfiniteHitsClassNames`, `InternalHighlightClassNames`, `PaginationClassNames`, `PoweredByClassNames`, `RangeInputClassNames`, `RefinementListClassNames`, `SearchBoxClassNames`, `SortByClassNames`, `ToggleRefinementClassNames` |

`noRefinementRoot`

| description | location |
| ----------- | -------- |
| Class names to apply to the root element when there are no refinements possible | `BreadcrumbClassNames`, `CurrentRefinementsClassNames`, `PaginationClassNames`, `RangeInputClassNames`, `RefinementListClassNames` |

`list`

| description | location |
| ----------- | -------- |
| Class names to apply to the list element | `BreadcrumbClassNames`, `CurrentRefinementsClassNames`, `HitsClassNames`, `InfiniteHitsClassNames`, `PaginationClassNames`, `RefinementListClassNames` |

`item`

| description | location |
| ----------- | -------- |
| Class names to apply to each item element | `BreadcrumbClassNames`, `HitsClassNames`, `InfiniteHitsClassNames`, `PaginationClassNames`, `RefinementListClassNames` |
| Class names to apply to each refinement | `CurrentRefinementsClassNames` |

`selectedItem`

| description | location |
| ----------- | -------- |
| Class names to apply to the selected item | `BreadcrumbClassNames` |
| Class names to apply to a selected page element | `PaginationClassNames` |
| Class names to apply to each selected item element | `RefinementListClassNames` |

`separator`

| description | location |
| ----------- | -------- |
| Class names to apply to the separator between items | `BreadcrumbClassNames` |
| Class names to apply to the separator between highlighted parts | `InternalHighlightClassNames` |
| Class names to apply to the separator element | `RangeInputClassNames` |

`link`

| description | location |
| ----------- | -------- |
| Class names to apply to each link element | `BreadcrumbClassNames`, `PaginationClassNames` |
| Class names to apply to the link element | `PoweredByClassNames` |

`button`

| description | location |
| ----------- | -------- |
| Class names to apply to the button | `ClearRefinementsClassNames` |

`disabledButton`

| description | location |
| ----------- | -------- |
| Class names to apply to the button when it's disabled | `ClearRefinementsClassNames` |

`listNoRefinement`

| description | location |
| ----------- | -------- |
| Class names to apply to the list element when there are no refinements possible | `CurrentRefinementsClassNames` |

`label`

| description | location |
| ----------- | -------- |
| Class names to apply to the label of each refinement | `CurrentRefinementsClassNames` |
| Class names to apply to each label element | `RangeInputClassNames`, `RefinementListClassNames` |
| Class names to apply to the label element | `ToggleRefinementClassNames` |

`category`

| description | location |
| ----------- | -------- |
| Class names to apply to the container of each refinement's value | `CurrentRefinementsClassNames` |

`categoryLabel`

| description | location |
| ----------- | -------- |
| Class names to apply to the text element of each refinement's value | `CurrentRefinementsClassNames` |

`delete`

| description | location |
| ----------- | -------- |
| Class names to apply to the each refinement's delete button | `CurrentRefinementsClassNames` |

`emptyRoot`

| description | location |
| ----------- | -------- |
| Class names to apply to the root element without results | `HitsClassNames`, `InfiniteHitsClassNames` |

`select`

| description | location |
| ----------- | -------- |
| Class names to apply to the select element | `HitsPerPageClassNames`, `SortByClassNames` |

`option`

| description | location |
| ----------- | -------- |
| Class names to apply to the option element | `HitsPerPageClassNames`, `SortByClassNames` |

`loadPrevious`

| description | location |
| ----------- | -------- |
| Class names to apply to the "load previous" button | `InfiniteHitsClassNames` |

`disabledLoadPrevious`

| description | location |
| ----------- | -------- |
| Class names to apply to the "load previous" button when it's disabled | `InfiniteHitsClassNames` |

`loadMore`

| description | location |
| ----------- | -------- |
| Class names to apply to the "load more" button | `InfiniteHitsClassNames` |

`disabledLoadMore`

| description | location |
| ----------- | -------- |
| Class names to apply to the "load more" button when it's disabled | `InfiniteHitsClassNames` |

`highlighted`

| description | location |
| ----------- | -------- |
| Class names to apply to the highlighted parts | `InternalHighlightClassNames` |

`nonHighlighted`

| description | location |
| ----------- | -------- |
| Class names to apply to the non-highlighted parts | `InternalHighlightClassNames` |

`firstPageItem`

| description | location |
| ----------- | -------- |
| Class names to apply to the first page element | `PaginationClassNames` |

`previousPageItem`

| description | location |
| ----------- | -------- |
| Class names to apply to the previous page element | `PaginationClassNames` |

`pageItem`

| description | location |
| ----------- | -------- |
| Class names to apply to each page element | `PaginationClassNames` |

`disabledItem`

| description | location |
| ----------- | -------- |
| Class names to apply to a disabled page element | `PaginationClassNames` |

`nextPageItem`

| description | location |
| ----------- | -------- |
| Class names to apply to the next page element | `PaginationClassNames` |

`lastPageItem`

| description | location |
| ----------- | -------- |
| Class names to apply to the last page element | `PaginationClassNames` |

`light`

| description | location |
| ----------- | -------- |
| Class names to apply to the root element with the light theme | `PoweredByClassNames` |

`dark`

| description | location |
| ----------- | -------- |
| Class names to apply to the root element with the dark theme | `PoweredByClassNames` |

`logo`

| description | location |
| ----------- | -------- |
| Class names to apply to the SVG logo | `PoweredByClassNames` |

`form`

| description | location |
| ----------- | -------- |
| Class names to apply to the form element | `RangeInputClassNames`, `SearchBoxClassNames` |

`input`

| description | location |
| ----------- | -------- |
| Class names to apply to each input element | `RangeInputClassNames` |
| Class names to apply to the input element | `SearchBoxClassNames` |

`inputMin`

| description | location |
| ----------- | -------- |
| Class names to apply to the minimum input element | `RangeInputClassNames` |

`inputMax`

| description | location |
| ----------- | -------- |
| Class names to apply to the maximum input element | `RangeInputClassNames` |

`submit`

| description | location |
| ----------- | -------- |
| Class names to apply to the submit button | `RangeInputClassNames`, `SearchBoxClassNames` |

`searchBox`

| description | location |
| ----------- | -------- |
| Class names to apply to the search box wrapper element | `RefinementListClassNames` |

`noResults`

| description | location |
| ----------- | -------- |
| Class names to apply to the root element | `RefinementListClassNames` |

`checkbox`

| description | location |
| ----------- | -------- |
| Class names to apply to each checkbox element | `RefinementListClassNames` |
| Class names to apply to the checkbox element | `ToggleRefinementClassNames` |

`labelText`

| description | location |
| ----------- | -------- |
| Class names to apply to the text for each label | `RefinementListClassNames` |
| Class names to apply to the label text | `ToggleRefinementClassNames` |

`count`

| description | location |
| ----------- | -------- |
| Class names to apply to the facet count of each item | `RefinementListClassNames` |

`showMore`

| description | location |
| ----------- | -------- |
| Class names to apply to the "Show more" button | `RefinementListClassNames` |

`disabledShowMore`

| description | location |
| ----------- | -------- |
| Class names to apply to the "Show more" button if it's disabled | `RefinementListClassNames` |

`reset`

| description | location |
| ----------- | -------- |
| Class names to apply to the reset button | `SearchBoxClassNames` |

`loadingIndicator`

| description | location |
| ----------- | -------- |
| Class names to apply to the loading indicator element | `SearchBoxClassNames` |

`submitIcon`

| description | location |
| ----------- | -------- |
| Class names to apply to the submit icon | `SearchBoxClassNames` |

`resetIcon`

| description | location |
| ----------- | -------- |
| Class names to apply to the reset icon | `SearchBoxClassNames` |

`loadingIcon`

| description | location |
| ----------- | -------- |
| Class names to apply to the loading icon | `SearchBoxClassNames` |

</details>