### PR TITLE
chore(hooks-web): provide type consistency in ui components and widgets

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/ui/Breadcrumb.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/Breadcrumb.tsx
@@ -47,7 +47,7 @@ type UseBreadcrumbRenderState = ReturnType<typeof useBreadcrumb>;
 
 type BreadcrumbItem = UseBreadcrumbRenderState['items'][number];
 
-export type BreadcrumbProps = React.HTMLAttributes<HTMLDivElement> &
+export type BreadcrumbProps = React.ComponentProps<'div'> &
   Pick<UseBreadcrumbRenderState, 'items' | 'createURL'> & {
     classNames?: Partial<BreadcrumbClassNames>;
     hasItems: boolean;

--- a/packages/react-instantsearch-hooks-web/src/ui/ClearRefinements.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/ClearRefinements.tsx
@@ -9,11 +9,8 @@ export type ClearRefinementsTranslations = {
   resetLabel: string;
 };
 
-export type ClearRefinementsProps = React.HTMLAttributes<HTMLDivElement> &
-  Pick<
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    'disabled' | 'onClick'
-  > & {
+export type ClearRefinementsProps = React.ComponentProps<'div'> &
+  Pick<React.ComponentProps<'button'>, 'disabled' | 'onClick'> & {
     translations: ClearRefinementsTranslations;
     classNames?: Partial<ClearRefinementsClassNames>;
   };

--- a/packages/react-instantsearch-hooks-web/src/ui/CurrentRefinements.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/CurrentRefinements.tsx
@@ -8,7 +8,7 @@ import type {
   CurrentRefinementsConnectorParamsRefinement,
 } from 'instantsearch.js/es/connectors/current-refinements/connectCurrentRefinements';
 
-export type CurrentRefinementsProps = React.HTMLAttributes<HTMLDivElement> & {
+export type CurrentRefinementsProps = React.ComponentProps<'div'> & {
   classNames?: Partial<CurrentRefinementsClassNames>;
   items?: Array<
     Pick<CurrentRefinementsConnectorParamsItem, 'label' | 'refinements'> &

--- a/packages/react-instantsearch-hooks-web/src/ui/HierarchicalMenu.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/HierarchicalMenu.tsx
@@ -66,7 +66,7 @@ type HierarchicalListProps = Pick<
   onNavigate: (value: string) => void;
 };
 
-export type HierarchicalMenuProps = React.HTMLAttributes<HTMLDivElement> &
+export type HierarchicalMenuProps = React.ComponentProps<'div'> &
   HierarchicalListProps & {
     hasItems: boolean;
     showMore?: boolean;

--- a/packages/react-instantsearch-hooks-web/src/ui/Hits.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/Hits.tsx
@@ -4,7 +4,7 @@ import { cx } from './lib/cx';
 
 import type { Hit } from 'instantsearch.js';
 
-export type HitsProps<THit> = React.HTMLAttributes<HTMLDivElement> & {
+export type HitsProps<THit> = React.ComponentProps<'div'> & {
   hits: THit[];
   hitComponent?: React.JSXElementConstructor<{ hit: THit }>;
   classNames?: Partial<HitsClassNames>;

--- a/packages/react-instantsearch-hooks-web/src/ui/HitsPerPage.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/HitsPerPage.tsx
@@ -4,10 +4,7 @@ import { cx } from './lib/cx';
 
 import type { HitsPerPageConnectorParamsItem as HitsPerPageItem } from 'instantsearch.js/es/connectors/hits-per-page/connectHitsPerPage';
 
-export type HitsPerPageProps = Omit<
-  React.HTMLAttributes<HTMLDivElement>,
-  'onChange'
-> & {
+export type HitsPerPageProps = Omit<React.ComponentProps<'div'>, 'onChange'> & {
   items: HitsPerPageItem[];
   onChange: (value: number) => void;
   currentValue: number;

--- a/packages/react-instantsearch-hooks-web/src/ui/HitsPerPage.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/HitsPerPage.tsx
@@ -4,7 +4,10 @@ import { cx } from './lib/cx';
 
 import type { HitsPerPageConnectorParamsItem as HitsPerPageItem } from 'instantsearch.js/es/connectors/hits-per-page/connectHitsPerPage';
 
-export type HitsPerPageProps = React.HTMLAttributes<HTMLDivElement> & {
+export type HitsPerPageProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onChange'
+> & {
   items: HitsPerPageItem[];
   onChange: (value: number) => void;
   currentValue: number;

--- a/packages/react-instantsearch-hooks-web/src/ui/InternalHighlight.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/InternalHighlight.tsx
@@ -54,7 +54,7 @@ export type InternalHighlightClassNames = {
   separator: string;
 };
 
-export type InternalHighlightProps = React.HTMLAttributes<HTMLSpanElement> & {
+export type InternalHighlightProps = React.ComponentProps<'span'> & {
   classNames: InternalHighlightClassNames;
   highlightedTagName?: React.ReactType;
   nonHighlightedTagName?: React.ReactType;

--- a/packages/react-instantsearch-hooks-web/src/ui/Menu.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/Menu.tsx
@@ -6,7 +6,7 @@ import { ShowMoreButton } from './ShowMoreButton';
 import type { CreateURL } from 'instantsearch.js';
 import type { MenuItem } from 'instantsearch.js/es/connectors/menu/connectMenu';
 
-export type MenuProps = React.HTMLAttributes<HTMLDivElement> & {
+export type MenuProps = React.ComponentProps<'div'> & {
   items: MenuItem[];
   classNames?: Partial<MenuCSSClasses>;
   showMore?: boolean;

--- a/packages/react-instantsearch-hooks-web/src/ui/Pagination.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/Pagination.tsx
@@ -48,7 +48,7 @@ export type PaginationTranslations = {
   ariaPage(currentPage: number): string;
 };
 
-export type PaginationProps = React.HTMLAttributes<HTMLDivElement> & {
+export type PaginationProps = React.ComponentProps<'div'> & {
   classNames?: Partial<PaginationClassNames>;
   pages: number[];
   currentPage: number;
@@ -232,13 +232,8 @@ export function Pagination({
   );
 }
 
-type PaginationItemProps = Omit<
-  React.AnchorHTMLAttributes<HTMLAnchorElement>,
-  'onClick'
-> & {
-  onClick: NonNullable<
-    React.AnchorHTMLAttributes<HTMLAnchorElement>['onClick']
-  >;
+type PaginationItemProps = Omit<React.ComponentProps<'a'>, 'onClick'> & {
+  onClick: NonNullable<React.ComponentProps<'a'>['onClick']>;
   isDisabled: boolean;
   classNames: Partial<PaginationClassNames>;
 };

--- a/packages/react-instantsearch-hooks-web/src/ui/PoweredBy.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/PoweredBy.tsx
@@ -25,7 +25,7 @@ export type PoweredByClassNames = {
   logo: string;
 };
 
-export type PoweredByProps = React.HTMLAttributes<HTMLDivElement> & {
+export type PoweredByProps = React.ComponentProps<'div'> & {
   classNames?: Partial<PoweredByClassNames>;
   url: string;
   theme?: 'light' | 'dark';

--- a/packages/react-instantsearch-hooks-web/src/ui/RangeInput.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/RangeInput.tsx
@@ -6,10 +6,7 @@ import type { useRange } from 'react-instantsearch-hooks';
 
 type RangeRenderState = ReturnType<typeof useRange>;
 
-export type RangeInputProps = Omit<
-  React.HTMLAttributes<HTMLDivElement>,
-  'onSubmit'
-> &
+export type RangeInputProps = Omit<React.ComponentProps<'div'>, 'onSubmit'> &
   Pick<RangeRenderState, 'range' | 'start'> & {
     classNames?: Partial<RangeInputClassNames>;
     disabled: boolean;

--- a/packages/react-instantsearch-hooks-web/src/ui/RefinementList.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/RefinementList.tsx
@@ -7,7 +7,7 @@ import { ShowMoreButton } from './ShowMoreButton';
 
 import type { RefinementListItem } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 
-export type RefinementListProps = React.HTMLAttributes<HTMLDivElement> & {
+export type RefinementListProps = React.ComponentProps<'div'> & {
   canRefine: boolean;
   items: RefinementListItem[];
   onRefine(item: RefinementListItem): void;

--- a/packages/react-instantsearch-hooks-web/src/ui/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/SearchBox.tsx
@@ -57,15 +57,12 @@ export type SearchBoxTranslations = {
 };
 
 export type SearchBoxProps = Omit<
-  React.HTMLAttributes<HTMLDivElement>,
+  React.ComponentProps<'div'>,
   'onSubmit' | 'onReset' | 'onChange'
 > &
-  Pick<React.HTMLAttributes<HTMLFormElement>, 'onSubmit'> &
-  Required<Pick<React.HTMLAttributes<HTMLFormElement>, 'onReset'>> &
-  Pick<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    'placeholder' | 'onChange'
-  > & {
+  Pick<React.ComponentProps<'form'>, 'onSubmit'> &
+  Required<Pick<React.ComponentProps<'form'>, 'onReset'>> &
+  Pick<React.ComponentProps<'input'>, 'placeholder' | 'onChange'> & {
     inputRef: React.RefObject<HTMLInputElement>;
     isSearchStalled: boolean;
     value: string;

--- a/packages/react-instantsearch-hooks-web/src/ui/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/SearchBox.tsx
@@ -56,7 +56,10 @@ export type SearchBoxTranslations = {
   resetTitle: string;
 };
 
-export type SearchBoxProps = React.HTMLAttributes<HTMLDivElement> &
+export type SearchBoxProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onSubmit' | 'onReset' | 'onChange'
+> &
   Pick<React.HTMLAttributes<HTMLFormElement>, 'onSubmit'> &
   Required<Pick<React.HTMLAttributes<HTMLFormElement>, 'onReset'>> &
   Pick<

--- a/packages/react-instantsearch-hooks-web/src/ui/ShowMoreButton.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/ShowMoreButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-type ShowMoreButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+type ShowMoreButtonProps = React.ComponentProps<'button'> & {
   isShowingMore: boolean;
 };
 

--- a/packages/react-instantsearch-hooks-web/src/ui/SortBy.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/SortBy.tsx
@@ -4,12 +4,9 @@ import { cx } from './lib/cx';
 
 import type { UseSortByProps } from 'react-instantsearch-hooks';
 
-export type SortByProps = Omit<
-  React.HTMLAttributes<HTMLDivElement>,
-  'onChange'
-> &
+export type SortByProps = Omit<React.ComponentProps<'div'>, 'onChange'> &
   Pick<UseSortByProps, 'items'> &
-  Pick<React.SelectHTMLAttributes<HTMLSelectElement>, 'value'> & {
+  Pick<React.ComponentProps<'select'>, 'value'> & {
     onChange?(value: string): void;
     classNames?: Partial<SortByClassNames>;
   };

--- a/packages/react-instantsearch-hooks-web/src/ui/ToggleRefinement.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/ToggleRefinement.tsx
@@ -22,10 +22,10 @@ export type ToggleRefinementClassNames = {
 };
 
 export type ToggleRefinementProps = Omit<
-  React.HTMLAttributes<HTMLDivElement>,
+  React.ComponentProps<'div'>,
   'onChange'
 > &
-  Pick<React.InputHTMLAttributes<HTMLInputElement>, 'checked'> & {
+  Pick<React.ComponentProps<'input'>, 'checked'> & {
     classNames?: Partial<ToggleRefinementClassNames>;
     onChange(isChecked: boolean): void;
     label: string;

--- a/packages/react-instantsearch-hooks-web/src/widgets/Breadcrumb.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Breadcrumb.tsx
@@ -6,10 +6,12 @@ import { Breadcrumb as BreadcrumbUiComponent } from '../ui/Breadcrumb';
 import type { BreadcrumbProps as BreadcrumbUiProps } from '../ui/Breadcrumb';
 import type { UseBreadcrumbProps } from 'react-instantsearch-hooks';
 
-export type BreadcrumbProps = Omit<
+type UiProps = Pick<
   BreadcrumbUiProps,
   'items' | 'hasItems' | 'createURL' | 'onNavigate' | 'translations'
-> &
+>;
+
+export type BreadcrumbProps = Omit<BreadcrumbUiProps, keyof UiProps> &
   Omit<UseBreadcrumbProps, 'separator'>;
 
 export function Breadcrumb({
@@ -28,17 +30,15 @@ export function Breadcrumb({
     { $$widgetType: 'ais.breadcrumb' }
   );
 
-  return (
-    <BreadcrumbUiComponent
-      {...props}
-      createURL={createURL}
-      items={items}
-      hasItems={canRefine}
-      onNavigate={refine}
-      separator={separator}
-      translations={{
-        root: 'Home',
-      }}
-    />
-  );
+  const uiProps: UiProps = {
+    items,
+    hasItems: canRefine,
+    createURL,
+    onNavigate: refine,
+    translations: {
+      root: 'Home',
+    },
+  };
+
+  return <BreadcrumbUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/ClearRefinements.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/ClearRefinements.tsx
@@ -6,9 +6,14 @@ import { ClearRefinements as ClearRefinementsUiComponent } from '../ui/ClearRefi
 import type { ClearRefinementsProps as ClearRefinementsUiComponentProps } from '../ui/ClearRefinements';
 import type { UseClearRefinementsProps } from 'react-instantsearch-hooks';
 
-export type ClearRefinementsProps = Omit<
+type UiProps = Pick<
   ClearRefinementsUiComponentProps,
   'disabled' | 'onClick' | 'translations'
+>;
+
+export type ClearRefinementsProps = Omit<
+  ClearRefinementsUiComponentProps,
+  keyof UiProps
 > &
   UseClearRefinementsProps;
 
@@ -29,14 +34,13 @@ export function ClearRefinements({
     }
   );
 
-  return (
-    <ClearRefinementsUiComponent
-      {...props}
-      translations={{
-        resetLabel: 'Clear refinements',
-      }}
-      onClick={refine}
-      disabled={!canRefine}
-    />
-  );
+  const uiProps: UiProps = {
+    onClick: refine,
+    disabled: !canRefine,
+    translations: {
+      resetLabel: 'Clear refinements',
+    },
+  };
+
+  return <ClearRefinementsUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/CurrentRefinements.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/CurrentRefinements.tsx
@@ -6,9 +6,14 @@ import { CurrentRefinements as CurrentRefinementsUiComponent } from '../ui/Curre
 import type { CurrentRefinementsProps as CurrentRefinementsUiComponentProps } from '../ui/CurrentRefinements';
 import type { UseCurrentRefinementsProps } from 'react-instantsearch-hooks';
 
+type UiProps = Pick<
+  CurrentRefinementsUiComponentProps,
+  'items' | 'onRemove' | 'hasRefinements'
+>;
+
 export type CurrentRefinementsProps = Omit<
   CurrentRefinementsUiComponentProps,
-  'disabled' | 'onClick' | 'items' | 'hasRefinements'
+  keyof UiProps
 > &
   UseCurrentRefinementsProps;
 
@@ -29,12 +34,11 @@ export function CurrentRefinements({
     }
   );
 
-  return (
-    <CurrentRefinementsUiComponent
-      {...props}
-      hasRefinements={canRefine}
-      items={items}
-      onRemove={refine}
-    />
-  );
+  const uiProps: UiProps = {
+    items,
+    onRemove: refine,
+    hasRefinements: canRefine,
+  };
+
+  return <CurrentRefinementsUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/HierarchicalMenu.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/HierarchicalMenu.tsx
@@ -6,7 +6,7 @@ import { HierarchicalMenu as HierarchicalMenuUiComponent } from '../ui/Hierarchi
 import type { HierarchicalMenuProps as HierarchicalMenuUiComponentProps } from '../ui/HierarchicalMenu';
 import type { UseHierarchicalMenuProps } from 'react-instantsearch-hooks';
 
-export type HierarchicalMenuProps = Omit<
+type UiProps = Pick<
   HierarchicalMenuUiComponentProps,
   | 'items'
   | 'createURL'
@@ -15,6 +15,11 @@ export type HierarchicalMenuProps = Omit<
   | 'canToggleShowMore'
   | 'onToggleShowMore'
   | 'isShowingMore'
+>;
+
+export type HierarchicalMenuProps = Omit<
+  HierarchicalMenuUiComponentProps,
+  keyof UiProps
 > &
   UseHierarchicalMenuProps;
 
@@ -55,17 +60,17 @@ export function HierarchicalMenu({
     }
   );
 
+  const uiProps: UiProps = {
+    items,
+    hasItems: canRefine,
+    createURL,
+    onNavigate: refine,
+    canToggleShowMore,
+    onToggleShowMore: toggleShowMore,
+    isShowingMore,
+  };
+
   return (
-    <HierarchicalMenuUiComponent
-      {...props}
-      items={items}
-      hasItems={canRefine}
-      createURL={createURL}
-      onNavigate={refine}
-      showMore={showMore}
-      canToggleShowMore={canToggleShowMore}
-      onToggleShowMore={toggleShowMore}
-      isShowingMore={isShowingMore}
-    />
+    <HierarchicalMenuUiComponent {...props} {...uiProps} showMore={showMore} />
   );
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/Hits.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Hits.tsx
@@ -7,14 +7,23 @@ import type { HitsProps as HitsUiComponentProps } from '../ui/Hits';
 import type { Hit, BaseHit } from 'instantsearch.js';
 import type { UseHitsProps } from 'react-instantsearch-hooks';
 
-export type HitsProps<THit extends BaseHit> = Omit<
+type UiProps<THit extends BaseHit> = Pick<
   HitsUiComponentProps<Hit<THit>>,
   'hits'
+>;
+
+export type HitsProps<THit extends BaseHit> = Omit<
+  HitsUiComponentProps<Hit<THit>>,
+  keyof UiProps<THit>
 > &
   UseHitsProps<THit>;
 
 export function Hits<THit extends BaseHit = BaseHit>(props: HitsProps<THit>) {
   const { hits } = useHits<THit>(props, { $$widgetType: 'ais.hits' });
 
-  return <HitsUiComponent {...props} hits={hits} />;
+  const uiProps: UiProps<THit> = {
+    hits,
+  };
+
+  return <HitsUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/HitsPerPage.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/HitsPerPage.tsx
@@ -6,9 +6,14 @@ import { HitsPerPage as HitsPerPageUiComponent } from '../ui/HitsPerPage';
 import type { HitsPerPageProps as HitsPerPageUiComponentProps } from '../ui/HitsPerPage';
 import type { UseHitsPerPageProps } from 'react-instantsearch-hooks';
 
-export type HitsPerPageProps = Omit<
+type UiProps = Pick<
   HitsPerPageUiComponentProps,
   'items' | 'onChange' | 'currentValue'
+>;
+
+export type HitsPerPageProps = Omit<
+  HitsPerPageUiComponentProps,
+  keyof UiProps
 > &
   UseHitsPerPageProps;
 
@@ -19,14 +24,11 @@ export function HitsPerPage(props: HitsPerPageProps) {
   const { value: currentValue } =
     items.find(({ isRefined }) => isRefined)! || {};
 
-  return (
-    <HitsPerPageUiComponent
-      {...props}
-      items={items}
-      currentValue={currentValue}
-      onChange={(value) => {
-        refine(value);
-      }}
-    />
-  );
+  const uiProps: UiProps = {
+    items,
+    currentValue,
+    onChange: (value) => refine(value),
+  };
+
+  return <HitsPerPageUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/InfiniteHits.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/InfiniteHits.tsx
@@ -7,7 +7,7 @@ import type { InfiniteHitsProps as InfiniteHitsUiComponentProps } from '../ui/In
 import type { BaseHit, Hit } from 'instantsearch.js';
 import type { UseInfiniteHitsProps } from 'react-instantsearch-hooks';
 
-export type InfiniteHitsProps<THit extends BaseHit = BaseHit> = Omit<
+type UiProps<THit extends BaseHit = BaseHit> = Pick<
   InfiniteHitsUiComponentProps<Hit<THit>>,
   | 'hits'
   | 'onShowPrevious'
@@ -15,6 +15,11 @@ export type InfiniteHitsProps<THit extends BaseHit = BaseHit> = Omit<
   | 'isFirstPage'
   | 'isLastPage'
   | 'translations'
+>;
+
+export type InfiniteHitsProps<THit extends BaseHit = BaseHit> = Omit<
+  InfiniteHitsUiComponentProps<Hit<THit>>,
+  keyof UiProps<THit>
 > &
   UseInfiniteHitsProps<THit> & {
     /**
@@ -32,18 +37,17 @@ export function InfiniteHits<THit extends BaseHit = BaseHit>({
   const { hits, showPrevious, showMore, isFirstPage, isLastPage } =
     useInfiniteHits<THit>(props, { $$widgetType: 'ais.infiniteHits' });
 
-  return (
-    <InfiniteHitsUiComponent
-      {...props}
-      translations={{
-        showPrevious: 'Show previous results',
-        showMore: 'Show more results',
-      }}
-      hits={hits}
-      onShowPrevious={shouldShowPrevious ? showPrevious : undefined}
-      onShowMore={showMore}
-      isFirstPage={isFirstPage}
-      isLastPage={isLastPage}
-    />
-  );
+  const uiProps: UiProps<THit> = {
+    hits,
+    onShowPrevious: shouldShowPrevious ? showPrevious : undefined,
+    onShowMore: showMore,
+    isFirstPage,
+    isLastPage,
+    translations: {
+      showPrevious: 'Show previous results',
+      showMore: 'Show more results',
+    },
+  };
+
+  return <InfiniteHitsUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/Menu.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Menu.tsx
@@ -6,16 +6,17 @@ import { Menu as MenuUiComponent } from '../ui/Menu';
 import type { MenuProps as MenuUiComponentProps } from '../ui/Menu';
 import type { UseMenuProps } from 'react-instantsearch-hooks';
 
-export type MenuProps = Omit<
+type UiProps = Pick<
   MenuUiComponentProps,
   | 'items'
   | 'onRefine'
   | 'createURL'
-  | 'noResults'
   | 'canToggleShowMore'
   | 'onToggleShowMore'
   | 'isShowingMore'
-> &
+>;
+
+export type MenuProps = Omit<MenuUiComponentProps, keyof UiProps> &
   UseMenuProps;
 
 export function Menu({
@@ -48,18 +49,14 @@ export function Menu({
     }
   );
 
-  return (
-    <MenuUiComponent
-      {...props}
-      items={items}
-      createURL={createURL}
-      onRefine={(item) => {
-        refine(item.value);
-      }}
-      showMore={showMore}
-      canToggleShowMore={canToggleShowMore}
-      onToggleShowMore={toggleShowMore}
-      isShowingMore={isShowingMore}
-    />
-  );
+  const uiProps: UiProps = {
+    items,
+    createURL,
+    onRefine: (item) => refine(item.value),
+    canToggleShowMore,
+    onToggleShowMore: toggleShowMore,
+    isShowingMore,
+  };
+
+  return <MenuUiComponent {...props} {...uiProps} showMore={showMore} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/Pagination.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Pagination.tsx
@@ -6,7 +6,7 @@ import { Pagination as PaginationUiComponent } from '../ui/Pagination';
 import type { PaginationProps as PaginationUiComponentProps } from '../ui/Pagination';
 import type { UsePaginationProps } from 'react-instantsearch-hooks';
 
-export type PaginationProps = Omit<
+type UiProps = Pick<
   PaginationUiComponentProps,
   | 'pages'
   | 'currentPage'
@@ -16,7 +16,9 @@ export type PaginationProps = Omit<
   | 'createURL'
   | 'onNavigate'
   | 'translations'
-> &
+>;
+
+export type PaginationProps = Omit<PaginationUiComponentProps, keyof UiProps> &
   UsePaginationProps;
 
 export function Pagination({
@@ -43,32 +45,36 @@ export function Pagination({
     }
   );
 
+  const uiProps: UiProps = {
+    pages,
+    currentPage: currentRefinement,
+    isFirstPage,
+    isLastPage,
+    nbPages,
+    createURL,
+    onNavigate: refine,
+    translations: {
+      first: '‹‹',
+      previous: '‹',
+      next: '›',
+      last: '››',
+      page: (currentPage: number) => String(currentPage),
+      ariaFirst: 'First',
+      ariaPrevious: 'Previous',
+      ariaNext: 'Next',
+      ariaLast: 'Last',
+      ariaPage: (currentPage: number) => `Page ${currentPage}`,
+    },
+  };
+
   return (
     <PaginationUiComponent
       {...props}
-      translations={{
-        first: '‹‹',
-        previous: '‹',
-        next: '›',
-        last: '››',
-        page: (currentPage: number) => String(currentPage),
-        ariaFirst: 'First',
-        ariaPrevious: 'Previous',
-        ariaNext: 'Next',
-        ariaLast: 'Last',
-        ariaPage: (currentPage: number) => `Page ${currentPage}`,
-      }}
+      {...uiProps}
       showFirst={showFirst}
       showPrevious={showPrevious}
       showNext={showNext}
       showLast={showLast}
-      isFirstPage={isFirstPage}
-      isLastPage={isLastPage}
-      currentPage={currentRefinement}
-      nbPages={nbPages}
-      createURL={createURL}
-      onNavigate={refine}
-      pages={pages}
     />
   );
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/PoweredBy.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/PoweredBy.tsx
@@ -5,10 +5,16 @@ import { PoweredBy as PoweredByUiComponent } from '../ui/PoweredBy';
 
 import type { PoweredByProps as PoweredByUiComponentProps } from '../ui/PoweredBy';
 
-export type PoweredByProps = Omit<PoweredByUiComponentProps, 'url'>;
+type UiProps = Pick<PoweredByUiComponentProps, 'url'>;
+
+export type PoweredByProps = Omit<PoweredByUiComponentProps, keyof UiProps>;
 
 export function PoweredBy(props: PoweredByProps) {
   const { url } = usePoweredBy();
 
-  return <PoweredByUiComponent {...props} url={url} />;
+  const uiProps: UiProps = {
+    url,
+  };
+
+  return <PoweredByUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/RangeInput.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/RangeInput.tsx
@@ -6,10 +6,12 @@ import { RangeInput as RangeInputUiComponent } from '../ui/RangeInput';
 import type { RangeInputProps as RangeInputUiProps } from '../ui/RangeInput';
 import type { UseRangeProps } from 'react-instantsearch-hooks';
 
-export type RangeInputProps = Omit<
+type UiProps = Pick<
   RangeInputUiProps,
   'disabled' | 'onSubmit' | 'range' | 'start' | 'step' | 'translations'
-> &
+>;
+
+export type RangeInputProps = Omit<RangeInputUiProps, keyof UiProps> &
   UseRangeProps;
 
 export function RangeInput({
@@ -26,15 +28,17 @@ export function RangeInput({
 
   const step = 1 / Math.pow(10, precision || 0);
 
-  return (
-    <RangeInputUiComponent
-      {...props}
-      range={range}
-      start={start}
-      step={step}
-      disabled={!canRefine}
-      onSubmit={refine}
-      translations={{ separator: 'to', submit: 'Go' }}
-    />
-  );
+  const uiProps: UiProps = {
+    range,
+    start,
+    step,
+    disabled: !canRefine,
+    onSubmit: refine,
+    translations: {
+      separator: 'to',
+      submit: 'Go',
+    },
+  };
+
+  return <RangeInputUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/RefinementList.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/RefinementList.tsx
@@ -9,7 +9,7 @@ import type { RefinementListItem } from 'instantsearch.js/es/connectors/refineme
 import type { RefinementListWidgetParams } from 'instantsearch.js/es/widgets/refinement-list/refinement-list';
 import type { UseRefinementListProps } from 'react-instantsearch-hooks';
 
-export type RefinementListProps = Omit<
+type UiProps = Pick<
   RefinementListUiComponentProps,
   | 'canRefine'
   | 'items'
@@ -20,6 +20,11 @@ export type RefinementListProps = Omit<
   | 'canToggleShowMore'
   | 'onToggleShowMore'
   | 'isShowingMore'
+>;
+
+export type RefinementListProps = Omit<
+  RefinementListUiComponentProps,
+  keyof UiProps
 > &
   UseRefinementListProps &
   Pick<RefinementListWidgetParams, 'searchable' | 'searchablePlaceholder'>;
@@ -92,37 +97,34 @@ export function RefinementList({
     }
   }
 
+  const uiProps: UiProps = {
+    items,
+    canRefine,
+    onRefine,
+    query,
+    searchBox: searchable && (
+      <SearchBoxUiComponent
+        inputRef={inputRef}
+        placeholder={searchablePlaceholder}
+        isSearchStalled={false}
+        value={query}
+        onChange={onChange}
+        onReset={onReset}
+        onSubmit={onSubmit}
+        translations={{
+          submitTitle: 'Submit the search query.',
+          resetTitle: 'Clear the search query.',
+        }}
+      />
+    ),
+    noResults:
+      searchable && isFromSearch && items.length === 0 && 'No results.',
+    canToggleShowMore,
+    onToggleShowMore: toggleShowMore,
+    isShowingMore,
+  };
+
   return (
-    <RefinementListUiComponent
-      {...props}
-      canRefine={canRefine}
-      items={items}
-      onRefine={onRefine}
-      query={query}
-      searchBox={
-        searchable && (
-          <SearchBoxUiComponent
-            inputRef={inputRef}
-            placeholder={searchablePlaceholder}
-            isSearchStalled={false}
-            value={query}
-            onChange={onChange}
-            onReset={onReset}
-            onSubmit={onSubmit}
-            translations={{
-              submitTitle: 'Submit the search query.',
-              resetTitle: 'Clear the search query.',
-            }}
-          />
-        )
-      }
-      noResults={
-        searchable && isFromSearch && items.length === 0 && 'No results.'
-      }
-      showMore={showMore}
-      canToggleShowMore={canToggleShowMore}
-      onToggleShowMore={toggleShowMore}
-      isShowingMore={isShowingMore}
-    />
+    <RefinementListUiComponent {...props} {...uiProps} showMore={showMore} />
   );
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -6,7 +6,7 @@ import { SearchBox as SearchBoxUiComponent } from '../ui/SearchBox';
 import type { SearchBoxProps as SearchBoxUiComponentProps } from '../ui/SearchBox';
 import type { UseSearchBoxProps } from 'react-instantsearch-hooks';
 
-export type SearchBoxProps = Omit<
+type UiProps = Pick<
   SearchBoxUiComponentProps,
   | 'inputRef'
   | 'isSearchStalled'
@@ -14,7 +14,9 @@ export type SearchBoxProps = Omit<
   | 'onReset'
   | 'value'
   | 'translations'
-> &
+>;
+
+export type SearchBoxProps = Omit<SearchBoxUiComponentProps, keyof UiProps> &
   UseSearchBoxProps;
 
 export function SearchBox(props: SearchBoxProps) {
@@ -54,18 +56,17 @@ export function SearchBox(props: SearchBoxProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
-  return (
-    <SearchBoxUiComponent
-      {...props}
-      inputRef={inputRef}
-      isSearchStalled={isSearchStalled}
-      onChange={onChange}
-      onReset={onReset}
-      value={value}
-      translations={{
-        submitTitle: 'Submit the search query.',
-        resetTitle: 'Clear the search query.',
-      }}
-    />
-  );
+  const uiProps: UiProps = {
+    inputRef,
+    isSearchStalled,
+    onChange,
+    onReset,
+    value,
+    translations: {
+      submitTitle: 'Submit the search query.',
+      resetTitle: 'Clear the search query.',
+    },
+  };
+
+  return <SearchBoxUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/SortBy.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SortBy.tsx
@@ -6,10 +6,9 @@ import { SortBy as SortByUiComponent } from '../ui/SortBy';
 import type { SortByProps as SortByUiComponentProps } from '../ui/SortBy';
 import type { UseSortByProps } from 'react-instantsearch-hooks';
 
-export type SortByProps = Omit<
-  SortByUiComponentProps,
-  'items' | 'value' | 'onSelect'
-> &
+type UiProps = Pick<SortByUiComponentProps, 'items' | 'value' | 'onChange'>;
+
+export type SortByProps = Omit<SortByUiComponentProps, keyof UiProps> &
   UseSortByProps;
 
 export function SortBy({ items, transformItems, ...props }: SortByProps) {
@@ -23,12 +22,11 @@ export function SortBy({ items, transformItems, ...props }: SortByProps) {
     }
   );
 
-  return (
-    <SortByUiComponent
-      {...props}
-      value={currentRefinement}
-      items={options}
-      onChange={refine}
-    />
-  );
+  const uiProps: UiProps = {
+    items: options,
+    value: currentRefinement,
+    onChange: refine,
+  };
+
+  return <SortByUiComponent {...props} {...uiProps} />;
 }

--- a/packages/react-instantsearch-hooks-web/src/widgets/ToggleRefinement.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/ToggleRefinement.tsx
@@ -7,8 +7,10 @@ import type { PartialKeys } from '../types';
 import type { ToggleRefinementProps as ToggleRefinementUiComponentProps } from '../ui/ToggleRefinement';
 import type { UseToggleRefinementProps } from 'react-instantsearch-hooks';
 
+type UiProps = Pick<ToggleRefinementUiComponentProps, 'onChange' | 'checked'>;
+
 export type ToggleRefinementProps = PartialKeys<
-  Omit<ToggleRefinementUiComponentProps, 'onChange' | 'checked'>,
+  Omit<ToggleRefinementUiComponentProps, keyof UiProps>,
   'label'
 > &
   UseToggleRefinementProps;
@@ -26,14 +28,12 @@ export function ToggleRefinement({
     }
   );
 
+  const uiProps: UiProps = {
+    checked: value.isRefined,
+    onChange: (isChecked) => refine({ isRefined: !isChecked }),
+  };
+
   return (
-    <ToggleRefinementUiComponent
-      label={value.name}
-      {...props}
-      checked={value.isRefined}
-      onChange={(isChecked) => {
-        refine({ isRefined: !isChecked });
-      }}
-    />
+    <ToggleRefinementUiComponent label={value.name} {...props} {...uiProps} />
   );
 }


### PR DESCRIPTION
**Summary**

This PR replaces #3440  and implements the solution proposed in #3459.

**Result**

- UI components and widgets have a consistent props type definition style
- UI components props are type checked when passed by widgets
