### PR TITLE
fix(hooks-highlight): make sure highlight and snippet don't show html-escaped content

### DIFF
--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -113,7 +113,7 @@ export function App() {
             />
             <HitsPerPage
               items={[
-                { label: '1 hits per page', value: 1, default: true },
+                { label: '20 hits per page', value: 20, default: true },
                 { label: '40 hits per page', value: 40 },
               ]}
             />

--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -113,7 +113,7 @@ export function App() {
             />
             <HitsPerPage
               items={[
-                { label: '20 hits per page', value: 20, default: true },
+                { label: '1 hits per page', value: 1, default: true },
                 { label: '40 hits per page', value: 40 },
               ]}
             />

--- a/packages/react-instantsearch-hooks-web/src/widgets/Highlight.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Highlight.tsx
@@ -1,6 +1,7 @@
 import {
   getHighlightedParts,
   getPropertyByPath,
+  unescape,
 } from 'instantsearch.js/es/lib/utils';
 import React from 'react';
 
@@ -31,7 +32,7 @@ export function Highlight<THit extends Hit<BaseHit>>({
   const properties = Array.isArray(property) ? property : [property];
 
   const parts = properties.map((singleValue) =>
-    getHighlightedParts(singleValue.value || '')
+    getHighlightedParts(unescape(singleValue.value || ''))
   );
 
   return (

--- a/packages/react-instantsearch-hooks-web/src/widgets/Snippet.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Snippet.tsx
@@ -1,6 +1,7 @@
 import {
   getHighlightedParts,
   getPropertyByPath,
+  unescape,
 } from 'instantsearch.js/es/lib/utils';
 import React from 'react';
 
@@ -31,7 +32,7 @@ export function Snippet<THit extends Hit<BaseHit>>({
   const properties = Array.isArray(property) ? property : [property];
 
   const parts = properties.map((singleValue) =>
-    getHighlightedParts(singleValue.value || '')
+    getHighlightedParts(unescape(singleValue.value || ''))
   );
 
   return (

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Highlight.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Highlight.test.tsx
@@ -199,6 +199,46 @@ describe('Highlight', () => {
     `);
   });
 
+  test("doesn't render html escaped content", () => {
+    const { container } = render(
+      <Highlight
+        hit={{
+          objectID: '1',
+          __position: 1,
+          data: 'test',
+          _highlightResult: {
+            data: {
+              matchedWords: ["don't"],
+              matchLevel: 'partial',
+              value:
+                '<mark>don</mark>&#39;t &lt;script&gt;alert(&quot;xss&quot;);&lt;/script&gt;',
+            },
+          },
+        }}
+        attribute="data"
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class="ais-Highlight"
+        >
+          <mark
+            class="ais-Highlight-highlighted"
+          >
+            don
+          </mark>
+          <span
+            class="ais-Highlight-nonHighlighted"
+          >
+            't &lt;script&gt;alert("xss");&lt;/script&gt;
+          </span>
+        </span>
+      </div>
+    `);
+  });
+
   test('forwards `className` and root props', () => {
     const { container } = render(
       <Highlight

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Snippet.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Snippet.test.tsx
@@ -195,6 +195,46 @@ describe('Snippet', () => {
     `);
   });
 
+  test("doesn't render html escaped content", () => {
+    const { container } = render(
+      <Snippet
+        hit={{
+          objectID: '1',
+          __position: 1,
+          data: 'test',
+          _snippetResult: {
+            data: {
+              matchedWords: ["don't"],
+              matchLevel: 'partial',
+              value:
+                '<mark>don</mark>&#39;t &lt;script&gt;alert(&quot;xss&quot;);&lt;/script&gt;',
+            },
+          },
+        }}
+        attribute="data"
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class="ais-Snippet"
+        >
+          <mark
+            class="ais-Snippet-highlighted"
+          >
+            don
+          </mark>
+          <span
+            class="ais-Snippet-nonHighlighted"
+          >
+            't &lt;script&gt;alert("xss");&lt;/script&gt;
+          </span>
+        </span>
+      </div>
+    `);
+  });
+
   test('forwards `className` and root props', () => {
     const { container } = render(
       <Snippet


### PR DESCRIPTION



<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

instantsearch.js escapes the html and replaces the original tags with <mark> in Hits. This is not desirable in React as it doesn't decode literal html literals.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

apostrophe, quote, lesser and greater signs show up as authored in the index. 

https://algolia.atlassian.net/browse/CR-1142