### PR TITLE
feat(hooks): make InstantSearch type generic

### DIFF
--- a/packages/react-instantsearch-hooks/src/components/InstantSearch.tsx
+++ b/packages/react-instantsearch-hooks/src/components/InstantSearch.tsx
@@ -5,13 +5,20 @@ import { InstantSearchContext } from '../lib/InstantSearchContext';
 import { useInstantSearch } from '../lib/useInstantSearch';
 
 import type { UseInstantSearchProps } from '../lib/useInstantSearch';
+import type { UiState } from 'instantsearch.js';
 
-export type InstantSearchProps = UseInstantSearchProps & {
+export type InstantSearchProps<
+  TUiState extends UiState = UiState,
+  TRouteState = TUiState
+> = UseInstantSearchProps<TUiState, TRouteState> & {
   children?: React.ReactNode;
 };
 
-export function InstantSearch({ children, ...props }: InstantSearchProps) {
-  const search = useInstantSearch(props);
+export function InstantSearch<
+  TUiState extends UiState = UiState,
+  TRouteState = TUiState
+>({ children, ...props }: InstantSearchProps<TUiState, TRouteState>) {
+  const search = useInstantSearch<TUiState, TRouteState>(props);
 
   if (!search.started) {
     return null;

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearch.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearch.ts
@@ -10,7 +10,11 @@ import { useStableValue } from './useStableValue';
 
 import type { InstantSearchServerContextApi } from '../components/InstantSearchServerContext';
 import type { InstantSearchServerState } from '../components/InstantSearchSSRProvider';
-import type { InstantSearchOptions, SearchClient } from 'instantsearch.js';
+import type {
+  InstantSearchOptions,
+  SearchClient,
+  UiState,
+} from 'instantsearch.js';
 
 const defaultUserAgents = [
   `react (${ReactVersion})`,
@@ -18,9 +22,14 @@ const defaultUserAgents = [
   `react-instantsearch-hooks (${version})`,
 ];
 
-export type UseInstantSearchProps = InstantSearchOptions;
+export type UseInstantSearchProps<
+  TUiState extends UiState,
+  TRouteState
+> = InstantSearchOptions<TUiState, TRouteState>;
 
-export function useInstantSearch(props: UseInstantSearchProps) {
+export function useInstantSearch<TUiState extends UiState, TRouteState>(
+  props: UseInstantSearchProps<TUiState, TRouteState>
+) {
   const serverContext = useInstantSearchServerContext();
   const serverState = useInstantSearchSSRContext();
   const stableProps = useStableValue(props);
@@ -55,12 +64,12 @@ export function useInstantSearch(props: UseInstantSearchProps) {
   return search;
 }
 
-function serverAdapter(
+function serverAdapter<TUiState extends UiState, TRouteState>(
   search: InstantSearch,
-  props: UseInstantSearchProps,
+  props: UseInstantSearchProps<TUiState, TRouteState>,
   serverContext: InstantSearchServerContextApi | null,
   serverState: Partial<InstantSearchServerState> | null
-): InstantSearch {
+): InstantSearch<TUiState, TRouteState> {
   const initialResults = serverState?.initialResults;
 
   if (serverContext || initialResults) {

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
@@ -4,14 +4,20 @@ import { invariant } from '../lib/invariant';
 
 import { InstantSearchContext } from './InstantSearchContext';
 
-export function useInstantSearchContext() {
-  const context = useContext(InstantSearchContext);
+import type { InstantSearch, UiState } from 'instantsearch.js';
+
+export function useInstantSearchContext<
+  TUiState extends UiState,
+  TRouteState = TUiState
+>() {
+  const search = useContext(InstantSearchContext);
 
   invariant(
-    context !== null,
+    search !== null,
     'Hooks must be used inside the <InstantSearch> component.\n\n' +
       'They are not compatible with the `react-instantsearch-core` and `react-instantsearch-dom` packages, so make sure to use the <InstantSearch> component from `react-instantsearch-hooks`.'
   );
 
-  return context;
+  // React context can't be generic itself, so we need to cast here.
+  return search as InstantSearch<TUiState, TRouteState>;
 }


### PR DESCRIPTION
**Summary**

Similar to how InstantSearch is generic to allow for writing a correct state mapping, we make InstantSearch and its props generic.

All new generics are optional, as they are in InstantSearch.js

Note that the InstantSearchContext isn't generic, as a constant (even if it's a function) can't be generic, but useInstantSearchContext could be in a future PR

<details><summary>possible implementation of useInstantSearchContext</summary>

```tsx
import { useContext } from 'react';

import { invariant } from '../lib/invariant';

import { InstantSearchContext } from './InstantSearchContext';

import type { InstantSearch, UiState } from 'instantsearch.js';

export function useInstantSearchContext<
  TUiState extends UiState,
  TRouteState = TUiState
>() {
  const search = useContext(InstantSearchContext);

  invariant(
    search !== null,
    'Hooks must be used inside the <InstantSearch> component.\n\n' +
      'They are not compatible with the `react-instantsearch-core` and `react-instantsearch-dom` packages, so make sure to use the <InstantSearch> component from `react-instantsearch-hooks`.'
  );

  // React context can't be generic itself, so we need to cast here.
  return search as InstantSearch<TUiState, TRouteState>;
}
```

</details>

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->



<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

InstantSearch, InstantSearchProps, useInstantSearch (private) and UseInstantSearchProps (private) now are generic, to mirror InstantSearch.js
