### PR TITLE
fix(hooks): prevent infinite loops from render state

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -148,14 +148,6 @@ const config = {
           },
         ],
         'import/extensions': ['error', 'never'],
-        'no-restricted-imports': [
-          'error',
-          {
-            // We disallow `dequal` imports to use our own fork that accepts a
-            // compare function.
-            paths: ['dequal', 'dequal/lite'],
-          },
-        ],
       },
       settings: {
         'import/parsers': {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -148,6 +148,14 @@ const config = {
           },
         ],
         'import/extensions': ['error', 'never'],
+        'no-restricted-imports': [
+          'error',
+          {
+            // We disallow `dequal` imports to use our own fork that accepts a
+            // compare function.
+            paths: ['dequal', 'dequal/lite'],
+          },
+        ],
       },
       settings: {
         'import/parsers': {

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "algoliasearch-helper": "^3.7.4",
-    "dequal": "^2.0.0",
     "instantsearch.js": "^4.40.1"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -1,3 +1,4 @@
+import { dequal } from 'dequal/lite';
 import { useMemo, useRef, useState } from 'react';
 
 import { createSearchResults } from '../lib/createSearchResults';
@@ -27,6 +28,9 @@ export function useConnector<
     additionalWidgetProperties
   );
   const shouldSetStateRef = useRef(true);
+  const previousRenderStateRef = useRef<TDescription['renderState'] | null>(
+    null
+  );
 
   const widget = useMemo(() => {
     const createWidget = connector(
@@ -54,8 +58,29 @@ export function useConnector<
           const { instantSearchInstance, widgetParams, ...renderState } =
             connectorState;
 
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          setState(renderState);
+          const renderStateWithoutFns = Object.entries(renderState).reduce(
+            (acc, [key, value]) => {
+              if (typeof value === 'function') {
+                return acc;
+              }
+
+              acc[key] = value;
+
+              return acc;
+            },
+            {}
+          );
+
+          // We only update the state if the widget render state has changed.
+          // This avoids infinite loops when a function prop reference changes.
+          // We base the check only on non-function parameters because functions
+          // cannot be compared. It's safe to omit them because they get updated
+          // every time another render param changes.
+          if (!dequal(renderStateWithoutFns, previousRenderStateRef.current)) {
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            setState(renderState);
+            previousRenderStateRef.current = renderStateWithoutFns;
+          }
         }
       },
       () => {

--- a/packages/react-instantsearch-hooks/src/lib/__tests__/dequal.test.ts
+++ b/packages/react-instantsearch-hooks/src/lib/__tests__/dequal.test.ts
@@ -1,0 +1,35 @@
+import { dequal } from '../dequal';
+
+describe('dequal', () => {
+  const areFunctions = (a: any, b: any): boolean =>
+    a?.constructor === Function && b?.constructor === Function;
+
+  test('without compare returns false for functions', () => {
+    expect(
+      dequal(
+        () => {},
+        () => {}
+      )
+    ).toEqual(false);
+  });
+
+  test('with a compare returns true for functions', () => {
+    expect(
+      dequal(
+        () => {},
+        () => {},
+        areFunctions
+      )
+    ).toEqual(true);
+  });
+
+  test('without compare returns false for nested functions', () => {
+    expect(dequal({ fn: () => {} }, { fn: () => {} })).toEqual(false);
+  });
+
+  test('with a compare returns true for nested functions', () => {
+    expect(dequal({ fn: () => {} }, { fn: () => {} }, areFunctions)).toEqual(
+      true
+    );
+  });
+});

--- a/packages/react-instantsearch-hooks/src/lib/dequal.ts
+++ b/packages/react-instantsearch-hooks/src/lib/dequal.ts
@@ -1,0 +1,54 @@
+/* eslint-disable complexity */
+
+/*
+ * Code taken from dequal/lite v2.0.0
+ * https://github.com/lukeed/dequal/blob/9aa73181ac7e081cd330cac67d313632ac04bb02/src/lite.js
+ *
+ * It adds a 3rd argument `compare(a, b)` that lets execute custom logic to
+ * compare values.
+ * We use it to skip comparing function references.
+ */
+
+const has = Object.prototype.hasOwnProperty;
+
+export function dequal(
+  foo: any,
+  bar: any,
+  compare?: (a: any, b: any) => boolean
+) {
+  // start of custom implementation
+  if (compare?.(foo, bar)) {
+    return true;
+  }
+  // end of custom implementation
+
+  let ctor;
+  let len;
+  if (foo === bar) return true;
+
+  if (foo && bar && (ctor = foo.constructor) === bar.constructor) {
+    if (ctor === Date) return foo.getTime() === bar.getTime();
+    if (ctor === RegExp) return foo.toString() === bar.toString();
+
+    if (ctor === Array) {
+      if ((len = foo.length) === bar.length) {
+        while (len-- && dequal(foo[len], bar[len], compare));
+      }
+      return len === -1;
+    }
+
+    if (!ctor || typeof foo === 'object') {
+      len = 0;
+      // eslint-disable-next-line guard-for-in, no-restricted-syntax
+      for (ctor in foo) {
+        if (has.call(foo, ctor) && ++len && !has.call(bar, ctor)) return false;
+        if (!(ctor in bar) || !dequal(foo[ctor], bar[ctor], compare))
+          return false;
+      }
+      return Object.keys(bar).length === len;
+    }
+  }
+
+  // eslint-disable-next-line no-self-compare
+  return foo !== foo && bar !== bar;
+}

--- a/packages/react-instantsearch-hooks/src/lib/useStableValue.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useStableValue.ts
@@ -1,5 +1,6 @@
-import { dequal } from 'dequal/lite';
 import { useEffect, useState } from 'react';
+
+import { dequal } from '../lib/dequal';
 
 export function useStableValue<TValue>(value: TValue) {
   const [stableValue, setStableValue] = useState<TValue>(() => value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12524,11 +12524,6 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
-dequal@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
-  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
-
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"


### PR DESCRIPTION
This optimizes when we update the React state in `useConnector()` to skip function reference changes in the render state. This lets us and users create unstable function references in `getWidgetRenderState()` (our own `connectSearchBox()` doesn't expose stable functions).

This **brings support for inline functions used in widgets**, like users are used to in RIS v6.

```jsx
function App(props) {
  const [favorites, setFavorites] = useState([]);

  return (
    <InstantSearch {...props}>
      <Hits
        hitComponent={Hit}
        transformItems={(hits) =>
          hits.map((hit) => ({
            ...hit,
            isFavorite: favorites.find((x) => x.objectID === hit.objectID),
          }))
        }
      />
    </InstantSearch>
  );
}
```

Prior to this change, **such an app would be prone to trigger an infinite loop**. Now, it triggers only two renders. In the future, we might be able to optimize it further to trigger a single render.

When using the Hook, users still need to stabilize their function references.

```jsx
function Search() {
  const [favorites, setFavorites] = useState([]);
  const transformItems = useCallback((items) => items, [favorites]);
  const { hits } = useHits({ transformItems });

  return <>{/* ... */}</>;
}

function App(props) {
  const [favorites, setFavorites] = useState([]);
  const transformItems = useCallback((items) => items, [favorites]);
  const { hits } = useHits({ transformItems });

  return (
    <InstantSearch {...props}>
      <Search />
    </InstantSearch>
  );
}
```