### PR TITLE
fix(packages): correctly mark peer dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,7 @@ jobs:
           name: Install algoliasearch v3
           command: |
             rm -rf examples
-            yarn remove -W @algolia/client-search
-            yarn add -W @types/algoliasearch@3.34.8 algoliasearch@3.35.1
+            yarn add -W -D @types/algoliasearch@3.34.8 algoliasearch@3.35.1
       - run:
           name: Type checking
           command: yarn type-check

--- a/package.json
+++ b/package.json
@@ -32,7 +32,12 @@
     "website:build": "yarn build && yarn webpack --config website/webpack.config.js"
   },
   "devDependencies": {
-    "@algolia/client-search": "4.10.5",
+    "@algolia/client-search": "4.11.0",
+    "@algolia/cache-common": "4.11.0",
+    "@algolia/cache-in-memory": "4.11.0",
+    "@algolia/logger-common": "4.11.0",
+    "@algolia/requester-node-http": "4.11.0",
+    "@algolia/transporter": "4.11.0",
     "@babel/cli": "7.15.4",
     "@babel/core": "7.15.5",
     "@babel/plugin-proposal-class-properties": "7.14.5",

--- a/packages/react-instantsearch-core/src/types/algoliasearch.ts
+++ b/packages/react-instantsearch-core/src/types/algoliasearch.ts
@@ -1,16 +1,15 @@
 // Custom types to support both algoliasearch
 // `v3` and algoliasearch `v4` clients.
 
-import type algoliasearch from 'algoliasearch';
-import type {
-  // @ts-ignore
-  Response as SearchResponseV3,
-} from 'algoliasearch';
+import type algoliasearch from 'algoliasearch/lite';
+import type * as AlgoliaSearch from 'algoliasearch/lite';
+/** @ts-ignore */
+import type * as ClientSearch from '@algolia/client-search';
 
-import type {
-  // @ts-ignore
-  SearchResponse as SearchResponseV4,
-} from '@algolia/client-search';
+/** @ts-ignore */
+type SearchResponseV3<TObject> = AlgoliaSearch.Response<TObject>;
+/** @ts-ignore */
+type SearchResponseV4<TObject> = ClientSearch.SearchResponse<TObject>;
 
 type DummySearchClientV4 = {
   readonly addAlgoliaAgent: (segment: string, version?: string) => void;

--- a/packages/react-instantsearch-dom-maps/package.json
+++ b/packages/react-instantsearch-dom-maps/package.json
@@ -44,6 +44,7 @@
     "scriptjs": "^2.5.8"
   },
   "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 5",
     "react": ">= 16.3.0 < 19",
     "react-dom": ">= 16.3.0 < 19",
     "react-instantsearch-dom": "6.23.3"

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -46,6 +46,7 @@
     "react-instantsearch-core": "6.23.3"
   },
   "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 5",
     "react": ">= 16.3.0 < 19",
     "react-dom": ">= 16.3.0 < 19"
   }

--- a/packages/react-instantsearch-hooks-dom/package.json
+++ b/packages/react-instantsearch-hooks-dom/package.json
@@ -51,6 +51,7 @@
     "react-instantsearch-hooks": "6.23.3"
   },
   "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 5",
     "react": ">= 16.8.0 < 19",
     "react-dom": ">= 16.8.0 < 19"
   }

--- a/packages/react-instantsearch-hooks-server/package.json
+++ b/packages/react-instantsearch-hooks-server/package.json
@@ -51,6 +51,7 @@
     "react-instantsearch-hooks": "6.23.3"
   },
   "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 5",
     "react": ">= 16.8.0 < 19",
     "react-dom": ">= 16.8.0 < 19"
   }

--- a/packages/react-instantsearch-native/package.json
+++ b/packages/react-instantsearch-native/package.json
@@ -41,6 +41,7 @@
     "react-instantsearch-core": "6.23.3"
   },
   "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 5",
     "react": ">= 16.3.0 < 18",
     "react-native": ">= 0.54.0"
   }

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -47,5 +47,8 @@
     "react-instantsearch-core": "6.23.3",
     "react-instantsearch-dom": "6.23.3",
     "react-instantsearch-native": "6.23.3"
+  },
+  "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 5"
   }
 }

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -49,6 +49,7 @@
     "react-instantsearch-native": "6.23.3"
   },
   "peerDependencies": {
-    "algoliasearch": ">= 3.1 < 5"
+    "algoliasearch": ">= 3.1 < 5",
+    "react": ">= 16.3.0 < 19"
   }
 }

