### PR TITLE
fix(types): export correct types for react-instantsearch-hooks-web

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,11 @@ module.exports = {
     '@testing-library/jest-dom/extend-expect',
     './scripts/jest/setupTests.ts',
   ],
-  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/examples/'],
+  testPathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/examples/',
+    '/__utils__/',
+  ],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   testEnvironment: 'jsdom',
   watchPlugins: [

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/__utils__/all-widgets.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/__utils__/all-widgets.tsx
@@ -5,8 +5,8 @@ import {
   InstantSearchServerContext,
 } from 'react-instantsearch-hooks';
 
-import * as widgets from '../';
-import { createSearchClient } from '../../../../../test/mock';
+import * as widgets from '../..';
+import { createSearchClient } from '../../../../../../test/mock';
 
 import type { InstantSearch as InstantSearchClass } from 'instantsearch.js';
 import type { ComponentProps } from 'react';

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/all-components.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/all-components.test.tsx
@@ -4,7 +4,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { getAllWidgets } from '../__testutils__/all-widgets';
+import { getAllWidgets } from './__utils__/all-widgets';
 
 describe('rendering', () => {
   const widgets = getAllWidgets();

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/all-widgets.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/all-widgets.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { getAllInstantSearchWidgets } from '../__testutils__/all-widgets';
+import { getAllInstantSearchWidgets } from './__utils__/all-widgets';
 
 describe('widgets', () => {
   const widgets = getAllInstantSearchWidgets();

--- a/tsconfig.declaration.json
+++ b/tsconfig.declaration.json
@@ -5,5 +5,5 @@
     "emitDeclarationOnly": true,
     "noEmit": false
   },
-  "exclude": ["**/__tests__/**/*", "**/dist/**/*"]
+  "exclude": ["**/__tests__/**/*", "**/__testutils__/**/*", "**/dist/**/*"],
 }

--- a/tsconfig.declaration.json
+++ b/tsconfig.declaration.json
@@ -5,5 +5,5 @@
     "emitDeclarationOnly": true,
     "noEmit": false
   },
-  "exclude": ["**/__tests__/**/*", "**/__testutils__/**/*", "**/dist/**/*"],
+  "exclude": ["**/__tests__/**/*", "**/dist/**/*"],
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

The reason the types previously were the wrong directory is because `__testutils__/all-widgets.ts` was included, and this imported items from the root, thus changing the output format of the types.


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Correct type definition files for React InstantSearch hooks web

before|after
---|---
<img width="224" alt="Screenshot 2022-05-02 at 11 05 45" src="https://user-images.githubusercontent.com/6270048/166210996-dfb2182e-8556-4231-9bdd-1c70928e49da.png"> | <img width="115" alt="Screenshot 2022-05-02 at 11 04 28" src="https://user-images.githubusercontent.com/6270048/166210993-68b6662a-1775-4ed2-ae3c-380d42312219.png">

