### PR TITLE
fix(numericmenu): include range values in comparison with minmax bounds

### DIFF
--- a/packages/react-instantsearch-core/src/connectors/__tests__/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/connectNumericMenu.js
@@ -268,6 +268,8 @@ describe('connectNumericMenu', () => {
             { label: '2', start: 400 },
             { label: '3', end: 200 },
             { label: '4', start: 100, end: 200 },
+            { label: '5', start: 300 },
+            { label: '6', start: 300, end: 300 },
           ],
           contextValue,
         },
@@ -282,6 +284,13 @@ describe('connectNumericMenu', () => {
           {
             label: '4',
             value: '100:200',
+            isRefined: false,
+            noRefinement: false,
+          },
+          { label: '5', value: '300:', isRefined: false, noRefinement: false },
+          {
+            label: '6',
+            value: '300:300',
             isRefined: false,
             noRefinement: false,
           },

--- a/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
+++ b/packages/react-instantsearch-core/src/connectors/connectNumericMenu.js
@@ -53,15 +53,15 @@ function getCurrentRefinement(props, searchState, context) {
 
 function isRefinementsRangeIncludesInsideItemRange(stats, start, end) {
   return (
-    (stats.min > start && stats.min < end) ||
-    (stats.max > start && stats.max < end)
+    (stats.min >= start && stats.min <= end) ||
+    (stats.max >= start && stats.max <= end)
   );
 }
 
 function isItemRangeIncludedInsideRefinementsRange(stats, start, end) {
   return (
-    (start > stats.min && start < stats.max) ||
-    (end > stats.min && end < stats.max)
+    (start >= stats.min && start <= stats.max) ||
+    (end >= stats.min && end <= stats.max)
   );
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR addresses an issue encountered by a customer, where an item on a `NumericMenu` having its `start` value set to the maximum value of a facet would wrongly be disabled in the widget.

Fixes [FX-1376](https://algolia.atlassian.net/browse/FX-1376).

**Result**

- The items are now correctly enabled/disabled
- Tests are updated to include these specific cases