### PR TITLE
feat(hooks): remove experimental warning

### DIFF
--- a/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
@@ -182,34 +182,4 @@ describe('InstantSearch', () => {
       expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
   });
-
-  describe('experimental warning', () => {
-    test('displays an experimental warning', () => {
-      const searchClient = createSearchClient({});
-
-      expect(() => {
-        render(
-          <InstantSearch indexName="indexName" searchClient={searchClient} />
-        );
-      }).toWarnDev(
-        '[InstantSearch] This version is experimental and not production-ready.\n\n' +
-          'Please report any bugs at https://github.com/algolia/react-instantsearch/issues/new?template=Bug_report_Hooks.md&labels=Scope%3A%20Hooks\n\n' +
-          '(To disable this warning, pass `suppressExperimentalWarning` to <InstantSearch>.)'
-      );
-    });
-
-    test('hides the experimental warning with suppressExperimentalWarning', () => {
-      const searchClient = createSearchClient({});
-
-      expect(() => {
-        render(
-          <InstantSearch
-            indexName="indexName"
-            searchClient={searchClient}
-            suppressExperimentalWarning={true}
-          />
-        );
-      }).not.toWarnDev();
-    });
-  });
 });

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearch.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearch.ts
@@ -19,21 +19,9 @@ const defaultUserAgents = [
   `react-instantsearch-hooks (${version})`,
 ];
 
-export type UseInstantSearchProps = InstantSearchOptions & {
-  /**
-   * Removes the console warning about the experimental version.
-   *
-   * Note that this warning is only displayed in development mode.
-   *
-   * @default false
-   */
-  suppressExperimentalWarning?: boolean;
-};
+export type UseInstantSearchProps = InstantSearchOptions;
 
-export function useInstantSearch({
-  suppressExperimentalWarning = false,
-  ...props
-}: UseInstantSearchProps) {
+export function useInstantSearch(props: UseInstantSearchProps) {
   const serverContext = useInstantSearchServerContext();
   const serverState = useInstantSearchSSRContext();
   const stableProps = useStableValue(props);
@@ -48,15 +36,6 @@ export function useInstantSearch({
     [stableProps, serverContext, serverState]
   );
   const forceUpdate = useForceUpdate();
-
-  useEffect(() => {
-    warn(
-      suppressExperimentalWarning,
-      'This version is experimental and not production-ready.\n\n' +
-        'Please report any bugs at https://github.com/algolia/react-instantsearch/issues/new?template=Bug_report_Hooks.md&labels=Scope%3A%20Hooks\n\n' +
-        '(To disable this warning, pass `suppressExperimentalWarning` to <InstantSearch>.)'
-    );
-  }, [suppressExperimentalWarning]);
 
   useEffect(() => {
     addAlgoliaAgents(stableProps.searchClient, defaultUserAgents);

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearch.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearch.ts
@@ -7,7 +7,6 @@ import version from '../version';
 
 import { useForceUpdate } from './useForceUpdate';
 import { useStableValue } from './useStableValue';
-import { warn } from './warn';
 
 import type { InstantSearchServerContextApi } from '../components/InstantSearchServerContext';
 import type { InstantSearchServerState } from '../components/InstantSearchSSRProvider';


### PR DESCRIPTION
## Description

This removes the experimental warning in React InstantSearch Hooks, as well as the `suppressExperimentalWarning` prop on `<InstantSearch>`.

## Related

- https://github.com/algolia/doc/pull/6911