--- a/test/mock/createSearchClient.ts
+++ b/test/mock/createSearchClient.ts
@@ -27,10 +27,10 @@ export function createSearchClient<TOptions extends Partial<SearchClient>>(
 ): OverrideKeys<SearchClient, TOptions> {
   const appId = (options as Record<string, unknown>).appId || 'appId';
 
-  if (algoliasearch.version.startsWith('4.')) {
-    (options.transporter as any) =
-      options.transporter ||
-      createTransporter({
+  // check if algoliasearch is v4 (has transporter)
+  if ('transporter' in algoliasearch('appId', 'apiKey')) {
+    options = {
+      transporter: createTransporter({
         timeouts: {
           connect: 2,
           read: 5,
@@ -54,7 +54,9 @@ export function createSearchClient<TOptions extends Partial<SearchClient>>(
         ]),
         headers: {},
         queryParameters: {},
-      });
+      }),
+      ...options,
+    };
   }
 
   return {

--- a/test/mock/createSearchClient.ts
+++ b/test/mock/createSearchClient.ts
@@ -9,7 +9,7 @@ import {
 import type { HostOptions } from '@algolia/transporter';
 import { createNullLogger } from '@algolia/logger-common';
 import { createNodeHttpRequester } from '@algolia/requester-node-http';
-import type algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch';
 import {
   createSingleSearchResponse,
   createMultiSearchResponse,
@@ -26,38 +26,42 @@ export function createSearchClient<TOptions extends Partial<SearchClient>>(
   options: TOptions
 ): OverrideKeys<SearchClient, TOptions> {
   const appId = (options as Record<string, unknown>).appId || 'appId';
-  const transporter = createTransporter({
-    timeouts: {
-      connect: 2,
-      read: 5,
-      write: 30,
-    },
-    userAgent: createUserAgent('test'),
-    requester: createNodeHttpRequester(),
-    logger: createNullLogger(),
-    responsesCache: createNullCache(),
-    requestsCache: createNullCache(),
-    hostsCache: createInMemoryCache(),
-    hosts: (
-      [
-        { url: `${appId}-dsn.algolia.net`, accept: CallEnum.Read },
-        { url: `${appId}.algolia.net`, accept: CallEnum.Write },
-      ] as readonly HostOptions[]
-    ).concat([
-      { url: `${appId}-1.algolianet.com` },
-      { url: `${appId}-2.algolianet.com` },
-      { url: `${appId}-3.algolianet.com` },
-    ]),
-    headers: {},
-    queryParameters: {},
-  });
+
+  if (algoliasearch.version.startsWith('4.')) {
+    (options.transporter as any) =
+      options.transporter ||
+      createTransporter({
+        timeouts: {
+          connect: 2,
+          read: 5,
+          write: 30,
+        },
+        userAgent: createUserAgent('test'),
+        requester: createNodeHttpRequester(),
+        logger: createNullLogger(),
+        responsesCache: createNullCache(),
+        requestsCache: createNullCache(),
+        hostsCache: createInMemoryCache(),
+        hosts: (
+          [
+            { url: `${appId}-dsn.algolia.net`, accept: CallEnum.Read },
+            { url: `${appId}.algolia.net`, accept: CallEnum.Write },
+          ] as readonly HostOptions[]
+        ).concat([
+          { url: `${appId}-1.algolianet.com` },
+          { url: `${appId}-2.algolianet.com` },
+          { url: `${appId}-3.algolianet.com` },
+        ]),
+        headers: {},
+        queryParameters: {},
+      });
+  }
 
   return {
     appId,
     addAlgoliaAgent: jest.fn(),
     clearCache: jest.fn(),
     initIndex: jest.fn(),
-    transporter,
     customRequest: jest.fn(),
     search: jest.fn((requests) =>
       Promise.resolve(

--- a/test/mock/createSearchClient.ts
+++ b/test/mock/createSearchClient.ts
@@ -57,6 +57,11 @@ export function createSearchClient<TOptions extends Partial<SearchClient>>(
       }),
       ...options,
     };
+  } else {
+    options = {
+      _ua: 'Algolia for JavaScript (test)',
+      ...options,
+    };
   }
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,11 +16,6 @@
   dependencies:
     "@algolia/cache-common" "4.12.1"
 
-"@algolia/cache-common@4.10.5":
-  version "4.10.5"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.10.5.tgz#9510419e9dfb6d8814582c6b20615196f213a9d6"
-  integrity sha512-1mClwdmTHll+OnHkG+yeRoFM17kSxDs4qXkjf6rNZhoZGXDvfYLy3YcZ1FX4Kyz0DJv8aroq5RYGBDsWkHj6Tw==
-
 "@algolia/cache-common@4.11.0":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.11.0.tgz#066fe6d58b18e4b028dbef9bb8de07c5e22a3594"
@@ -83,14 +78,6 @@
     "@algolia/requester-common" "4.12.1"
     "@algolia/transporter" "4.12.1"
 
-"@algolia/client-common@4.10.5":
-  version "4.10.5"
-  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.10.5.tgz#a7d0833796a9a2da68be16be76b6dc3962bf2f18"
-  integrity sha512-21FAvIai5qm8DVmZHm2Gp4LssQ/a0nWwMchAx+1hIRj1TX7OcdW6oZDPyZ8asQdvTtK7rStQrRnD8a95SCUnzA==
-  dependencies:
-    "@algolia/requester-common" "4.10.5"
-    "@algolia/transporter" "4.10.5"
-
 "@algolia/client-common@4.11.0":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.11.0.tgz#9a2d1f6f8eaad25ba5d6d4ce307ba5bd84e6f999"
@@ -125,15 +112,6 @@
     "@algolia/requester-common" "4.12.1"
     "@algolia/transporter" "4.12.1"
 
-"@algolia/client-search@4.10.5":
-  version "4.10.5"
-  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.10.5.tgz#47907232a3e4ecf2aa4459b8de17242afd88147c"
-  integrity sha512-1eQFMz9uodrc5OM+9HeT+hHcfR1E1AsgFWXwyJ9Q3xejA2c1c4eObGgOgC9ZoshuHHdptaTN1m3rexqAxXRDBg==
-  dependencies:
-    "@algolia/client-common" "4.10.5"
-    "@algolia/requester-common" "4.10.5"
-    "@algolia/transporter" "4.10.5"
-
 "@algolia/client-search@4.11.0":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.11.0.tgz#c1105d715a2a04ba27231eca86f5d6620f68f4ae"
@@ -156,11 +134,6 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@algolia/events/-/events-4.0.1.tgz#fd39e7477e7bc703d7f893b556f676c032af3950"
   integrity sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==
-
-"@algolia/logger-common@4.10.5":
-  version "4.10.5"
-  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.10.5.tgz#cf807107e755ad4a72c5afc787e968ff1196f1cc"
-  integrity sha512-gRJo9zt1UYP4k3woEmZm4iuEBIQd/FrArIsjzsL/b+ihNoOqIxZKTSuGFU4UUZOEhvmxDReiA4gzvQXG+TMTmA==
 
 "@algolia/logger-common@4.11.0":
   version "4.11.0"
@@ -200,11 +173,6 @@
   dependencies:
     "@algolia/requester-common" "4.12.1"
 
-"@algolia/requester-common@4.10.5":
-  version "4.10.5"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.10.5.tgz#52abfbf10b743d26afd3ce20f62771bc393ff4f0"
-  integrity sha512-UkVa1Oyuj6NPiAEt5ZvrbVopEv1m/mKqjs40KLB+dvfZnNcj+9Fry4Oxnt15HMy/HLORXsx4UwcthAvBuOXE9Q==
-
 "@algolia/requester-common@4.11.0":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.11.0.tgz#d16de98d3ff72434bac39e4d915eab08035946a9"
@@ -228,15 +196,6 @@
   integrity sha512-awBtwaD+s0hxkA1aehYn8F0t9wqGoBVWgY4JPHBmp1ChO3pK7RKnnvnv7QQa9vTlllX29oPt/BBVgMo1Z3n1Qg==
   dependencies:
     "@algolia/requester-common" "4.12.1"
-
-"@algolia/transporter@4.10.5":
-  version "4.10.5"
-  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.10.5.tgz#9354989f12af3e2ce7d3109a94f519d467a960e0"
-  integrity sha512-F8DLkmIlvCoMwSCZA3FKHtmdjH3o5clbt0pi2ktFStVNpC6ZDmY307HcK619bKP5xW6h8sVJhcvrLB775D2cyA==
-  dependencies:
-    "@algolia/cache-common" "4.10.5"
-    "@algolia/logger-common" "4.10.5"
-    "@algolia/requester-common" "4.10.5"
 
 "@algolia/transporter@4.11.0":
   version "4.11.0"


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Transitively the peerDependency on algoliasearch is already required through algoliasearch-helper, and it's pretty much required for types too.

This won't add new errors, as the peerDependency is already present.

fixes #3428


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

No errors when installing `yarn add react-instantsearch-dom algoliasearch` using Yarn 3