### PR TITLE
feat(hooks-server): support import from React 18

### DIFF
--- a/packages/react-instantsearch-hooks-server/rollup.config.js
+++ b/packages/react-instantsearch-hooks-server/rollup.config.js
@@ -40,13 +40,14 @@ const plugins = [
 const createConfiguration = ({ name, minify = false } = {}) => ({
   input: 'src/index.ts',
   external: ['react', 'react-instantsearch-hooks'],
+  inlineDynamicImports: true,
   output: {
     file: `dist/umd/ReactInstantSearch${name}${minify ? '.min' : ''}.js`,
     name: `ReactInstantSearch${name}`,
     format: 'umd',
     globals: {
       react: 'React',
-      'react-dom': 'ReactDOM',
+      'react-dom/server.js': 'ReactDOM',
       'react-instantsearch-hooks': 'ReactInstantSearchHooks',
     },
     banner: createBanner(name),

--- a/packages/react-instantsearch-hooks-server/rollup.config.js
+++ b/packages/react-instantsearch-hooks-server/rollup.config.js
@@ -47,7 +47,7 @@ const createConfiguration = ({ name, minify = false } = {}) => ({
     format: 'umd',
     globals: {
       react: 'React',
-      'react-dom/server.js': 'ReactDOM',
+      'react-dom/server.js': 'ReactDOMServer',
       'react-instantsearch-hooks': 'ReactInstantSearchHooks',
     },
     banner: createBanner(name),

--- a/packages/react-instantsearch-hooks-server/rollup.config.js
+++ b/packages/react-instantsearch-hooks-server/rollup.config.js
@@ -39,7 +39,7 @@ const plugins = [
 
 const createConfiguration = ({ name, minify = false } = {}) => ({
   input: 'src/index.ts',
-  external: ['react', 'react-dom', 'react-instantsearch-hooks'],
+  external: ['react', 'react-instantsearch-hooks'],
   output: {
     file: `dist/umd/ReactInstantSearch${name}${minify ? '.min' : ''}.js`,
     name: `ReactInstantSearch${name}`,

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ */
+
+import React from 'react';
+import {
+  InstantSearch,
+  InstantSearchSSRProvider,
+  Index,
+  useHits,
+  useRefinementList,
+  useSearchBox,
+} from 'react-instantsearch-hooks';
+
+import { createSearchClient } from '../../../../test/mock';
+import { getServerState } from '../getServerState';
+
+import type {
+  InstantSearchServerState,
+  InstantSearchProps,
+  UseRefinementListProps,
+} from 'react-instantsearch-hooks';
+
+type CreateTestEnvironmentProps = {
+  searchClient: InstantSearchProps['searchClient'];
+  initialUiState?: InstantSearchProps['initialUiState'];
+};
+
+function createTestEnvironment({
+  searchClient,
+  initialUiState = {
+    instant_search: {
+      query: 'iphone',
+      refinementList: {
+        brand: ['Apple'],
+      },
+    },
+    instant_search_price_asc: {
+      query: 'iphone',
+      refinementList: {
+        brand: ['Apple'],
+      },
+    },
+  },
+}: CreateTestEnvironmentProps) {
+  function Search({ children }: { children?: React.ReactNode }) {
+    return (
+      <InstantSearch
+        searchClient={searchClient}
+        indexName="instant_search"
+        initialUiState={initialUiState}
+      >
+        {children}
+        <RefinementList attribute="brand" />
+        <SearchBox />
+        <Hits />
+
+        <Index indexName="instant_search_price_asc">
+          <Hits />
+
+          <Index indexName="instant_search_rating_desc">
+            <Hits />
+          </Index>
+        </Index>
+
+        <Index indexName="instant_search_price_desc">
+          <Hits />
+        </Index>
+      </InstantSearch>
+    );
+  }
+
+  function App({
+    serverState,
+    children,
+  }: {
+    serverState?: InstantSearchServerState;
+    children?: React.ReactNode;
+  }) {
+    return (
+      <InstantSearchSSRProvider {...serverState}>
+        <Search>{children}</Search>
+      </InstantSearchSSRProvider>
+    );
+  }
+
+  return {
+    App,
+  };
+}
+
+// Neither of the modules exist
+jest.mock(
+  'react-dom/server.js',
+  () => {
+    throw new Error('simulate the module not existing');
+  },
+  { virtual: true }
+);
+
+jest.mock(
+  'react-dom/server',
+  () => {
+    throw new Error('simulate the module not existing');
+  },
+  { virtual: true }
+);
+
+describe('react-dom imports', () => {
+  test('throws when no react-dom is present', async () => {
+    const searchClient = createSearchClient({});
+    const { App } = createTestEnvironment({ searchClient });
+
+    await expect(
+      getServerState(<App />)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Could not import ReactDOMServer."`
+    );
+  });
+});
+
+function SearchBox() {
+  useSearchBox();
+  return null;
+}
+
+function Hits() {
+  useHits();
+  return null;
+}
+
+function RefinementList(props: UseRefinementListProps) {
+  useRefinementList(props);
+  return null;
+}

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
@@ -106,8 +106,8 @@ jest.mock(
   { virtual: true }
 );
 
-describe('react-dom imports', () => {
-  test('throws when no react-dom is present', async () => {
+describe('ReactDOMServer imports', () => {
+  test('throws when no ReactDOMServer is present', async () => {
     const searchClient = createSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
 

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-with-extension.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-with-extension.test.tsx
@@ -89,7 +89,7 @@ function createTestEnvironment({
   };
 }
 
-// the module with extension exists
+// Only the module with extension exists
 jest.mock(
   'react-dom/server.js',
   () => {
@@ -106,8 +106,8 @@ jest.mock(
   { virtual: true }
 );
 
-describe('react-dom imports', () => {
-  test('works when one of the two imports exists (with extension)', async () => {
+describe('ReactDOMServer imports', () => {
+  test('works when the import with an extension exists', async () => {
     const searchClient = createSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
 

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-with-extension.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-with-extension.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ */
+
+import React from 'react';
+import {
+  InstantSearch,
+  InstantSearchSSRProvider,
+  Index,
+  useHits,
+  useRefinementList,
+  useSearchBox,
+} from 'react-instantsearch-hooks';
+
+import { createSearchClient } from '../../../../test/mock';
+import { getServerState } from '../getServerState';
+
+import type {
+  InstantSearchServerState,
+  InstantSearchProps,
+  UseRefinementListProps,
+} from 'react-instantsearch-hooks';
+
+type CreateTestEnvironmentProps = {
+  searchClient: InstantSearchProps['searchClient'];
+  initialUiState?: InstantSearchProps['initialUiState'];
+};
+
+function createTestEnvironment({
+  searchClient,
+  initialUiState = {
+    instant_search: {
+      query: 'iphone',
+      refinementList: {
+        brand: ['Apple'],
+      },
+    },
+    instant_search_price_asc: {
+      query: 'iphone',
+      refinementList: {
+        brand: ['Apple'],
+      },
+    },
+  },
+}: CreateTestEnvironmentProps) {
+  function Search({ children }: { children?: React.ReactNode }) {
+    return (
+      <InstantSearch
+        searchClient={searchClient}
+        indexName="instant_search"
+        initialUiState={initialUiState}
+      >
+        {children}
+        <RefinementList attribute="brand" />
+        <SearchBox />
+        <Hits />
+
+        <Index indexName="instant_search_price_asc">
+          <Hits />
+
+          <Index indexName="instant_search_rating_desc">
+            <Hits />
+          </Index>
+        </Index>
+
+        <Index indexName="instant_search_price_desc">
+          <Hits />
+        </Index>
+      </InstantSearch>
+    );
+  }
+
+  function App({
+    serverState,
+    children,
+  }: {
+    serverState?: InstantSearchServerState;
+    children?: React.ReactNode;
+  }) {
+    return (
+      <InstantSearchSSRProvider {...serverState}>
+        <Search>{children}</Search>
+      </InstantSearchSSRProvider>
+    );
+  }
+
+  return {
+    App,
+  };
+}
+
+// the module with extension exists
+jest.mock(
+  'react-dom/server.js',
+  () => {
+    return jest.requireActual('react-dom/server');
+  },
+  { virtual: true }
+);
+
+jest.mock(
+  'react-dom/server',
+  () => {
+    throw new Error('simulate the module not existing');
+  },
+  { virtual: true }
+);
+
+describe('react-dom imports', () => {
+  test('works when one of the two imports exists (with extension)', async () => {
+    const searchClient = createSearchClient({});
+    const { App } = createTestEnvironment({ searchClient });
+
+    const serverState = await getServerState(<App />);
+
+    expect(serverState.initialResults).toEqual(expect.any(Object));
+  });
+});
+
+function SearchBox() {
+  useSearchBox();
+  return null;
+}
+
+function Hits() {
+  useHits();
+  return null;
+}
+
+function RefinementList(props: UseRefinementListProps) {
+  useRefinementList(props);
+  return null;
+}

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-without-extension.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-without-extension.test.tsx
@@ -89,7 +89,7 @@ function createTestEnvironment({
   };
 }
 
-// the module without extension exists
+// Only the module without extension exists
 jest.mock(
   'react-dom/server.js',
   () => {
@@ -106,8 +106,8 @@ jest.mock(
   { virtual: true }
 );
 
-describe('react-dom imports', () => {
-  test('works when one of the two imports exists (no extension)', async () => {
+describe('ReactDOMServer imports', () => {
+  test('works when the import with no extension exists', async () => {
     const searchClient = createSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
 

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-without-extension.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-without-extension.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ */
+
+import React from 'react';
+import {
+  InstantSearch,
+  InstantSearchSSRProvider,
+  Index,
+  useHits,
+  useRefinementList,
+  useSearchBox,
+} from 'react-instantsearch-hooks';
+
+import { createSearchClient } from '../../../../test/mock';
+import { getServerState } from '../getServerState';
+
+import type {
+  InstantSearchServerState,
+  InstantSearchProps,
+  UseRefinementListProps,
+} from 'react-instantsearch-hooks';
+
+type CreateTestEnvironmentProps = {
+  searchClient: InstantSearchProps['searchClient'];
+  initialUiState?: InstantSearchProps['initialUiState'];
+};
+
+function createTestEnvironment({
+  searchClient,
+  initialUiState = {
+    instant_search: {
+      query: 'iphone',
+      refinementList: {
+        brand: ['Apple'],
+      },
+    },
+    instant_search_price_asc: {
+      query: 'iphone',
+      refinementList: {
+        brand: ['Apple'],
+      },
+    },
+  },
+}: CreateTestEnvironmentProps) {
+  function Search({ children }: { children?: React.ReactNode }) {
+    return (
+      <InstantSearch
+        searchClient={searchClient}
+        indexName="instant_search"
+        initialUiState={initialUiState}
+      >
+        {children}
+        <RefinementList attribute="brand" />
+        <SearchBox />
+        <Hits />
+
+        <Index indexName="instant_search_price_asc">
+          <Hits />
+
+          <Index indexName="instant_search_rating_desc">
+            <Hits />
+          </Index>
+        </Index>
+
+        <Index indexName="instant_search_price_desc">
+          <Hits />
+        </Index>
+      </InstantSearch>
+    );
+  }
+
+  function App({
+    serverState,
+    children,
+  }: {
+    serverState?: InstantSearchServerState;
+    children?: React.ReactNode;
+  }) {
+    return (
+      <InstantSearchSSRProvider {...serverState}>
+        <Search>{children}</Search>
+      </InstantSearchSSRProvider>
+    );
+  }
+
+  return {
+    App,
+  };
+}
+
+// the module without extension exists
+jest.mock(
+  'react-dom/server.js',
+  () => {
+    throw new Error('simulate the module not existing');
+  },
+  { virtual: true }
+);
+
+jest.mock(
+  'react-dom/server',
+  () => {
+    return jest.requireActual('react-dom/server');
+  },
+  { virtual: true }
+);
+
+describe('react-dom imports', () => {
+  test('works when one of the two imports exists (no extension)', async () => {
+    const searchClient = createSearchClient({});
+    const { App } = createTestEnvironment({ searchClient });
+
+    const serverState = await getServerState(<App />);
+
+    expect(serverState.initialResults).toEqual(expect.any(Object));
+  });
+});
+
+function SearchBox() {
+  useSearchBox();
+  return null;
+}
+
+function Hits() {
+  useHits();
+  return null;
+}
+
+function RefinementList(props: UseRefinementListProps) {
+  useRefinementList(props);
+  return null;
+}

--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -1,6 +1,5 @@
 import { isIndexWidget } from 'instantsearch.js/es/widgets/index/index';
 import React from 'react';
-import ReactDOM from 'react-dom/server';
 import {
   InstantSearchServerContext,
   InstantSearchSSRProvider,
@@ -9,10 +8,13 @@ import {
 import type { InitialResults, InstantSearch } from 'instantsearch.js';
 import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
 import type { ReactNode } from 'react';
+import type { renderToString as RenderToString } from 'react-dom/server';
 import type {
   InstantSearchServerContextApi,
   InstantSearchServerState,
 } from 'react-instantsearch-hooks';
+
+type SearchRef = { current: InstantSearch | undefined };
 
 /**
  * Returns the InstantSearch server state from a component.
@@ -20,7 +22,7 @@ import type {
 export function getServerState(
   children: ReactNode
 ): Promise<InstantSearchServerState> {
-  const searchRef: { current: InstantSearch | undefined } = {
+  const searchRef: SearchRef = {
     current: undefined,
   };
 
@@ -30,64 +32,110 @@ export function getServerState(
     searchRef.current = search;
   };
 
-  // eslint-disable-next-line no-shadow
-  function execute(children: ReactNode) {
-    ReactDOM.renderToString(
-      <InstantSearchServerContext.Provider value={{ notifyServer }}>
-        {children}
-      </InstantSearchServerContext.Provider>
-    );
-
-    // We wait for the component to mount so that `notifyServer()` is called.
-    return new Promise((resolve) => setTimeout(resolve, 0))
-      .then(() => {
-        // If `notifyServer()` is not called by then, it means that <InstantSearch>
-        // wasn't within the `children`.
-        // We decide to go with a strict behavior in that case; throwing. If users have
-        // some routes that don't mount the <InstantSearch> component, they would need
-        // to try/catch the `getServerState()` call.
-        // If this behavior turns out to be too strict for many users, we can decide
-        // to warn instead of throwing.
-        if (!searchRef.current) {
-          throw new Error(
-            "Unable to retrieve InstantSearch's server state in `getServerState()`. Did you mount the <InstantSearch> component?"
-          );
-        }
-
-        return waitForResults(searchRef.current);
-      })
-      .then(() => {
-        const initialResults = getInitialResults(searchRef.current!.mainIndex);
-
-        return {
-          initialResults,
-        };
-      });
-  }
-
-  return execute(children).then((serverState) => {
-    let shouldRefetch = false;
-
-    // <DynamicWidgets> requires another query to retrieve the dynamic widgets
-    // to render.
-    walkIndex(searchRef.current!.mainIndex, (index) => {
-      shouldRefetch =
-        shouldRefetch ||
-        index
-          .getWidgets()
-          .some((widget) => widget.$$type === 'ais.dynamicWidgets');
-    });
-
-    if (shouldRefetch) {
-      return execute(
-        <InstantSearchSSRProvider {...serverState}>
-          {children}
-        </InstantSearchSSRProvider>
+  return Promise.resolve()
+    .then(() => {
+      return Promise.all([
+        // React pre-18 doesn't use `exports` in package.json, requiring a fully resolved path
+        // Thus, only one of these imports is correct
+        // eslint-disable-next-line import/extensions
+        import('react-dom/server.js').catch(() => {}),
+        import('react-dom/server').catch(() => {}),
+      ]);
+    })
+    .then((imports) => {
+      const valid = imports.find(
+        (mod): mod is { renderToString: typeof RenderToString } =>
+          mod !== undefined
       );
-    }
 
-    return serverState;
-  });
+      if (!valid) {
+        throw new Error('Could not import ReactDOMServer');
+      }
+
+      return valid.renderToString;
+    })
+    .then((renderToString) => {
+      return execute({
+        children,
+        renderToString,
+        searchRef,
+        notifyServer,
+      }).then((serverState) => ({ serverState, renderToString }));
+    })
+    .then(({ renderToString, serverState }) => {
+      let shouldRefetch = false;
+
+      // <DynamicWidgets> requires another query to retrieve the dynamic widgets
+      // to render.
+      walkIndex(searchRef.current!.mainIndex, (index) => {
+        shouldRefetch =
+          shouldRefetch ||
+          index
+            .getWidgets()
+            .some((widget) => widget.$$type === 'ais.dynamicWidgets');
+      });
+
+      if (shouldRefetch) {
+        return execute({
+          children: (
+            <InstantSearchSSRProvider {...serverState}>
+              {children}
+            </InstantSearchSSRProvider>
+          ),
+          renderToString,
+          searchRef,
+          notifyServer,
+        });
+      }
+
+      return serverState;
+    });
+}
+
+type ExecuteArgs = {
+  children: ReactNode;
+  renderToString: typeof RenderToString;
+  notifyServer: InstantSearchServerContextApi['notifyServer'];
+  searchRef: SearchRef;
+};
+
+function execute({
+  children,
+  renderToString,
+  notifyServer,
+  searchRef,
+}: ExecuteArgs) {
+  renderToString(
+    <InstantSearchServerContext.Provider value={{ notifyServer }}>
+      {children}
+    </InstantSearchServerContext.Provider>
+  );
+
+  // We wait for the component to mount so that `notifyServer()` is called.
+  return new Promise((resolve) => setTimeout(resolve, 0))
+    .then(() => {
+      // If `notifyServer()` is not called by then, it means that <InstantSearch>
+      // wasn't within the `children`.
+      // We decide to go with a strict behavior in that case; throwing. If users have
+      // some routes that don't mount the <InstantSearch> component, they would need
+      // to try/catch the `getServerState()` call.
+      // If this behavior turns out to be too strict for many users, we can decide
+      // to warn instead of throwing.
+      if (!searchRef.current) {
+        throw new Error(
+          "Unable to retrieve InstantSearch's server state in `getServerState()`. Did you mount the <InstantSearch> component?"
+        );
+      }
+
+      return waitForResults(searchRef.current);
+    })
+    .then(() => {
+      const initialResults = getInitialResults(searchRef.current!.mainIndex);
+
+      return {
+        initialResults,
+      };
+    });
 }
 
 /**

--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -71,27 +71,6 @@ export function getServerState(
     });
 }
 
-function importRenderToString() {
-  return Promise.all([
-    // React pre-18 doesn't use `exports` in package.json, requiring a fully resolved path
-    // Thus, only one of these imports is correct
-    // eslint-disable-next-line import/extensions
-    import('react-dom/server.js').catch(() => {}),
-    import('react-dom/server').catch(() => {}),
-  ]).then((imports) => {
-    const valid = imports.find(
-      (mod): mod is { renderToString: typeof RenderToString } =>
-        mod !== undefined
-    );
-
-    if (!valid) {
-      throw new Error('Could not import ReactDOMServer');
-    }
-
-    return valid.renderToString;
-  });
-}
-
 type ExecuteArgs = {
   children: ReactNode;
   renderToString: typeof RenderToString;
@@ -200,4 +179,25 @@ function getInitialResults(rootIndex: IndexWidget): InitialResults {
   });
 
   return initialResults;
+}
+
+function importRenderToString() {
+  return Promise.all([
+    // React pre-18 doesn't use `exports` in package.json, requiring a fully resolved path
+    // Thus, only one of these imports is correct
+    // eslint-disable-next-line import/extensions
+    import('react-dom/server.js').catch(() => {}),
+    import('react-dom/server').catch(() => {}),
+  ]).then((imports) => {
+    const valid = imports.find(
+      (mod): mod is { renderToString: typeof RenderToString } =>
+        mod !== undefined
+    );
+
+    if (!valid) {
+      throw new Error('Could not import ReactDOMServer');
+    }
+
+    return valid.renderToString;
+  });
 }

--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -189,15 +189,15 @@ function importRenderToString() {
     import('react-dom/server.js').catch(() => {}),
     import('react-dom/server').catch(() => {}),
   ]).then((imports) => {
-    const valid = imports.find(
+    const ReactDOMServer = imports.find(
       (mod): mod is { renderToString: typeof RenderToString } =>
         mod !== undefined
     );
 
-    if (!valid) {
-      throw new Error('Could not import ReactDOMServer');
+    if (!ReactDOMServer) {
+      throw new Error('Could not import ReactDOMServer.');
     }
 
-    return valid.renderToString;
+    return ReactDOMServer.renderToString;
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNEXT",
-    "module": "es2015",
+    "module": "es2020",
     "moduleResolution": "node",
     "jsx": "preserve",
     "noEmit": true,


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Import both `react-dom/server.js` (react 16 and 17) and `react-dom/server` (react 18, since they added "exports" in package.json) dynamically to make sure server-side rendering works in all situations

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

fixes #3453
FX-1405

I don't see how this can be tested immediately, but we can add a react 18 next.js example later along the existing react 17 one, which would fail before this PR

We were slightly worried this may hurt TTFB, but in reality that doesn't seem to be the case, as evidenced by a quick benchmark (using https://github.com/mildsunrise/curl-benchmark) done:

```
Before the change:

              DNS      TCP        SSL  Request           Content
     Code  lookup  connect  handshake     sent    TTFB  download
     min:     9.0      0.0        0.0      0.0    52.0       0.0
     avg:    14.4      0.3        0.0      0.1    83.2       0.4
     med:    15.0      0.0        0.0      0.0    76.0       0.0
     max:    21.0      1.0        0.0      1.0   203.0       1.0
     dev:   23.2%   160.4%       0.0%   339.1%   35.3%    133.3%
           requests: 25    samples: 25    failures: 0

After the change:

              DNS      TCP        SSL  Request           Content
     Code  lookup  connect  handshake     sent    TTFB  download
     min:    10.0      0.0        0.0      0.0    44.0       0.0
     avg:    15.7      0.3        0.0      0.1    72.4       0.3
     med:    16.0      0.0        0.0      0.0    63.0       0.0
     max:    24.0      1.0        0.0      1.0   220.0       1.0
     dev:   23.0%   152.8%       0.0%   374.2%   51.6%    165.8%
           requests: 30    samples: 30    failures: 0 
```