### PR TITLE
feat(dom-maps): expose GeoSearchContext

### DIFF
--- a/packages/react-instantsearch-dom-maps/src/index.js
+++ b/packages/react-instantsearch-dom-maps/src/index.js
@@ -1,7 +1,8 @@
-export { default as GoogleMapsLoader } from './GoogleMapsLoader';
 export { default as GeoSearch } from './GeoSearch';
 export { default as Marker } from './Marker';
 export { default as CustomMarker } from './CustomMarker';
 export { default as Redo } from './Redo';
 export { default as Control } from './Control';
+export { default as GeoSearchContext } from './GeoSearchContext';
+export { default as GoogleMapsLoader } from './GoogleMapsLoader';
 export { default as withGoogleMaps } from './withGoogleMaps';


### PR DESCRIPTION
**Summary**

To allow a custom control for "refine on map move" to be made without resorting to importing from the individual files, which is hard/not recommended, we need to expose the GeoSearchContext

**Result**

fixes #3448

GeoSearchContext is exposed