### PR TITLE
fix(tests): react 18 compatibility

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Breadcrumb.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Breadcrumb.test.tsx
@@ -8,7 +8,7 @@ import {
   createSearchClient,
   createSingleSearchResponse,
 } from '../../../../../test/mock';
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { Breadcrumb } from '../Breadcrumb';
 
 import type { UseHierarchicalMenuProps } from 'react-instantsearch-hooks';
@@ -50,7 +50,7 @@ describe('Breadcrumb', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -95,7 +95,7 @@ describe('Breadcrumb', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(container).toMatchInlineSnapshot(`
       <div>

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Breadcrumb.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Breadcrumb.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { useHierarchicalMenu } from 'react-instantsearch-hooks';
@@ -172,7 +172,7 @@ describe('Breadcrumb', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(
       [...container.querySelectorAll('.ais-Breadcrumb-item')].map(
@@ -206,9 +206,8 @@ describe('Breadcrumb', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
-    expect(searchClient.search).toHaveBeenCalledTimes(1);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -260,8 +259,6 @@ describe('Breadcrumb', () => {
     `);
 
     userEvent.click(getByText('Cameras & Camcorders'));
-
-    await wait(0);
 
     expect(searchClient.search).toHaveBeenCalledTimes(2);
     expect(searchClient.search).toHaveBeenLastCalledWith(

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Breadcrumb.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Breadcrumb.test.tsx
@@ -24,7 +24,7 @@ describe('Breadcrumb', () => {
   };
   const hierarchicalAttributes = Object.keys(hierarchicalFacets);
 
-  function getNewSearchClient() {
+  function createMockedSearchClient() {
     return createSearchClient({
       search: jest.fn((requests) =>
         Promise.resolve(
@@ -41,7 +41,7 @@ describe('Breadcrumb', () => {
   }
 
   test('renders with props', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <VirtualHierarchicalMenu attributes={hierarchicalAttributes} />
@@ -76,7 +76,7 @@ describe('Breadcrumb', () => {
   });
 
   test('renders with initial refinements', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -149,7 +149,7 @@ describe('Breadcrumb', () => {
   });
 
   test('transforms the items', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -189,7 +189,7 @@ describe('Breadcrumb', () => {
   });
 
   test('navigates to a parent category', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container, getByText } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -277,7 +277,7 @@ describe('Breadcrumb', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <VirtualHierarchicalMenu attributes={hierarchicalAttributes} />

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Breadcrumb.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Breadcrumb.test.tsx
@@ -24,25 +24,24 @@ describe('Breadcrumb', () => {
   };
   const hierarchicalAttributes = Object.keys(hierarchicalFacets);
 
-  const searchClient = createSearchClient({
-    search: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          ...requests.map(() =>
-            createSingleSearchResponse({
-              facets: hierarchicalFacets,
-            })
+  function getNewSearchClient() {
+    return createSearchClient({
+      search: jest.fn((requests) =>
+        Promise.resolve(
+          createMultiSearchResponse(
+            ...requests.map(() =>
+              createSingleSearchResponse({
+                facets: hierarchicalFacets,
+              })
+            )
           )
         )
-      )
-    ),
-  });
-
-  beforeEach(() => {
-    searchClient.search.mockClear();
-  });
+      ),
+    });
+  }
 
   test('renders with props', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <VirtualHierarchicalMenu attributes={hierarchicalAttributes} />
@@ -77,6 +76,7 @@ describe('Breadcrumb', () => {
   });
 
   test('renders with initial refinements', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -149,6 +149,7 @@ describe('Breadcrumb', () => {
   });
 
   test('transforms the items', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -188,6 +189,7 @@ describe('Breadcrumb', () => {
   });
 
   test('navigates to a parent category', async () => {
+    const searchClient = getNewSearchClient();
     const { container, getByText } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -275,6 +277,7 @@ describe('Breadcrumb', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <VirtualHierarchicalMenu attributes={hierarchicalAttributes} />

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ClearRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ClearRefinements.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {
@@ -6,7 +6,8 @@ import {
   useRefinementList,
 } from 'react-instantsearch-hooks';
 
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { createSearchClient } from '../../../../../test/mock';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { ClearRefinements } from '../ClearRefinements';
 
 import type {
@@ -14,10 +15,17 @@ import type {
   UseCurrentRefinementsProps,
 } from 'react-instantsearch-hooks';
 
+const searchClient = createSearchClient({});
+
 describe('ClearRefinements', () => {
+  beforeEach(() => {
+    searchClient.search.mockClear();
+  });
+
   test('renders with default props', async () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             refinementList: {
@@ -31,7 +39,7 @@ describe('ClearRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -50,12 +58,12 @@ describe('ClearRefinements', () => {
 
   test('renders with a disabled button when there are no refinements', async () => {
     const { container } = render(
-      <InstantSearchHooksTestWrapper>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <ClearRefinements />
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     const button = document.querySelector('.ais-ClearRefinements-button');
 
@@ -80,6 +88,7 @@ describe('ClearRefinements', () => {
   test('clears all refinements', async () => {
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             refinementList: {
@@ -94,7 +103,7 @@ describe('ClearRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(queryAllByRole('listitem')).toHaveLength(1);
     expect(container).toMatchInlineSnapshot(`
@@ -128,9 +137,8 @@ describe('ClearRefinements', () => {
       ) as HTMLButtonElement
     );
 
-    await wait(0);
+    await waitFor(() => expect(queryAllByRole('listitem')).toHaveLength(0));
 
-    expect(queryAllByRole('listitem')).toHaveLength(0);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <ul />
@@ -151,6 +159,7 @@ describe('ClearRefinements', () => {
   test('inclusively restricts what refinements to clear', async () => {
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             refinementList: {
@@ -167,7 +176,7 @@ describe('ClearRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(queryAllByRole('listitem')).toHaveLength(2);
     expect(container).toMatchInlineSnapshot(`
@@ -210,9 +219,8 @@ describe('ClearRefinements', () => {
       ) as HTMLButtonElement
     );
 
-    await wait(0);
+    await waitFor(() => expect(queryAllByRole('listitem')).toHaveLength(1));
 
-    expect(queryAllByRole('listitem')).toHaveLength(1);
     expect(queryAllByRole('listitem')[0]).toHaveTextContent('brand:Apple');
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -244,6 +252,7 @@ describe('ClearRefinements', () => {
   test('exclusively restricts what refinements to clear', async () => {
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             refinementList: {
@@ -260,7 +269,7 @@ describe('ClearRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(queryAllByRole('listitem')).toHaveLength(2);
     expect(container).toMatchInlineSnapshot(`
@@ -303,9 +312,8 @@ describe('ClearRefinements', () => {
       ) as HTMLButtonElement
     );
 
-    await wait(0);
+    await waitFor(() => expect(queryAllByRole('listitem')).toHaveLength(1));
 
-    expect(queryAllByRole('listitem')).toHaveLength(1);
     expect(queryAllByRole('listitem')[0]).toHaveTextContent('categories:Audio');
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -337,6 +345,7 @@ describe('ClearRefinements', () => {
   test('restricts what refinements to clear with custom logic', async () => {
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             refinementList: {
@@ -355,7 +364,7 @@ describe('ClearRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(queryAllByRole('listitem')).toHaveLength(2);
     expect(container).toMatchInlineSnapshot(`
@@ -398,9 +407,8 @@ describe('ClearRefinements', () => {
       ) as HTMLButtonElement
     );
 
-    await wait(0);
+    await waitFor(() => expect(queryAllByRole('listitem')).toHaveLength(1));
 
-    expect(queryAllByRole('listitem')).toHaveLength(1);
     expect(queryAllByRole('listitem')[0]).toHaveTextContent('brand:Apple');
     expect(container).toMatchInlineSnapshot(`
       <div>

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ClearRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ClearRefinements.test.tsx
@@ -15,14 +15,13 @@ import type {
   UseCurrentRefinementsProps,
 } from 'react-instantsearch-hooks';
 
-const searchClient = createSearchClient({});
+function getNewSearchClient() {
+  return createSearchClient({});
+}
 
 describe('ClearRefinements', () => {
-  beforeEach(() => {
-    searchClient.search.mockClear();
-  });
-
   test('renders with default props', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -57,6 +56,7 @@ describe('ClearRefinements', () => {
   });
 
   test('renders with a disabled button when there are no refinements', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <ClearRefinements />
@@ -86,6 +86,7 @@ describe('ClearRefinements', () => {
   });
 
   test('clears all refinements', async () => {
+    const searchClient = getNewSearchClient();
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -157,6 +158,7 @@ describe('ClearRefinements', () => {
   });
 
   test('inclusively restricts what refinements to clear', async () => {
+    const searchClient = getNewSearchClient();
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -250,6 +252,7 @@ describe('ClearRefinements', () => {
   });
 
   test('exclusively restricts what refinements to clear', async () => {
+    const searchClient = getNewSearchClient();
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -343,6 +346,7 @@ describe('ClearRefinements', () => {
   });
 
   test('restricts what refinements to clear with custom logic', async () => {
+    const searchClient = getNewSearchClient();
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ClearRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ClearRefinements.test.tsx
@@ -15,13 +15,9 @@ import type {
   UseCurrentRefinementsProps,
 } from 'react-instantsearch-hooks';
 
-function getNewSearchClient() {
-  return createSearchClient({});
-}
-
 describe('ClearRefinements', () => {
   test('renders with default props', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -56,7 +52,7 @@ describe('ClearRefinements', () => {
   });
 
   test('renders with a disabled button when there are no refinements', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <ClearRefinements />
@@ -86,7 +82,7 @@ describe('ClearRefinements', () => {
   });
 
   test('clears all refinements', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -158,7 +154,7 @@ describe('ClearRefinements', () => {
   });
 
   test('inclusively restricts what refinements to clear', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -252,7 +248,7 @@ describe('ClearRefinements', () => {
   });
 
   test('exclusively restricts what refinements to clear', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -346,7 +342,7 @@ describe('ClearRefinements', () => {
   });
 
   test('restricts what refinements to clear with custom logic', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container, queryAllByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/CurrentRefinements.test.tsx
@@ -9,13 +9,11 @@ import { CurrentRefinements } from '../CurrentRefinements';
 
 import type { UseRefinementListProps } from 'react-instantsearch-hooks';
 
-const searchClient = createSearchClient({});
+function getNewSearchClient() {
+  return createSearchClient({});
+}
 
 describe('CurrentRefinements', () => {
-  beforeEach(() => {
-    searchClient.search.mockClear();
-  });
-
   test('renders with default props', async () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper
@@ -123,6 +121,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('renders with a specific set of class names when there are no refinements', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <CurrentRefinements />
@@ -300,6 +299,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('does not trigger default event', async () => {
+    const searchClient = getNewSearchClient();
     const onSubmit = jest.fn();
 
     render(
@@ -332,6 +332,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('does not clear when pressing a modifier key', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -447,6 +448,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('inclusively restricts what refinements to display', async () => {
+    const searchClient = getNewSearchClient();
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -509,6 +511,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('exclusively restricts what refinements to display', async () => {
+    const searchClient = getNewSearchClient();
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -571,6 +574,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('restricts what refinements to display with custom logic', async () => {
+    const searchClient = getNewSearchClient();
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/CurrentRefinements.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { useRefinementList } from 'react-instantsearch-hooks';
@@ -27,14 +27,15 @@ describe('CurrentRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-item')
+      ).toHaveLength(2);
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-category')
+      ).toHaveLength(3);
+    });
 
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-item')
-    ).toHaveLength(2);
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-category')
-    ).toHaveLength(3);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -154,14 +155,15 @@ describe('CurrentRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-item')
+      ).toHaveLength(2);
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-category')
+      ).toHaveLength(3);
+    });
 
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-item')
-    ).toHaveLength(2);
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-category')
-    ).toHaveLength(3);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -246,46 +248,48 @@ describe('CurrentRefinements', () => {
 
     userEvent.click(button3);
 
-    await wait(0);
+    await waitFor(() => {
+      expect(queryByText('Audio')).toBeNull();
+      expect(queryByText('Apple')).not.toBeNull();
+      expect(queryByText('Samsung')).not.toBeNull();
 
-    expect(queryByText('Audio')).toBeNull();
-    expect(queryByText('Apple')).not.toBeNull();
-    expect(queryByText('Samsung')).not.toBeNull();
-
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-item')
-    ).toHaveLength(1);
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-category')
-    ).toHaveLength(2);
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-item')
+      ).toHaveLength(1);
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-category')
+      ).toHaveLength(2);
+    });
 
     userEvent.click(button1);
 
-    await wait(0);
+    await waitFor(() => {
+      expect(queryByText('Audio')).toBeNull();
+      expect(queryByText('Apple')).toBeNull();
+      expect(queryByText('Samsung')).not.toBeNull();
 
-    expect(queryByText('Audio')).toBeNull();
-    expect(queryByText('Apple')).toBeNull();
-    expect(queryByText('Samsung')).not.toBeNull();
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-item')
-    ).toHaveLength(1);
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-category')
-    ).toHaveLength(1);
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-item')
+      ).toHaveLength(1);
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-category')
+      ).toHaveLength(1);
+    });
 
     userEvent.click(button2);
 
-    await wait(0);
+    await waitFor(() => {
+      expect(queryByText('Audio')).toBeNull();
+      expect(queryByText('Apple')).toBeNull();
+      expect(queryByText('Samsung')).toBeNull();
 
-    expect(queryByText('Audio')).toBeNull();
-    expect(queryByText('Apple')).toBeNull();
-    expect(queryByText('Samsung')).toBeNull();
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-item')
-    ).toHaveLength(0);
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-category')
-    ).toHaveLength(0);
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-item')
+      ).toHaveLength(0);
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-category')
+      ).toHaveLength(0);
+    });
   });
 
   test('does not trigger default event', async () => {

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/CurrentRefinements.test.tsx
@@ -9,10 +9,6 @@ import { CurrentRefinements } from '../CurrentRefinements';
 
 import type { UseRefinementListProps } from 'react-instantsearch-hooks';
 
-function getNewSearchClient() {
-  return createSearchClient({});
-}
-
 describe('CurrentRefinements', () => {
   test('renders with default props', async () => {
     const { container } = render(
@@ -121,7 +117,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('renders with a specific set of class names when there are no refinements', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <CurrentRefinements />
@@ -299,7 +295,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('does not trigger default event', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const onSubmit = jest.fn();
 
     render(
@@ -332,7 +328,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('does not clear when pressing a modifier key', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -448,7 +444,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('inclusively restricts what refinements to display', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -511,7 +507,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('exclusively restricts what refinements to display', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -574,7 +570,7 @@ describe('CurrentRefinements', () => {
   });
 
   test('restricts what refinements to display with custom logic', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/CurrentRefinements.test.tsx
@@ -3,12 +3,19 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { useRefinementList } from 'react-instantsearch-hooks';
 
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { createSearchClient } from '../../../../../test/mock';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { CurrentRefinements } from '../CurrentRefinements';
 
 import type { UseRefinementListProps } from 'react-instantsearch-hooks';
 
+const searchClient = createSearchClient({});
+
 describe('CurrentRefinements', () => {
+  beforeEach(() => {
+    searchClient.search.mockClear();
+  });
+
   test('renders with default props', async () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper
@@ -117,12 +124,12 @@ describe('CurrentRefinements', () => {
 
   test('renders with a specific set of class names when there are no refinements', async () => {
     const { container } = render(
-      <InstantSearchHooksTestWrapper>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <CurrentRefinements />
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -298,6 +305,7 @@ describe('CurrentRefinements', () => {
     render(
       <form onSubmit={onSubmit}>
         <InstantSearchHooksTestWrapper
+          searchClient={searchClient}
           initialUiState={{
             indexName: {
               refinementList: {
@@ -312,7 +320,7 @@ describe('CurrentRefinements', () => {
       </form>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     userEvent.click(
       document.querySelector(
@@ -320,14 +328,13 @@ describe('CurrentRefinements', () => {
       ) as HTMLButtonElement
     );
 
-    await wait(0);
-
-    expect(onSubmit).not.toHaveBeenCalled();
+    await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
   });
 
   test('does not clear when pressing a modifier key', async () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             refinementList: {
@@ -341,7 +348,7 @@ describe('CurrentRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(
       document.querySelectorAll('.ais-CurrentRefinements-item')
@@ -394,11 +401,12 @@ describe('CurrentRefinements', () => {
     userEvent.click(button, { metaKey: true });
     userEvent.click(button, { shiftKey: true });
 
-    await wait(0);
+    await waitFor(() =>
+      expect(
+        document.querySelectorAll('.ais-CurrentRefinements-item')
+      ).toHaveLength(1)
+    );
 
-    expect(
-      document.querySelectorAll('.ais-CurrentRefinements-item')
-    ).toHaveLength(1);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -441,6 +449,7 @@ describe('CurrentRefinements', () => {
   test('inclusively restricts what refinements to display', async () => {
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             refinementList: {
@@ -456,7 +465,7 @@ describe('CurrentRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(queryByText('Apple')).toBeNull();
     expect(queryByText('Audio')).not.toBeNull();
@@ -502,6 +511,7 @@ describe('CurrentRefinements', () => {
   test('exclusively restricts what refinements to display', async () => {
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             refinementList: {
@@ -517,7 +527,7 @@ describe('CurrentRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(queryByText('Apple')).toBeNull();
     expect(queryByText('Audio')).not.toBeNull();
@@ -563,6 +573,7 @@ describe('CurrentRefinements', () => {
   test('restricts what refinements to display with custom logic', async () => {
     const { container, queryByText } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             refinementList: {
@@ -582,7 +593,7 @@ describe('CurrentRefinements', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(queryByText('Apple')).toBeNull();
     expect(queryByText('Audio')).not.toBeNull();

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
@@ -15,7 +15,7 @@ const attributes = [
   'hierarchicalCategories.lvl1',
 ];
 
-function getNewSearchClient() {
+function createMockedSearchClient() {
   const search = jest.fn((requests) =>
     Promise.resolve(
       createMultiSearchResponse(
@@ -43,7 +43,7 @@ function getNewSearchClient() {
 
 describe('HierarchicalMenu', () => {
   test('renders with props', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HierarchicalMenu attributes={attributes} />
@@ -158,7 +158,7 @@ describe('HierarchicalMenu', () => {
   });
 
   test('limits the number of items to display', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HierarchicalMenu attributes={attributes} limit={1} />
@@ -205,7 +205,7 @@ describe('HierarchicalMenu', () => {
   });
 
   test('transforms the items', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HierarchicalMenu
@@ -232,7 +232,7 @@ describe('HierarchicalMenu', () => {
 
   describe('sorting', () => {
     test('sorts the items by ascending name', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu attributes={attributes} sortBy={['name:asc']} />
@@ -253,7 +253,7 @@ describe('HierarchicalMenu', () => {
     });
 
     test('sorts the items by descending name', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu attributes={attributes} sortBy={['name:desc']} />
@@ -274,7 +274,7 @@ describe('HierarchicalMenu', () => {
     });
 
     test('sorts the items by count', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu attributes={attributes} sortBy={['count']} />
@@ -291,7 +291,7 @@ describe('HierarchicalMenu', () => {
     });
 
     test('sorts the items by refinement state', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container, findByText } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu
@@ -349,7 +349,7 @@ describe('HierarchicalMenu', () => {
     });
 
     test('sorts the items using a sorting function', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu
@@ -375,7 +375,7 @@ describe('HierarchicalMenu', () => {
 
   describe('Show more / less', () => {
     test('displays a "Show more" button', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu attributes={attributes} limit={1} showMore={true} />
@@ -441,7 +441,7 @@ describe('HierarchicalMenu', () => {
     });
 
     test('limits the number of items to reveal', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu
@@ -476,7 +476,7 @@ describe('HierarchicalMenu', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HierarchicalMenu

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
@@ -7,7 +7,7 @@ import {
   createSearchClient,
   createSingleSearchResponse,
 } from '../../../../../test/mock';
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { HierarchicalMenu } from '../HierarchicalMenu';
 
 const attributes = [
@@ -426,12 +426,12 @@ describe('HierarchicalMenu', () => {
 
       userEvent.click(showMoreButton);
 
-      await wait(0);
-
-      expect(showMoreButton).toHaveTextContent('Show less');
-      expect(
-        container.querySelectorAll('.ais-HierarchicalMenu-item')
-      ).toHaveLength(3);
+      await waitFor(() => {
+        expect(showMoreButton).toHaveTextContent('Show less');
+        expect(
+          container.querySelectorAll('.ais-HierarchicalMenu-item')
+        ).toHaveLength(3);
+      });
     });
 
     test('limits the number of items to reveal', async () => {
@@ -461,11 +461,11 @@ describe('HierarchicalMenu', () => {
 
       userEvent.click(showMoreButton);
 
-      await wait(0);
-
-      expect(
-        container.querySelectorAll('.ais-HierarchicalMenu-item')
-      ).toHaveLength(2);
+      await waitFor(() =>
+        expect(
+          container.querySelectorAll('.ais-HierarchicalMenu-item')
+        ).toHaveLength(2)
+      );
     });
   });
 

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -45,13 +45,13 @@ describe('HierarchicalMenu', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll('.ais-HierarchicalMenu-item')
+      ).toHaveLength(3);
+      expect(client.search).toHaveBeenCalledTimes(1);
+    });
 
-    expect(client.search).toHaveBeenCalledTimes(1);
-
-    expect(
-      container.querySelectorAll('.ais-HierarchicalMenu-item')
-    ).toHaveLength(3);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -132,23 +132,23 @@ describe('HierarchicalMenu', () => {
       ) as HTMLAnchorElement
     );
 
-    await wait(0);
+    await waitFor(() => {
+      expect(firstCategory).toHaveClass('ais-HierarchicalMenu-item--selected');
 
-    expect(firstCategory).toHaveClass('ais-HierarchicalMenu-item--selected');
-
-    // Once on load, once on check
-    expect(client.search).toHaveBeenCalledTimes(2);
-    expect(client.search).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          params: expect.objectContaining({
-            facetFilters: [
-              ['hierarchicalCategories.lvl0:Cameras & Camcorders'],
-            ],
+      // Once on load, once on check
+      expect(client.search).toHaveBeenCalledTimes(2);
+      expect(client.search).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            params: expect.objectContaining({
+              facetFilters: [
+                ['hierarchicalCategories.lvl0:Cameras & Camcorders'],
+              ],
+            }),
           }),
-        }),
-      ])
-    );
+        ])
+      );
+    });
   });
 
   test('limits the number of items to display', async () => {
@@ -159,11 +159,12 @@ describe('HierarchicalMenu', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll('.ais-HierarchicalMenu-item')
+      ).toHaveLength(1)
+    );
 
-    expect(
-      container.querySelectorAll('.ais-HierarchicalMenu-item')
-    ).toHaveLength(1);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -210,19 +211,17 @@ describe('HierarchicalMenu', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(
-      [...container.querySelectorAll('.ais-HierarchicalMenu-item')].map(
-        (item) => item.textContent
-      )
-    ).toMatchInlineSnapshot(`
-      Array [
-        "CAMERAS & CAMCORDERS1369",
-        "VIDEO GAMES505",
-        "WEARABLE TECHNOLOGY271",
-      ]
-    `);
+    await waitFor(() => {
+      expect(
+        Array.from(
+          container.querySelectorAll('.ais-HierarchicalMenu-item')
+        ).map((item) => item.textContent)
+      ).toEqual([
+        'CAMERAS & CAMCORDERS1369',
+        'VIDEO GAMES505',
+        'WEARABLE TECHNOLOGY271',
+      ]);
+    });
   });
 
   describe('sorting', () => {
@@ -234,13 +233,17 @@ describe('HierarchicalMenu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-HierarchicalMenu-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual(['Cameras & Camcorders', 'Video Games', 'Wearable Technology']);
+      await waitFor(() =>
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Cameras & Camcorders',
+          'Video Games',
+          'Wearable Technology',
+        ])
+      );
     });
 
     test('sorts the items by descending name', async () => {
@@ -251,13 +254,17 @@ describe('HierarchicalMenu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-HierarchicalMenu-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual(['Wearable Technology', 'Video Games', 'Cameras & Camcorders']);
+      await waitFor(() =>
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Wearable Technology',
+          'Video Games',
+          'Cameras & Camcorders',
+        ])
+      );
     });
 
     test('sorts the items by count', async () => {
@@ -268,13 +275,13 @@ describe('HierarchicalMenu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-HierarchicalMenu-count')
-        ).map((item) => item.textContent)
-      ).toEqual(['1369', '505', '271']);
+      await waitFor(() =>
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-HierarchicalMenu-count')
+          ).map((item) => item.textContent)
+        ).toEqual(['1369', '505', '271'])
+      );
     });
 
     test('sorts the items by refinement state', async () => {
@@ -294,45 +301,45 @@ describe('HierarchicalMenu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-HierarchicalMenu-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'Cameras & Camcorders n',
-        'Video Games n',
-        'Wearable Technology n',
-      ]);
+      await waitFor(() =>
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Cameras & Camcorders n',
+          'Video Games n',
+          'Wearable Technology n',
+        ])
+      );
 
       userEvent.click(await findByText('Video Games n'));
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-HierarchicalMenu-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'Video Games y',
-        'Cameras & Camcorders n',
-        'Wearable Technology n',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Video Games y',
+          'Cameras & Camcorders n',
+          'Wearable Technology n',
+        ]);
+      });
 
       userEvent.click(await findByText('Wearable Technology n'));
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-HierarchicalMenu-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'Wearable Technology y',
-        'Cameras & Camcorders n',
-        'Video Games n',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Wearable Technology y',
+          'Cameras & Camcorders n',
+          'Video Games n',
+        ]);
+      });
     });
 
     test('sorts the items using a sorting function', async () => {
@@ -346,13 +353,17 @@ describe('HierarchicalMenu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-HierarchicalMenu-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual(['Wearable Technology', 'Video Games', 'Cameras & Camcorders']);
+      await waitFor(() =>
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Wearable Technology',
+          'Video Games',
+          'Cameras & Camcorders',
+        ])
+      );
     });
   });
 
@@ -365,16 +376,17 @@ describe('HierarchicalMenu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
+      await waitFor(() =>
+        expect(
+          container.querySelectorAll('.ais-HierarchicalMenu-item')
+        ).toHaveLength(1)
+      );
 
       const showMoreButton = container.querySelector(
         '.ais-HierarchicalMenu-showMore'
       ) as HTMLButtonElement;
       expect(showMoreButton).toHaveTextContent('Show more');
 
-      expect(
-        container.querySelectorAll('.ais-HierarchicalMenu-item')
-      ).toHaveLength(1);
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
@@ -435,15 +447,16 @@ describe('HierarchicalMenu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
+      await waitFor(() =>
+        expect(
+          container.querySelectorAll('.ais-HierarchicalMenu-item')
+        ).toHaveLength(1)
+      );
 
       const showMoreButton = container.querySelector(
         '.ais-HierarchicalMenu-showMore'
       ) as HTMLButtonElement;
 
-      expect(
-        container.querySelectorAll('.ais-HierarchicalMenu-item')
-      ).toHaveLength(1);
       expect(showMoreButton).toBeInTheDocument();
 
       userEvent.click(showMoreButton);

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
@@ -14,33 +14,38 @@ const attributes = [
   'hierarchicalCategories.lvl0',
   'hierarchicalCategories.lvl1',
 ];
-const search = jest.fn((requests) =>
-  Promise.resolve(
-    createMultiSearchResponse(
-      ...requests.map(() =>
-        createSingleSearchResponse({
-          facets: {
-            'hierarchicalCategories.lvl0': {
-              'Cameras & Camcorders': 1369,
-              'Video Games': 505,
-              'Wearable Technology': 271,
+
+function getNewSearchClient() {
+  const search = jest.fn((requests) =>
+    Promise.resolve(
+      createMultiSearchResponse(
+        ...requests.map(() =>
+          createSingleSearchResponse({
+            facets: {
+              'hierarchicalCategories.lvl0': {
+                'Cameras & Camcorders': 1369,
+                'Video Games': 505,
+                'Wearable Technology': 271,
+              },
+              'hierarchicalCategories.lvl1': {
+                'Cameras & Camcorders > Digital Cameras': 170,
+                'Cameras & Camcorders > Memory Cards': 113,
+              },
             },
-            'hierarchicalCategories.lvl1': {
-              'Cameras & Camcorders > Digital Cameras': 170,
-              'Cameras & Camcorders > Memory Cards': 113,
-            },
-          },
-        })
+          })
+        )
       )
     )
-  )
-);
+  );
+
+  return createSearchClient({ search });
+}
 
 describe('HierarchicalMenu', () => {
   test('renders with props', async () => {
-    const client = createSearchClient({ search });
+    const searchClient = getNewSearchClient();
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HierarchicalMenu attributes={attributes} />
       </InstantSearchHooksTestWrapper>
     );
@@ -49,7 +54,7 @@ describe('HierarchicalMenu', () => {
       expect(
         container.querySelectorAll('.ais-HierarchicalMenu-item')
       ).toHaveLength(3);
-      expect(client.search).toHaveBeenCalledTimes(1);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
 
     expect(container).toMatchInlineSnapshot(`
@@ -136,8 +141,8 @@ describe('HierarchicalMenu', () => {
       expect(firstCategory).toHaveClass('ais-HierarchicalMenu-item--selected');
 
       // Once on load, once on check
-      expect(client.search).toHaveBeenCalledTimes(2);
-      expect(client.search).toHaveBeenLastCalledWith(
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
+      expect(searchClient.search).toHaveBeenLastCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
             params: expect.objectContaining({
@@ -152,9 +157,9 @@ describe('HierarchicalMenu', () => {
   });
 
   test('limits the number of items to display', async () => {
-    const client = createSearchClient({ search });
+    const searchClient = getNewSearchClient();
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HierarchicalMenu attributes={attributes} limit={1} />
       </InstantSearchHooksTestWrapper>
     );
@@ -199,9 +204,9 @@ describe('HierarchicalMenu', () => {
   });
 
   test('transforms the items', async () => {
-    const client = createSearchClient({ search });
+    const searchClient = getNewSearchClient();
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HierarchicalMenu
           attributes={attributes}
           transformItems={(items) =>
@@ -226,9 +231,9 @@ describe('HierarchicalMenu', () => {
 
   describe('sorting', () => {
     test('sorts the items by ascending name', async () => {
-      const client = createSearchClient({ search });
+      const searchClient = getNewSearchClient();
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu attributes={attributes} sortBy={['name:asc']} />
         </InstantSearchHooksTestWrapper>
       );
@@ -247,9 +252,9 @@ describe('HierarchicalMenu', () => {
     });
 
     test('sorts the items by descending name', async () => {
-      const client = createSearchClient({ search });
+      const searchClient = getNewSearchClient();
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu attributes={attributes} sortBy={['name:desc']} />
         </InstantSearchHooksTestWrapper>
       );
@@ -268,9 +273,9 @@ describe('HierarchicalMenu', () => {
     });
 
     test('sorts the items by count', async () => {
-      const client = createSearchClient({ search });
+      const searchClient = getNewSearchClient();
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu attributes={attributes} sortBy={['count']} />
         </InstantSearchHooksTestWrapper>
       );
@@ -285,9 +290,9 @@ describe('HierarchicalMenu', () => {
     });
 
     test('sorts the items by refinement state', async () => {
-      const client = createSearchClient({ search });
+      const searchClient = getNewSearchClient();
       const { container, findByText } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu
             attributes={attributes}
             sortBy={['isRefined', 'name']}
@@ -343,9 +348,9 @@ describe('HierarchicalMenu', () => {
     });
 
     test('sorts the items using a sorting function', async () => {
-      const client = createSearchClient({ search });
+      const searchClient = getNewSearchClient();
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu
             attributes={attributes}
             sortBy={(a, b) => b.name.localeCompare(a.name)}
@@ -369,9 +374,9 @@ describe('HierarchicalMenu', () => {
 
   describe('Show more / less', () => {
     test('displays a "Show more" button', async () => {
-      const client = createSearchClient({ search });
+      const searchClient = getNewSearchClient();
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu attributes={attributes} limit={1} showMore={true} />
         </InstantSearchHooksTestWrapper>
       );
@@ -435,9 +440,9 @@ describe('HierarchicalMenu', () => {
     });
 
     test('limits the number of items to reveal', async () => {
-      const client = createSearchClient({ search });
+      const searchClient = getNewSearchClient();
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <HierarchicalMenu
             attributes={attributes}
             limit={1}
@@ -470,9 +475,9 @@ describe('HierarchicalMenu', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const client = createSearchClient({ search });
+    const searchClient = getNewSearchClient();
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HierarchicalMenu
           attributes={attributes}
           className="MyHierarchicalMenu"

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
@@ -51,11 +51,12 @@ describe('HierarchicalMenu', () => {
     );
 
     await waitFor(() => {
-      expect(
-        container.querySelectorAll('.ais-HierarchicalMenu-item')
-      ).toHaveLength(3);
       expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
+
+    expect(
+      container.querySelectorAll('.ais-HierarchicalMenu-item')
+    ).toHaveLength(3);
 
     expect(container).toMatchInlineSnapshot(`
       <div>

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HitsPerPage.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HitsPerPage.test.tsx
@@ -1,15 +1,21 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { createSearchClient } from '../../../../../test/mock';
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { HitsPerPage } from '../HitsPerPage';
 
+const searchClient = createSearchClient({});
+
 describe('HitsPerPage', () => {
+  beforeEach(() => {
+    searchClient.search.mockClear();
+  });
+
   test('renders with props', async () => {
     const { container } = render(
-      <InstantSearchHooksTestWrapper>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HitsPerPage
           items={[
             { label: '10', value: 10, default: true },
@@ -20,7 +26,7 @@ describe('HitsPerPage', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -57,6 +63,7 @@ describe('HitsPerPage', () => {
   test('selects current value', async () => {
     const { getByRole } = render(
       <InstantSearchHooksTestWrapper
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             hitsPerPage: 20,
@@ -73,7 +80,7 @@ describe('HitsPerPage', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(
       (getByRole('option', { name: '10' }) as HTMLOptionElement).selected
@@ -87,7 +94,6 @@ describe('HitsPerPage', () => {
   });
 
   test('refines on select', async () => {
-    const searchClient = createSearchClient({});
     const { getByRole } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HitsPerPage
@@ -100,9 +106,7 @@ describe('HitsPerPage', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(searchClient.search).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     userEvent.selectOptions(getByRole('combobox'), ['30']);
 

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HitsPerPage.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HitsPerPage.test.tsx
@@ -6,13 +6,9 @@ import { createSearchClient } from '../../../../../test/mock';
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { HitsPerPage } from '../HitsPerPage';
 
-function getNewSearchClient() {
-  return createSearchClient({});
-}
-
 describe('HitsPerPage', () => {
   test('renders with props', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HitsPerPage
@@ -60,7 +56,7 @@ describe('HitsPerPage', () => {
   });
 
   test('selects current value', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { getByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -94,7 +90,7 @@ describe('HitsPerPage', () => {
   });
 
   test('refines on select', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createSearchClient({});
     const { getByRole } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HitsPerPage

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HitsPerPage.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HitsPerPage.test.tsx
@@ -6,14 +6,13 @@ import { createSearchClient } from '../../../../../test/mock';
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { HitsPerPage } from '../HitsPerPage';
 
-const searchClient = createSearchClient({});
+function getNewSearchClient() {
+  return createSearchClient({});
+}
 
 describe('HitsPerPage', () => {
-  beforeEach(() => {
-    searchClient.search.mockClear();
-  });
-
   test('renders with props', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HitsPerPage
@@ -61,6 +60,7 @@ describe('HitsPerPage', () => {
   });
 
   test('selects current value', async () => {
+    const searchClient = getNewSearchClient();
     const { getByRole } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -94,6 +94,7 @@ describe('HitsPerPage', () => {
   });
 
   test('refines on select', async () => {
+    const searchClient = getNewSearchClient();
     const { getByRole } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <HitsPerPage

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/InfiniteHits.test.tsx
@@ -55,10 +55,10 @@ describe('InfiniteHits', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(container.querySelectorAll('.ais-InfiniteHits-item')).toHaveLength(
-      3
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ais-InfiniteHits-item')).toHaveLength(
+        3
+      )
     );
 
     expect(container.querySelector('.ais-InfiniteHits')).toMatchInlineSnapshot(`
@@ -125,9 +125,10 @@ describe('InfiniteHits', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(container.querySelectorAll('strong')).toHaveLength(3)
+    );
 
-    expect(container.querySelectorAll('strong')).toHaveLength(3);
     expect(container.querySelector('.ais-InfiniteHits')).toMatchInlineSnapshot(`
         <div
           class="ais-InfiniteHits"
@@ -183,9 +184,9 @@ describe('InfiniteHits', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(container.querySelectorAll('strong')).toHaveLength(3);
+    await waitFor(() =>
+      expect(container.querySelectorAll('strong')).toHaveLength(3)
+    );
 
     expect(searchClient.search).toHaveBeenCalledTimes(1);
     expect(searchClient.search).toHaveBeenLastCalledWith([
@@ -205,23 +206,23 @@ describe('InfiniteHits', () => {
       userEvent.click(container.querySelector('.ais-InfiniteHits-loadMore')!);
     });
 
-    await wait(0);
+    await waitFor(() => {
+      expect(container.querySelectorAll('strong')).toHaveLength(6);
 
-    expect(container.querySelectorAll('strong')).toHaveLength(6);
-
-    expect(searchClient.search).toHaveBeenCalledTimes(2);
-    expect(searchClient.search).toHaveBeenLastCalledWith([
-      {
-        indexName: 'indexName',
-        params: {
-          facets: [],
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          page: 1,
-          tagFilters: '',
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
+      expect(searchClient.search).toHaveBeenLastCalledWith([
+        {
+          indexName: 'indexName',
+          params: {
+            facets: [],
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            page: 1,
+            tagFilters: '',
+          },
         },
-      },
-    ]);
+      ]);
+    });
   });
 
   test('displays previous hits when clicking the "Show Previous" button', async () => {
@@ -238,9 +239,9 @@ describe('InfiniteHits', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(container.querySelectorAll('strong')).toHaveLength(3);
+    await waitFor(() =>
+      expect(container.querySelectorAll('strong')).toHaveLength(3)
+    );
 
     expect(searchClient.search).toHaveBeenCalledTimes(1);
     expect(searchClient.search).toHaveBeenLastCalledWith([
@@ -262,23 +263,23 @@ describe('InfiniteHits', () => {
       );
     });
 
-    await wait(0);
+    await waitFor(() => {
+      expect(container.querySelectorAll('strong')).toHaveLength(6);
 
-    expect(container.querySelectorAll('strong')).toHaveLength(6);
-
-    expect(searchClient.search).toHaveBeenCalledTimes(2);
-    expect(searchClient.search).toHaveBeenLastCalledWith([
-      {
-        indexName: 'indexName',
-        params: {
-          facets: [],
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          page: 2,
-          tagFilters: '',
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
+      expect(searchClient.search).toHaveBeenLastCalledWith([
+        {
+          indexName: 'indexName',
+          params: {
+            facets: [],
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            page: 2,
+            tagFilters: '',
+          },
         },
-      },
-    ]);
+      ]);
+    });
   });
 
   test('hides the "Show Previous" button when `showPrevious` is `false`', async () => {

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/InfiniteHits.test.tsx
@@ -7,7 +7,7 @@ import {
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '../../../../../test/mock/createAPIResponse';
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { InfiniteHits } from '../InfiniteHits';
 
 type CustomHit = {
@@ -320,7 +320,7 @@ describe('InfiniteHits', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(
       container.querySelector<HTMLButtonElement>(
@@ -348,7 +348,7 @@ describe('InfiniteHits', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(
       container.querySelector<HTMLButtonElement>('.ais-InfiniteHits-loadMore')

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/InfiniteHits.test.tsx
@@ -14,41 +14,40 @@ type CustomHit = {
   somethingSpecial: string;
 };
 
-const searchClient = createSearchClient({
-  search: jest.fn((requests) =>
-    Promise.resolve(
-      createMultiSearchResponse(
-        ...requests.map((request) => {
-          const { hitsPerPage = 3, page = 0 } = request.params!;
-          const hits = Array.from({ length: hitsPerPage }, (_, i) => {
-            const offset = hitsPerPage * page;
-            return {
-              objectID: (i + offset).toString(),
-              somethingSpecial: String.fromCharCode(
-                'a'.charCodeAt(0) + i + offset
-              ),
-            };
-          });
+function getNewSearchClient() {
+  return createSearchClient({
+    search: jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map((request) => {
+            const { hitsPerPage = 3, page = 0 } = request.params!;
+            const hits = Array.from({ length: hitsPerPage }, (_, i) => {
+              const offset = hitsPerPage * page;
+              return {
+                objectID: (i + offset).toString(),
+                somethingSpecial: String.fromCharCode(
+                  'a'.charCodeAt(0) + i + offset
+                ),
+              };
+            });
 
-          return createSingleSearchResponse<CustomHit>({
-            hits,
-            page,
-            nbPages: 10,
-            hitsPerPage,
-            index: request.indexName,
-          });
-        })
+            return createSingleSearchResponse<CustomHit>({
+              hits,
+              page,
+              nbPages: 10,
+              hitsPerPage,
+              index: request.indexName,
+            });
+          })
+        )
       )
-    )
-  ),
-});
+    ),
+  });
+}
 
 describe('InfiniteHits', () => {
-  beforeEach(() => {
-    searchClient.search.mockClear();
-  });
-
   test('renders with default props', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits />
@@ -115,6 +114,7 @@ describe('InfiniteHits', () => {
   });
 
   test('renders with a custom hit component', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits<CustomHit>
@@ -174,6 +174,7 @@ describe('InfiniteHits', () => {
   });
 
   test('displays more hits when clicking the "Show More" button', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits
@@ -226,6 +227,7 @@ describe('InfiniteHits', () => {
   });
 
   test('displays previous hits when clicking the "Show Previous" button', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -283,6 +285,7 @@ describe('InfiniteHits', () => {
   });
 
   test('hides the "Show Previous" button when `showPrevious` is `false`', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits showPrevious={false} />
@@ -314,6 +317,7 @@ describe('InfiniteHits', () => {
   });
 
   test('marks the "Show Previous" button as disabled on first page', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits />
@@ -339,6 +343,7 @@ describe('InfiniteHits', () => {
   });
 
   test('marks the "Show More" button as disabled on last page', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -363,6 +368,7 @@ describe('InfiniteHits', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/InfiniteHits.test.tsx
@@ -14,7 +14,7 @@ type CustomHit = {
   somethingSpecial: string;
 };
 
-function getNewSearchClient() {
+function createMockedSearchClient() {
   return createSearchClient({
     search: jest.fn((requests) =>
       Promise.resolve(
@@ -47,7 +47,7 @@ function getNewSearchClient() {
 
 describe('InfiniteHits', () => {
   test('renders with default props', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits />
@@ -114,7 +114,7 @@ describe('InfiniteHits', () => {
   });
 
   test('renders with a custom hit component', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits<CustomHit>
@@ -174,7 +174,7 @@ describe('InfiniteHits', () => {
   });
 
   test('displays more hits when clicking the "Show More" button', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits
@@ -227,7 +227,7 @@ describe('InfiniteHits', () => {
   });
 
   test('displays previous hits when clicking the "Show Previous" button', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -285,7 +285,7 @@ describe('InfiniteHits', () => {
   });
 
   test('hides the "Show Previous" button when `showPrevious` is `false`', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits showPrevious={false} />
@@ -317,7 +317,7 @@ describe('InfiniteHits', () => {
   });
 
   test('marks the "Show Previous" button as disabled on first page', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits />
@@ -343,7 +343,7 @@ describe('InfiniteHits', () => {
   });
 
   test('marks the "Show More" button as disabled on last page', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -368,7 +368,7 @@ describe('InfiniteHits', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <InfiniteHits

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Menu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Menu.test.tsx
@@ -10,49 +10,48 @@ import {
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { Menu } from '../Menu';
 
-const searchClient = createSearchClient({
-  search: jest.fn((requests) => {
-    return Promise.resolve(
-      createMultiSearchResponse(
-        ...requests.map(() =>
-          createSingleSearchResponse({
-            facets: {
-              brand: {
-                'Insignia™': 746,
-                Samsung: 633,
-                Metra: 591,
-                HP: 530,
-                Apple: 442,
-                GE: 394,
-                Sony: 350,
-                Incipio: 320,
-                KitchenAid: 318,
-                Whirlpool: 298,
-                LG: 291,
-                Canon: 287,
-                Frigidaire: 275,
-                Speck: 216,
-                OtterBox: 214,
-                Epson: 204,
-                'Dynex™': 184,
-                Dell: 174,
-                'Hamilton Beach': 173,
-                Platinum: 155,
+function getNewSearchClient() {
+  return createSearchClient({
+    search: jest.fn((requests) => {
+      return Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map(() =>
+            createSingleSearchResponse({
+              facets: {
+                brand: {
+                  'Insignia™': 746,
+                  Samsung: 633,
+                  Metra: 591,
+                  HP: 530,
+                  Apple: 442,
+                  GE: 394,
+                  Sony: 350,
+                  Incipio: 320,
+                  KitchenAid: 318,
+                  Whirlpool: 298,
+                  LG: 291,
+                  Canon: 287,
+                  Frigidaire: 275,
+                  Speck: 216,
+                  OtterBox: 214,
+                  Epson: 204,
+                  'Dynex™': 184,
+                  Dell: 174,
+                  'Hamilton Beach': 173,
+                  Platinum: 155,
+                },
               },
-            },
-          })
+            })
+          )
         )
-      )
-    );
-  }),
-});
+      );
+    }),
+  });
+}
 
 describe('Menu', () => {
-  beforeEach(() => {
-    searchClient.search.mockClear();
-  });
-
   test('renders with props', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Menu attribute="brand" />
@@ -291,6 +290,7 @@ describe('Menu', () => {
   });
 
   test('limits the number of items to display', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Menu attribute="brand" limit={5} />
@@ -411,6 +411,7 @@ describe('Menu', () => {
   });
 
   test('transforms the items', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Menu
@@ -447,6 +448,7 @@ describe('Menu', () => {
 
   describe('sorting', () => {
     test('sorts the items by ascending name', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" sortBy={['name:asc']} />
@@ -474,6 +476,7 @@ describe('Menu', () => {
     });
 
     test('sorts the items by descending name', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" sortBy={['name:desc']} />
@@ -501,6 +504,7 @@ describe('Menu', () => {
     });
 
     test('sorts the items by count', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" sortBy={['count']} />
@@ -528,6 +532,7 @@ describe('Menu', () => {
     });
 
     test('sorts the items by refinement state', async () => {
+      const searchClient = getNewSearchClient();
       const { container, findByText } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu
@@ -606,6 +611,7 @@ describe('Menu', () => {
     });
 
     test('sorts the items using a sorting function', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu
@@ -638,6 +644,7 @@ describe('Menu', () => {
 
   describe('Show more / less', () => {
     test('displays a "Show more" button', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" showMore={true} />
@@ -870,6 +877,7 @@ describe('Menu', () => {
     });
 
     test('limits the number of items to reveal', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" showMore={true} showMoreLimit={11} />
@@ -896,6 +904,7 @@ describe('Menu', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Menu

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Menu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Menu.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -54,11 +54,12 @@ describe('Menu', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ais-Menu-item')).toHaveLength(10)
+    );
 
     expect(client.search).toHaveBeenCalledTimes(1);
 
-    expect(container.querySelectorAll('.ais-Menu-item')).toHaveLength(10);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -293,9 +294,10 @@ describe('Menu', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ais-Menu-item')).toHaveLength(5)
+    );
 
-    expect(container.querySelectorAll('.ais-Menu-item')).toHaveLength(5);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -421,26 +423,24 @@ describe('Menu', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(
-      [...container.querySelectorAll('.ais-Menu-item')].map(
-        (el) => el.textContent
-      )
-    ).toMatchInlineSnapshot(`
-      Array [
-        "INSIGNIA™746",
-        "SAMSUNG633",
-        "METRA591",
-        "HP530",
-        "APPLE442",
-        "GE394",
-        "SONY350",
-        "INCIPIO320",
-        "KITCHENAID318",
-        "WHIRLPOOL298",
-      ]
-    `);
+    await waitFor(() => {
+      expect(
+        Array.from(container.querySelectorAll('.ais-Menu-item')).map(
+          (item) => item.textContent
+        )
+      ).toEqual([
+        'INSIGNIA™746',
+        'SAMSUNG633',
+        'METRA591',
+        'HP530',
+        'APPLE442',
+        'GE394',
+        'SONY350',
+        'INCIPIO320',
+        'KITCHENAID318',
+        'WHIRLPOOL298',
+      ]);
+    });
   });
 
   describe('sorting', () => {
@@ -452,24 +452,24 @@ describe('Menu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(container.querySelectorAll('.ais-Menu-label')).map(
-          (item) => item.textContent
-        )
-      ).toEqual([
-        'Apple',
-        'Canon',
-        'Dell',
-        'Dynex™',
-        'Epson',
-        'Frigidaire',
-        'GE',
-        'HP',
-        'Hamilton Beach',
-        'Incipio',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(container.querySelectorAll('.ais-Menu-label')).map(
+            (item) => item.textContent
+          )
+        ).toEqual([
+          'Apple',
+          'Canon',
+          'Dell',
+          'Dynex™',
+          'Epson',
+          'Frigidaire',
+          'GE',
+          'HP',
+          'Hamilton Beach',
+          'Incipio',
+        ]);
+      });
     });
 
     test('sorts the items by descending name', async () => {
@@ -480,24 +480,24 @@ describe('Menu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(container.querySelectorAll('.ais-Menu-label')).map(
-          (item) => item.textContent
-        )
-      ).toEqual([
-        'Whirlpool',
-        'Speck',
-        'Sony',
-        'Samsung',
-        'Platinum',
-        'OtterBox',
-        'Metra',
-        'LG',
-        'KitchenAid',
-        'Insignia™',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(container.querySelectorAll('.ais-Menu-label')).map(
+            (item) => item.textContent
+          )
+        ).toEqual([
+          'Whirlpool',
+          'Speck',
+          'Sony',
+          'Samsung',
+          'Platinum',
+          'OtterBox',
+          'Metra',
+          'LG',
+          'KitchenAid',
+          'Insignia™',
+        ]);
+      });
     });
 
     test('sorts the items by count', async () => {
@@ -508,24 +508,24 @@ describe('Menu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(container.querySelectorAll('.ais-Menu-count')).map(
-          (item) => item.textContent
-        )
-      ).toEqual([
-        '746',
-        '633',
-        '591',
-        '530',
-        '442',
-        '394',
-        '350',
-        '320',
-        '318',
-        '298',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(container.querySelectorAll('.ais-Menu-count')).map(
+            (item) => item.textContent
+          )
+        ).toEqual([
+          '746',
+          '633',
+          '591',
+          '530',
+          '442',
+          '394',
+          '350',
+          '320',
+          '318',
+          '298',
+        ]);
+      });
     });
 
     test('sorts the items by refinement state', async () => {
@@ -545,66 +545,66 @@ describe('Menu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(container.querySelectorAll('.ais-Menu-label')).map(
-          (item) => item.textContent
-        )
-      ).toEqual([
-        'Apple n',
-        'Canon n',
-        'Dell n',
-        'Dynex™ n',
-        'Epson n',
-        'Frigidaire n',
-        'GE n',
-        'HP n',
-        'Hamilton Beach n',
-        'Incipio n',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(container.querySelectorAll('.ais-Menu-label')).map(
+            (item) => item.textContent
+          )
+        ).toEqual([
+          'Apple n',
+          'Canon n',
+          'Dell n',
+          'Dynex™ n',
+          'Epson n',
+          'Frigidaire n',
+          'GE n',
+          'HP n',
+          'Hamilton Beach n',
+          'Incipio n',
+        ]);
+      });
 
       userEvent.click(await findByText('Hamilton Beach n'));
 
-      await wait(0);
-
-      expect(
-        Array.from(container.querySelectorAll('.ais-Menu-label')).map(
-          (item) => item.textContent
-        )
-      ).toEqual([
-        'Hamilton Beach y',
-        'Apple n',
-        'Canon n',
-        'Dell n',
-        'Dynex™ n',
-        'Epson n',
-        'Frigidaire n',
-        'GE n',
-        'HP n',
-        'Incipio n',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(container.querySelectorAll('.ais-Menu-label')).map(
+            (item) => item.textContent
+          )
+        ).toEqual([
+          'Hamilton Beach y',
+          'Apple n',
+          'Canon n',
+          'Dell n',
+          'Dynex™ n',
+          'Epson n',
+          'Frigidaire n',
+          'GE n',
+          'HP n',
+          'Incipio n',
+        ]);
+      });
 
       userEvent.click(await findByText('Frigidaire n'));
 
-      await wait(0);
-
-      expect(
-        Array.from(container.querySelectorAll('.ais-Menu-label')).map(
-          (item) => item.textContent
-        )
-      ).toEqual([
-        'Frigidaire y',
-        'Apple n',
-        'Canon n',
-        'Dell n',
-        'Dynex™ n',
-        'Epson n',
-        'GE n',
-        'HP n',
-        'Hamilton Beach n',
-        'Incipio n',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(container.querySelectorAll('.ais-Menu-label')).map(
+            (item) => item.textContent
+          )
+        ).toEqual([
+          'Frigidaire y',
+          'Apple n',
+          'Canon n',
+          'Dell n',
+          'Dynex™ n',
+          'Epson n',
+          'GE n',
+          'HP n',
+          'Hamilton Beach n',
+          'Incipio n',
+        ]);
+      });
     });
 
     test('sorts the items using a sorting function', async () => {
@@ -618,24 +618,24 @@ describe('Menu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(container.querySelectorAll('.ais-Menu-label')).map(
-          (item) => item.textContent
-        )
-      ).toEqual([
-        'Whirlpool',
-        'Speck',
-        'Sony',
-        'Samsung',
-        'Platinum',
-        'OtterBox',
-        'Metra',
-        'LG',
-        'KitchenAid',
-        'Insignia™',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(container.querySelectorAll('.ais-Menu-label')).map(
+            (item) => item.textContent
+          )
+        ).toEqual([
+          'Whirlpool',
+          'Speck',
+          'Sony',
+          'Samsung',
+          'Platinum',
+          'OtterBox',
+          'Metra',
+          'LG',
+          'KitchenAid',
+          'Insignia™',
+        ]);
+      });
     });
   });
 
@@ -648,14 +648,15 @@ describe('Menu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
+      await waitFor(() =>
+        expect(container.querySelectorAll('.ais-Menu-item')).toHaveLength(10)
+      );
 
       const showMoreButton = container.querySelector(
         '.ais-Menu-showMore'
       ) as HTMLButtonElement;
 
       expect(showMoreButton).toHaveTextContent('Show more');
-      expect(container.querySelectorAll('.ais-Menu-item')).toHaveLength(10);
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
@@ -880,9 +881,10 @@ describe('Menu', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
+      await waitFor(() =>
+        expect(container.querySelectorAll('.ais-Menu-item')).toHaveLength(10)
+      );
 
-      expect(container.querySelectorAll('.ais-Menu-item')).toHaveLength(10);
       expect(container.querySelector('.ais-Menu-showMore')).toBeInTheDocument();
 
       userEvent.click(

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Menu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Menu.test.tsx
@@ -10,7 +10,7 @@ import {
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { Menu } from '../Menu';
 
-function getNewSearchClient() {
+function createMockedSearchClient() {
   return createSearchClient({
     search: jest.fn((requests) => {
       return Promise.resolve(
@@ -51,7 +51,7 @@ function getNewSearchClient() {
 
 describe('Menu', () => {
   test('renders with props', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Menu attribute="brand" />
@@ -290,7 +290,7 @@ describe('Menu', () => {
   });
 
   test('limits the number of items to display', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Menu attribute="brand" limit={5} />
@@ -411,7 +411,7 @@ describe('Menu', () => {
   });
 
   test('transforms the items', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Menu
@@ -448,7 +448,7 @@ describe('Menu', () => {
 
   describe('sorting', () => {
     test('sorts the items by ascending name', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" sortBy={['name:asc']} />
@@ -476,7 +476,7 @@ describe('Menu', () => {
     });
 
     test('sorts the items by descending name', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" sortBy={['name:desc']} />
@@ -504,7 +504,7 @@ describe('Menu', () => {
     });
 
     test('sorts the items by count', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" sortBy={['count']} />
@@ -532,7 +532,7 @@ describe('Menu', () => {
     });
 
     test('sorts the items by refinement state', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container, findByText } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu
@@ -611,7 +611,7 @@ describe('Menu', () => {
     });
 
     test('sorts the items using a sorting function', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu
@@ -644,7 +644,7 @@ describe('Menu', () => {
 
   describe('Show more / less', () => {
     test('displays a "Show more" button', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" showMore={true} />
@@ -877,7 +877,7 @@ describe('Menu', () => {
     });
 
     test('limits the number of items to reveal', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <Menu attribute="brand" showMore={true} showMoreLimit={11} />
@@ -904,7 +904,7 @@ describe('Menu', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Menu

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Pagination.test.tsx
@@ -10,28 +10,26 @@ import {
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { Pagination } from '../Pagination';
 
-const searchClient = createSearchClient({
-  search: jest.fn((requests) =>
-    Promise.resolve(
-      createMultiSearchResponse(
-        ...requests.map((request) =>
-          createSingleSearchResponse({
-            hits: Array.from({ length: 1000 }).map((_, index) => ({
-              objectID: String(index),
-            })),
-            index: request.indexName,
-          })
+function getNewSearchClient() {
+  return createSearchClient({
+    search: jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map((request) =>
+            createSingleSearchResponse({
+              hits: Array.from({ length: 1000 }).map((_, index) => ({
+                objectID: String(index),
+              })),
+              index: request.indexName,
+            })
+          )
         )
       )
-    )
-  ),
-});
+    ),
+  });
+}
 
 describe('Pagination', () => {
-  beforeEach(() => {
-    searchClient.search.mockClear();
-  });
-
   test('renders with default props', async () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
@@ -111,6 +109,7 @@ describe('Pagination', () => {
   });
 
   test('renders with props', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination />
@@ -272,6 +271,7 @@ describe('Pagination', () => {
   });
 
   test('navigates between pages', async () => {
+    const searchClient = getNewSearchClient();
     const { container, getByText } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination />
@@ -1208,6 +1208,7 @@ describe('Pagination', () => {
   });
 
   test('does not navigate when pressing a modifier key', async () => {
+    const searchClient = getNewSearchClient();
     const { getByText } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination />
@@ -1276,6 +1277,7 @@ describe('Pagination', () => {
   });
 
   test('adds items around the current one', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination padding={4} />
@@ -1595,6 +1597,7 @@ describe('Pagination', () => {
   });
 
   test('limits the total pages to display', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination totalPages={4} />

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Pagination.test.tsx
@@ -10,7 +10,7 @@ import {
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { Pagination } from '../Pagination';
 
-function getNewSearchClient() {
+function createMockedSearchClient() {
   return createSearchClient({
     search: jest.fn((requests) =>
       Promise.resolve(
@@ -109,7 +109,7 @@ describe('Pagination', () => {
   });
 
   test('renders with props', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination />
@@ -271,7 +271,7 @@ describe('Pagination', () => {
   });
 
   test('navigates between pages', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container, getByText } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination />
@@ -1208,7 +1208,7 @@ describe('Pagination', () => {
   });
 
   test('does not navigate when pressing a modifier key', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { getByText } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination />
@@ -1277,7 +1277,7 @@ describe('Pagination', () => {
   });
 
   test('adds items around the current one', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination padding={4} />
@@ -1597,7 +1597,7 @@ describe('Pagination', () => {
   });
 
   test('limits the total pages to display', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <Pagination totalPages={4} />

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Pagination.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -108,12 +108,15 @@ describe('Pagination', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(
+        document.querySelectorAll('.ais-Pagination-item--page')
+      ).toHaveLength(7)
+    );
 
-    const pageItems = document.querySelectorAll('.ais-Pagination-item--page');
-
-    expect(pageItems).toHaveLength(7);
-    expect(pageItems[0]).toHaveClass('ais-Pagination-item--selected');
+    expect(
+      document.querySelectorAll('.ais-Pagination-item--page')[0]
+    ).toHaveClass('ais-Pagination-item--selected');
     expect(
       document.querySelector('.ais-Pagination-item--firstPage')
     ).toHaveClass('ais-Pagination-item--disabled');
@@ -282,7 +285,11 @@ describe('Pagination', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(
+        document.querySelectorAll('.ais-Pagination-item--page')
+      ).toHaveLength(7)
+    );
 
     search.mockClear();
 
@@ -454,16 +461,17 @@ describe('Pagination', () => {
     // We navigate to page 2
     userEvent.click(getByText('2'));
 
-    await wait(0);
+    await waitFor(() => {
+      expect(search).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          params: expect.objectContaining({ page: 1 }),
+        }),
+      ]);
+      expect(
+        document.querySelector('.ais-Pagination-item--selected')
+      ).toHaveTextContent('2');
+    });
 
-    expect(search).toHaveBeenLastCalledWith([
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 1 }),
-      }),
-    ]);
-    expect(
-      document.querySelector('.ais-Pagination-item--selected')
-    ).toHaveTextContent('2');
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -601,16 +609,17 @@ describe('Pagination', () => {
     // We click on "Next" link
     userEvent.click(getByText('›'));
 
-    await wait(0);
+    await waitFor(() => {
+      expect(search).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          params: expect.objectContaining({ page: 2 }),
+        }),
+      ]);
+      expect(
+        document.querySelector('.ais-Pagination-item--selected')
+      ).toHaveTextContent('3');
+    });
 
-    expect(search).toHaveBeenLastCalledWith([
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 2 }),
-      }),
-    ]);
-    expect(
-      document.querySelector('.ais-Pagination-item--selected')
-    ).toHaveTextContent('3');
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -748,16 +757,17 @@ describe('Pagination', () => {
     // We click on "Last" link
     userEvent.click(getByText('››'));
 
-    await wait(0);
+    await waitFor(() => {
+      expect(search).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          params: expect.objectContaining({ page: 49 }),
+        }),
+      ]);
+      expect(
+        document.querySelector('.ais-Pagination-item--selected')
+      ).toHaveTextContent('50');
+    });
 
-    expect(search).toHaveBeenLastCalledWith([
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 49 }),
-      }),
-    ]);
-    expect(
-      document.querySelector('.ais-Pagination-item--selected')
-    ).toHaveTextContent('50');
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -903,9 +913,9 @@ describe('Pagination', () => {
       lastPageItem!.querySelector('.ais-Pagination-link') as HTMLAnchorElement
     );
 
-    await wait(0);
-
-    expect(search).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(search).not.toHaveBeenCalled();
+    });
 
     // We click on "Previous" link
     userEvent.click(
@@ -914,16 +924,17 @@ describe('Pagination', () => {
       ) as HTMLAnchorElement
     );
 
-    await wait(0);
+    await waitFor(() => {
+      expect(search).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          params: expect.objectContaining({ page: 48 }),
+        }),
+      ]);
+      expect(
+        document.querySelector('.ais-Pagination-item--selected')
+      ).toHaveTextContent('49');
+    });
 
-    expect(search).toHaveBeenLastCalledWith([
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 48 }),
-      }),
-    ]);
-    expect(
-      document.querySelector('.ais-Pagination-item--selected')
-    ).toHaveTextContent('49');
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -1063,16 +1074,17 @@ describe('Pagination', () => {
       firstPageItem!.querySelector('.ais-Pagination-link') as HTMLAnchorElement
     );
 
-    await wait(0);
+    await waitFor(() => {
+      expect(search).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          params: expect.objectContaining({ page: 0 }),
+        }),
+      ]);
+      expect(
+        document.querySelector('.ais-Pagination-item--selected')
+      ).toHaveTextContent('1');
+    });
 
-    expect(search).toHaveBeenLastCalledWith([
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 0 }),
-      }),
-    ]);
-    expect(
-      document.querySelector('.ais-Pagination-item--selected')
-    ).toHaveTextContent('1');
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -1313,11 +1325,12 @@ describe('Pagination', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(
+        document.querySelectorAll('.ais-Pagination-item--page')
+      ).toHaveLength(9)
+    );
 
-    expect(
-      document.querySelectorAll('.ais-Pagination-item--page')
-    ).toHaveLength(9);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -1496,11 +1509,12 @@ describe('Pagination', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(
+        document.querySelectorAll('.ais-Pagination-item--page')
+      ).toHaveLength(6)
+    );
 
-    expect(
-      document.querySelectorAll('.ais-Pagination-item--page')
-    ).toHaveLength(6);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -1646,11 +1660,12 @@ describe('Pagination', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(
+        document.querySelectorAll('.ais-Pagination-item--page')
+      ).toHaveLength(4)
+    );
 
-    expect(
-      document.querySelectorAll('.ais-Pagination-item--page')
-    ).toHaveLength(4);
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/PoweredBy.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/PoweredBy.test.tsx
@@ -1,18 +1,16 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { PoweredBy } from '../PoweredBy';
 
 describe('PoweredBy', () => {
-  test('renders with default props', async () => {
+  test('renders with default props', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <PoweredBy />
       </InstantSearchHooksTestWrapper>
     );
-
-    await wait(0);
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -53,14 +51,12 @@ describe('PoweredBy', () => {
     `);
   });
 
-  test('renders for dark themes', async () => {
+  test('renders for dark themes', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <PoweredBy theme="dark" />
       </InstantSearchHooksTestWrapper>
     );
-
-    await wait(0);
 
     expect(container.firstChild).toHaveClass('ais-PoweredBy--dark');
     expect(container).toMatchInlineSnapshot(`
@@ -102,7 +98,7 @@ describe('PoweredBy', () => {
     `);
   });
 
-  test('customizes the class names with the light theme', async () => {
+  test('customizes the class names with the light theme', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <PoweredBy
@@ -115,8 +111,6 @@ describe('PoweredBy', () => {
         />
       </InstantSearchHooksTestWrapper>
     );
-
-    await wait(0);
 
     expect(container.firstChild).toHaveClass(
       'ais-PoweredBy',
@@ -132,7 +126,7 @@ describe('PoweredBy', () => {
     );
   });
 
-  test('customizes the class names with the dark theme', async () => {
+  test('customizes the class names with the dark theme', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <PoweredBy
@@ -146,8 +140,6 @@ describe('PoweredBy', () => {
         />
       </InstantSearchHooksTestWrapper>
     );
-
-    await wait(0);
 
     expect(container.firstChild).toHaveClass(
       'ais-PoweredBy',

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RangeInput.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RangeInput.test.tsx
@@ -10,7 +10,7 @@ import {
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { RangeInput } from '../RangeInput';
 
-function getNewSearchClient() {
+function createMockedSearchClient() {
   return createSearchClient({
     search: jest.fn((requests) => {
       return Promise.resolve(
@@ -38,7 +38,7 @@ function getNewSearchClient() {
 
 describe('RangeInput', () => {
   test('renders with default props', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RangeInput attribute="price" />
@@ -101,7 +101,7 @@ describe('RangeInput', () => {
   });
 
   test('renders with initial refinements', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
         searchClient={searchClient}
@@ -128,7 +128,7 @@ describe('RangeInput', () => {
   });
 
   test('renders with precision', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RangeInput attribute="price" precision={2} />
@@ -145,7 +145,7 @@ describe('RangeInput', () => {
   });
 
   test('refines on submit', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RangeInput attribute="price" />
@@ -181,7 +181,7 @@ describe('RangeInput', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RangeInput

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RangeInput.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RangeInput.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -45,9 +45,9 @@ describe('RangeInput', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(client.search).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(client.search).toHaveBeenCalledTimes(1);
+    });
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -152,9 +152,9 @@ describe('RangeInput', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(client.search).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(client.search).toHaveBeenCalledTimes(1);
+    });
 
     userEvent.type(
       container.querySelector('.ais-RangeInput-input--min')!,

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RangeInput.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RangeInput.test.tsx
@@ -10,7 +10,7 @@ import {
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { RangeInput } from '../RangeInput';
 
-function createSearchClientWithFacetsStats() {
+function getNewSearchClient() {
   return createSearchClient({
     search: jest.fn((requests) => {
       return Promise.resolve(
@@ -38,15 +38,15 @@ function createSearchClientWithFacetsStats() {
 
 describe('RangeInput', () => {
   test('renders with default props', async () => {
-    const client = createSearchClientWithFacetsStats();
+    const searchClient = getNewSearchClient();
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RangeInput attribute="price" />
       </InstantSearchHooksTestWrapper>
     );
 
     await waitFor(() => {
-      expect(client.search).toHaveBeenCalledTimes(1);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
 
     expect(container).toMatchInlineSnapshot(`
@@ -101,10 +101,10 @@ describe('RangeInput', () => {
   });
 
   test('renders with initial refinements', async () => {
-    const client = createSearchClientWithFacetsStats();
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper
-        searchClient={client}
+        searchClient={searchClient}
         initialUiState={{
           indexName: {
             range: {
@@ -117,7 +117,7 @@ describe('RangeInput', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await waitFor(() => expect(client.search).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     expect(container.querySelector('.ais-RangeInput-input--min')).toHaveValue(
       100
@@ -128,14 +128,14 @@ describe('RangeInput', () => {
   });
 
   test('renders with precision', async () => {
-    const client = createSearchClientWithFacetsStats();
+    const searchClient = getNewSearchClient();
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RangeInput attribute="price" precision={2} />
       </InstantSearchHooksTestWrapper>
     );
 
-    await waitFor(() => expect(client.search).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     ['min', 'max'].forEach((target) => {
       expect(
@@ -145,15 +145,15 @@ describe('RangeInput', () => {
   });
 
   test('refines on submit', async () => {
-    const client = createSearchClientWithFacetsStats();
+    const searchClient = getNewSearchClient();
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RangeInput attribute="price" />
       </InstantSearchHooksTestWrapper>
     );
 
     await waitFor(() => {
-      expect(client.search).toHaveBeenCalledTimes(1);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
 
     userEvent.type(
@@ -167,9 +167,9 @@ describe('RangeInput', () => {
 
     userEvent.click(container.querySelector('.ais-RangeInput-submit')!);
 
-    await waitFor(() => expect(client.search).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(2));
 
-    expect(client.search).toHaveBeenLastCalledWith(
+    expect(searchClient.search).toHaveBeenLastCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
           params: expect.objectContaining({
@@ -181,9 +181,9 @@ describe('RangeInput', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const client = createSearchClientWithFacetsStats();
+    const searchClient = getNewSearchClient();
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RangeInput
           attribute="price"
           className="MyRangeInput"

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RangeInput.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RangeInput.test.tsx
@@ -7,7 +7,7 @@ import {
   createSearchClient,
   createSingleSearchResponse,
 } from '../../../../../test/mock';
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { RangeInput } from '../RangeInput';
 
 function createSearchClientWithFacetsStats() {
@@ -117,7 +117,7 @@ describe('RangeInput', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(client.search).toHaveBeenCalledTimes(1));
 
     expect(container.querySelector('.ais-RangeInput-input--min')).toHaveValue(
       100
@@ -135,7 +135,7 @@ describe('RangeInput', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => expect(client.search).toHaveBeenCalledTimes(1));
 
     ['min', 'max'].forEach((target) => {
       expect(
@@ -167,9 +167,8 @@ describe('RangeInput', () => {
 
     userEvent.click(container.querySelector('.ais-RangeInput-submit')!);
 
-    await wait(0);
+    await waitFor(() => expect(client.search).toHaveBeenCalledTimes(2));
 
-    expect(client.search).toHaveBeenCalledTimes(2);
     expect(client.search).toHaveBeenLastCalledWith(
       expect.arrayContaining([
         expect.objectContaining({

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RefinementList.test.tsx
@@ -11,108 +11,108 @@ import {
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { RefinementList } from '../RefinementList';
 
-const searchClient = createSearchClient({
-  search: jest.fn((requests) => {
-    return Promise.resolve(
-      createMultiSearchResponse(
-        ...requests.map(() =>
-          createSingleSearchResponse({
-            facets: {
-              brand: {
-                'Insignia™': 746,
-                Samsung: 633,
-                Metra: 591,
-                HP: 530,
-                Apple: 442,
-                GE: 394,
-                Sony: 350,
-                Incipio: 320,
-                KitchenAid: 318,
-                Whirlpool: 298,
-                LG: 291,
-                Canon: 287,
-                Frigidaire: 275,
-                Speck: 216,
-                OtterBox: 214,
-                Epson: 204,
-                'Dynex™': 184,
-                Dell: 174,
-                'Hamilton Beach': 173,
-                Platinum: 155,
+function getNewSearchClient(parameters: Record<string, any> = {}) {
+  return createSearchClient({
+    search: jest.fn((requests) => {
+      return Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map(() =>
+            createSingleSearchResponse({
+              facets: {
+                brand: {
+                  'Insignia™': 746,
+                  Samsung: 633,
+                  Metra: 591,
+                  HP: 530,
+                  Apple: 442,
+                  GE: 394,
+                  Sony: 350,
+                  Incipio: 320,
+                  KitchenAid: 318,
+                  Whirlpool: 298,
+                  LG: 291,
+                  Canon: 287,
+                  Frigidaire: 275,
+                  Speck: 216,
+                  OtterBox: 214,
+                  Epson: 204,
+                  'Dynex™': 184,
+                  Dell: 174,
+                  'Hamilton Beach': 173,
+                  Platinum: 155,
+                },
               },
-            },
-          })
+            })
+          )
         )
-      )
-    );
-  }),
-  searchForFacetValues: jest.fn(() =>
-    Promise.resolve([
-      createSFFVResponse({
-        facetHits: [
-          {
-            value: 'Apple',
-            highlighted: '__ais-highlight__App__/ais-highlight__le',
-            count: 442,
-          },
-          {
-            value: 'Alpine',
-            highlighted: '__ais-highlight__Alp__/ais-highlight__ine',
-            count: 30,
-          },
-          {
-            value: 'APC',
-            highlighted: '__ais-highlight__AP__/ais-highlight__C',
-            count: 24,
-          },
-          {
-            value: 'Amped Wireless',
-            highlighted: '__ais-highlight__Amp__/ais-highlight__ed Wireless',
-            count: 4,
-          },
-          {
-            value: "Applebee's",
-            highlighted: "__ais-highlight__App__/ais-highlight__lebee's",
-            count: 2,
-          },
-          {
-            value: 'Amplicom',
-            highlighted: '__ais-highlight__Amp__/ais-highlight__licom',
-            count: 1,
-          },
-          {
-            value: 'Apollo Enclosures',
-            highlighted: '__ais-highlight__Ap__/ais-highlight__ollo Enclosures',
-            count: 1,
-          },
-          {
-            value: 'Apple®',
-            highlighted: '__ais-highlight__App__/ais-highlight__le®',
-            count: 1,
-          },
-          {
-            value: 'Applica',
-            highlighted: '__ais-highlight__App__/ais-highlight__lica',
-            count: 1,
-          },
-          {
-            value: 'Apricorn',
-            highlighted: '__ais-highlight__Ap__/ais-highlight__ricorn',
-            count: 1,
-          },
-        ],
-      }),
-    ])
-  ),
-});
+      );
+    }),
+    searchForFacetValues: jest.fn(() =>
+      Promise.resolve([
+        createSFFVResponse({
+          facetHits: [
+            {
+              value: 'Apple',
+              highlighted: '__ais-highlight__App__/ais-highlight__le',
+              count: 442,
+            },
+            {
+              value: 'Alpine',
+              highlighted: '__ais-highlight__Alp__/ais-highlight__ine',
+              count: 30,
+            },
+            {
+              value: 'APC',
+              highlighted: '__ais-highlight__AP__/ais-highlight__C',
+              count: 24,
+            },
+            {
+              value: 'Amped Wireless',
+              highlighted: '__ais-highlight__Amp__/ais-highlight__ed Wireless',
+              count: 4,
+            },
+            {
+              value: "Applebee's",
+              highlighted: "__ais-highlight__App__/ais-highlight__lebee's",
+              count: 2,
+            },
+            {
+              value: 'Amplicom',
+              highlighted: '__ais-highlight__Amp__/ais-highlight__licom',
+              count: 1,
+            },
+            {
+              value: 'Apollo Enclosures',
+              highlighted:
+                '__ais-highlight__Ap__/ais-highlight__ollo Enclosures',
+              count: 1,
+            },
+            {
+              value: 'Apple®',
+              highlighted: '__ais-highlight__App__/ais-highlight__le®',
+              count: 1,
+            },
+            {
+              value: 'Applica',
+              highlighted: '__ais-highlight__App__/ais-highlight__lica',
+              count: 1,
+            },
+            {
+              value: 'Apricorn',
+              highlighted: '__ais-highlight__Ap__/ais-highlight__ricorn',
+              count: 1,
+            },
+          ],
+        }),
+      ])
+    ),
+    ...parameters,
+  });
+}
 
 describe('RefinementList', () => {
-  beforeEach(() => {
-    searchClient.search.mockClear();
-    searchClient.searchForFacetValues.mockClear();
-  });
-
   test('renders with props', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList attribute="brand" />
@@ -396,6 +396,7 @@ describe('RefinementList', () => {
   });
 
   test('enables conjunctive faceting', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList attribute="brand" operator="and" />
@@ -431,6 +432,7 @@ describe('RefinementList', () => {
   });
 
   test('limits the number of items to display', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList attribute="brand" limit={5} />
@@ -573,6 +575,7 @@ describe('RefinementList', () => {
   });
 
   test('transforms the items', async () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList
@@ -609,6 +612,7 @@ describe('RefinementList', () => {
 
   describe('sorting', () => {
     test('sorts the items by ascending name', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['name:asc']} />
@@ -636,6 +640,7 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items by descending name', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['name:desc']} />
@@ -663,6 +668,7 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items by count', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['count']} />
@@ -690,6 +696,7 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items by refinement state', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['isRefined']} />
@@ -745,6 +752,7 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items using a sorting function', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
@@ -777,6 +785,7 @@ describe('RefinementList', () => {
 
   describe('searching', () => {
     test('displays a search box', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
@@ -861,14 +870,13 @@ describe('RefinementList', () => {
     });
 
     test('displays a fallback when there are no results', async () => {
-      const client = createSearchClient({
-        search: searchClient.search,
+      const searchClient = getNewSearchClient({
         searchForFacetValues: jest.fn(() =>
           Promise.resolve([createSFFVResponse({ facetHits: [] })])
         ),
       });
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
             attribute="brand"
             searchable={true}
@@ -877,7 +885,7 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await waitFor(() => expect(client.search).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
       userEvent.type(
         container.querySelector('.ais-SearchBox-input') as HTMLInputElement,
@@ -885,7 +893,7 @@ describe('RefinementList', () => {
       );
 
       await waitFor(() => {
-        expect(client.searchForFacetValues).toHaveBeenCalledTimes(7);
+        expect(searchClient.searchForFacetValues).toHaveBeenCalledTimes(7);
 
         expect(
           container.querySelector('.ais-RefinementList-noResults')
@@ -1009,6 +1017,7 @@ describe('RefinementList', () => {
 
   describe('Show more / less', () => {
     test('displays a "Show more" button', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" showMore={true} />
@@ -1286,6 +1295,7 @@ describe('RefinementList', () => {
     });
 
     test('limits the number of items to reveal', async () => {
+      const searchClient = getNewSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
@@ -1324,6 +1334,7 @@ describe('RefinementList', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
+    const searchClient = getNewSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RefinementList.test.tsx
@@ -8,108 +8,113 @@ import {
   createSFFVResponse,
   createSingleSearchResponse,
 } from '../../../../../test/mock';
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { RefinementList } from '../RefinementList';
 
-const search = jest.fn((requests) => {
-  return Promise.resolve(
-    createMultiSearchResponse(
-      ...requests.map(() =>
-        createSingleSearchResponse({
-          facets: {
-            brand: {
-              'Insignia™': 746,
-              Samsung: 633,
-              Metra: 591,
-              HP: 530,
-              Apple: 442,
-              GE: 394,
-              Sony: 350,
-              Incipio: 320,
-              KitchenAid: 318,
-              Whirlpool: 298,
-              LG: 291,
-              Canon: 287,
-              Frigidaire: 275,
-              Speck: 216,
-              OtterBox: 214,
-              Epson: 204,
-              'Dynex™': 184,
-              Dell: 174,
-              'Hamilton Beach': 173,
-              Platinum: 155,
+const searchClient = createSearchClient({
+  search: jest.fn((requests) => {
+    return Promise.resolve(
+      createMultiSearchResponse(
+        ...requests.map(() =>
+          createSingleSearchResponse({
+            facets: {
+              brand: {
+                'Insignia™': 746,
+                Samsung: 633,
+                Metra: 591,
+                HP: 530,
+                Apple: 442,
+                GE: 394,
+                Sony: 350,
+                Incipio: 320,
+                KitchenAid: 318,
+                Whirlpool: 298,
+                LG: 291,
+                Canon: 287,
+                Frigidaire: 275,
+                Speck: 216,
+                OtterBox: 214,
+                Epson: 204,
+                'Dynex™': 184,
+                Dell: 174,
+                'Hamilton Beach': 173,
+                Platinum: 155,
+              },
             },
-          },
-        })
+          })
+        )
       )
-    )
-  );
+    );
+  }),
+  searchForFacetValues: jest.fn(() =>
+    Promise.resolve([
+      createSFFVResponse({
+        facetHits: [
+          {
+            value: 'Apple',
+            highlighted: '__ais-highlight__App__/ais-highlight__le',
+            count: 442,
+          },
+          {
+            value: 'Alpine',
+            highlighted: '__ais-highlight__Alp__/ais-highlight__ine',
+            count: 30,
+          },
+          {
+            value: 'APC',
+            highlighted: '__ais-highlight__AP__/ais-highlight__C',
+            count: 24,
+          },
+          {
+            value: 'Amped Wireless',
+            highlighted: '__ais-highlight__Amp__/ais-highlight__ed Wireless',
+            count: 4,
+          },
+          {
+            value: "Applebee's",
+            highlighted: "__ais-highlight__App__/ais-highlight__lebee's",
+            count: 2,
+          },
+          {
+            value: 'Amplicom',
+            highlighted: '__ais-highlight__Amp__/ais-highlight__licom',
+            count: 1,
+          },
+          {
+            value: 'Apollo Enclosures',
+            highlighted: '__ais-highlight__Ap__/ais-highlight__ollo Enclosures',
+            count: 1,
+          },
+          {
+            value: 'Apple®',
+            highlighted: '__ais-highlight__App__/ais-highlight__le®',
+            count: 1,
+          },
+          {
+            value: 'Applica',
+            highlighted: '__ais-highlight__App__/ais-highlight__lica',
+            count: 1,
+          },
+          {
+            value: 'Apricorn',
+            highlighted: '__ais-highlight__Ap__/ais-highlight__ricorn',
+            count: 1,
+          },
+        ],
+      }),
+    ])
+  ),
 });
 
-const searchForFacetValues = jest.fn(() =>
-  Promise.resolve([
-    createSFFVResponse({
-      facetHits: [
-        {
-          value: 'Apple',
-          highlighted: '__ais-highlight__App__/ais-highlight__le',
-          count: 442,
-        },
-        {
-          value: 'Alpine',
-          highlighted: '__ais-highlight__Alp__/ais-highlight__ine',
-          count: 30,
-        },
-        {
-          value: 'APC',
-          highlighted: '__ais-highlight__AP__/ais-highlight__C',
-          count: 24,
-        },
-        {
-          value: 'Amped Wireless',
-          highlighted: '__ais-highlight__Amp__/ais-highlight__ed Wireless',
-          count: 4,
-        },
-        {
-          value: "Applebee's",
-          highlighted: "__ais-highlight__App__/ais-highlight__lebee's",
-          count: 2,
-        },
-        {
-          value: 'Amplicom',
-          highlighted: '__ais-highlight__Amp__/ais-highlight__licom',
-          count: 1,
-        },
-        {
-          value: 'Apollo Enclosures',
-          highlighted: '__ais-highlight__Ap__/ais-highlight__ollo Enclosures',
-          count: 1,
-        },
-        {
-          value: 'Apple®',
-          highlighted: '__ais-highlight__App__/ais-highlight__le®',
-          count: 1,
-        },
-        {
-          value: 'Applica',
-          highlighted: '__ais-highlight__App__/ais-highlight__lica',
-          count: 1,
-        },
-        {
-          value: 'Apricorn',
-          highlighted: '__ais-highlight__Ap__/ais-highlight__ricorn',
-          count: 1,
-        },
-      ],
-    }),
-  ])
-);
-
 describe('RefinementList', () => {
+  beforeEach(() => {
+    searchClient.search.mockClear();
+    searchClient.searchForFacetValues.mockClear();
+  });
+
   test('renders with props', async () => {
-    const client = createSearchClient({ search });
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList attribute="brand" />
       </InstantSearchHooksTestWrapper>
     );
@@ -120,7 +125,7 @@ describe('RefinementList', () => {
       ).toHaveLength(10)
     );
 
-    expect(client.search).toHaveBeenCalledTimes(1);
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -373,26 +378,26 @@ describe('RefinementList', () => {
 
     userEvent.click(firstCheckbox);
 
-    await wait(0);
+    await waitFor(() => {
+      expect(firstCheckbox).toBeChecked();
 
-    expect(firstCheckbox).toBeChecked();
-    // Once on load, once on check.
-    expect(client.search).toHaveBeenCalledTimes(2);
-    expect(client.search).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          params: expect.objectContaining({
-            facetFilters: [['brand:Insignia™']],
+      // Once on load, once on check.
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
+      expect(searchClient.search).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            params: expect.objectContaining({
+              facetFilters: [['brand:Insignia™']],
+            }),
           }),
-        }),
-      ])
-    );
+        ])
+      );
+    });
   });
 
   test('enables conjunctive faceting', async () => {
-    const client = createSearchClient({ search });
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList attribute="brand" operator="and" />
       </InstantSearchHooksTestWrapper>
     );
@@ -409,12 +414,12 @@ describe('RefinementList', () => {
       ) as NodeListOf<HTMLInputElement>),
     ].slice(0, 2);
 
-    userEvent.click(checkbox1);
-    userEvent.click(checkbox2);
+    userEvent.click(checkbox1); // client.search call 2
+    userEvent.click(checkbox2); // client.search call 3
 
-    await wait(0);
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(3));
 
-    expect(client.search).toHaveBeenLastCalledWith(
+    expect(searchClient.search).toHaveBeenLastCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
           params: expect.objectContaining({
@@ -426,9 +431,8 @@ describe('RefinementList', () => {
   });
 
   test('limits the number of items to display', async () => {
-    const client = createSearchClient({ search });
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList attribute="brand" limit={5} />
       </InstantSearchHooksTestWrapper>
     );
@@ -569,9 +573,8 @@ describe('RefinementList', () => {
   });
 
   test('transforms the items', async () => {
-    const client = createSearchClient({ search });
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList
           attribute="brand"
           transformItems={(items) =>
@@ -606,9 +609,8 @@ describe('RefinementList', () => {
 
   describe('sorting', () => {
     test('sorts the items by ascending name', async () => {
-      const client = createSearchClient({ search });
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['name:asc']} />
         </InstantSearchHooksTestWrapper>
       );
@@ -634,9 +636,8 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items by descending name', async () => {
-      const client = createSearchClient({ search });
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['name:desc']} />
         </InstantSearchHooksTestWrapper>
       );
@@ -662,9 +663,8 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items by count', async () => {
-      const client = createSearchClient({ search });
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['count']} />
         </InstantSearchHooksTestWrapper>
       );
@@ -690,9 +690,8 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items by refinement state', async () => {
-      const client = createSearchClient({ search });
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['isRefined']} />
         </InstantSearchHooksTestWrapper>
       );
@@ -746,9 +745,8 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items using a sorting function', async () => {
-      const client = createSearchClient({ search });
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
             attribute="brand"
             sortBy={(a, b) => a.name.length - b.name.length}
@@ -779,9 +777,8 @@ describe('RefinementList', () => {
 
   describe('searching', () => {
     test('displays a search box', async () => {
-      const client = createSearchClient({ search, searchForFacetValues });
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
             attribute="brand"
             searchable={true}
@@ -827,8 +824,8 @@ describe('RefinementList', () => {
 
       await waitFor(() => {
         // One call per keystroke
-        expect(client.searchForFacetValues).toHaveBeenCalledTimes(3);
-        expect(client.searchForFacetValues).toHaveBeenLastCalledWith(
+        expect(searchClient.searchForFacetValues).toHaveBeenCalledTimes(3);
+        expect(searchClient.searchForFacetValues).toHaveBeenLastCalledWith(
           expect.arrayContaining([
             expect.objectContaining({
               params: expect.objectContaining({
@@ -865,7 +862,7 @@ describe('RefinementList', () => {
 
     test('displays a fallback when there are no results', async () => {
       const client = createSearchClient({
-        search,
+        search: searchClient.search,
         searchForFacetValues: jest.fn(() =>
           Promise.resolve([createSFFVResponse({ facetHits: [] })])
         ),
@@ -880,18 +877,21 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
+      await waitFor(() => expect(client.search).toHaveBeenCalledTimes(1));
 
       userEvent.type(
         container.querySelector('.ais-SearchBox-input') as HTMLInputElement,
         'nothing'
       );
 
-      await wait(0);
+      await waitFor(() => {
+        expect(client.searchForFacetValues).toHaveBeenCalledTimes(7);
 
-      expect(
-        container.querySelector('.ais-RefinementList-noResults')
-      ).toHaveTextContent('No results.');
+        expect(
+          container.querySelector('.ais-RefinementList-noResults')
+        ).toHaveTextContent('No results.');
+      });
+
       expect(container.querySelector('.ais-RefinementList-list')).toBeNull();
       expect(container).toMatchInlineSnapshot(`
         <div>
@@ -1009,9 +1009,8 @@ describe('RefinementList', () => {
 
   describe('Show more / less', () => {
     test('displays a "Show more" button', async () => {
-      const client = createSearchClient({ search });
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" showMore={true} />
         </InstantSearchHooksTestWrapper>
       );
@@ -1278,18 +1277,17 @@ describe('RefinementList', () => {
 
       userEvent.click(showMoreButton);
 
-      await wait(0);
-
-      expect(showMoreButton).toHaveTextContent('Show less');
-      expect(
-        container.querySelectorAll('.ais-RefinementList-item')
-      ).toHaveLength(20);
+      await waitFor(() => {
+        expect(showMoreButton).toHaveTextContent('Show less');
+        expect(
+          container.querySelectorAll('.ais-RefinementList-item')
+        ).toHaveLength(20);
+      });
     });
 
     test('limits the number of items to reveal', async () => {
-      const client = createSearchClient({ search });
       const { container } = render(
-        <InstantSearchHooksTestWrapper searchClient={client}>
+        <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
             attribute="brand"
             showMore={true}
@@ -1314,21 +1312,20 @@ describe('RefinementList', () => {
         ) as HTMLButtonElement
       );
 
-      await wait(0);
-
-      expect(
-        container.querySelectorAll('.ais-RefinementList-item')
-      ).toHaveLength(11);
-      expect(
-        container.querySelector('.ais-RefinementList-showMore')
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.ais-RefinementList-item')
+        ).toHaveLength(11);
+        expect(
+          container.querySelector('.ais-RefinementList-showMore')
+        ).toBeInTheDocument();
+      });
     });
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const client = createSearchClient({ search });
     const { container } = render(
-      <InstantSearchHooksTestWrapper searchClient={client}>
+      <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList
           attribute="brand"
           className="MyRefinementList"

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RefinementList.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -114,13 +114,14 @@ describe('RefinementList', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll('.ais-RefinementList-item')
+      ).toHaveLength(10)
+    );
 
     expect(client.search).toHaveBeenCalledTimes(1);
 
-    expect(container.querySelectorAll('.ais-RefinementList-item')).toHaveLength(
-      10
-    );
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -396,7 +397,11 @@ describe('RefinementList', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll('.ais-RefinementList-item').length
+      ).toEqual(10);
+    });
 
     const [checkbox1, checkbox2] = [
       ...(container.querySelectorAll(
@@ -428,11 +433,12 @@ describe('RefinementList', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(container.querySelectorAll('.ais-RefinementList-item')).toHaveLength(
-      5
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll('.ais-RefinementList-item')
+      ).toHaveLength(5)
     );
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -578,26 +584,24 @@ describe('RefinementList', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(
-      [...container.querySelectorAll('.ais-RefinementList-item')].map(
-        (item) => item.textContent
-      )
-    ).toMatchInlineSnapshot(`
-      Array [
-        "Insignia™746",
-        "Samsung633",
-        "Metra591",
-        "HP530",
-        "Apple442",
-        "GE394",
-        "Sony350",
-        "Incipio320",
-        "KitchenAid318",
-        "Whirlpool298",
-      ]
-    `);
+    await waitFor(() => {
+      expect(
+        Array.from(container.querySelectorAll('.ais-RefinementList-item')).map(
+          (item) => item.textContent
+        )
+      ).toEqual([
+        'Insignia™746',
+        'Samsung633',
+        'Metra591',
+        'HP530',
+        'Apple442',
+        'GE394',
+        'Sony350',
+        'Incipio320',
+        'KitchenAid318',
+        'Whirlpool298',
+      ]);
+    });
   });
 
   describe('sorting', () => {
@@ -609,24 +613,24 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-RefinementList-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'Apple',
-        'Canon',
-        'Dell',
-        'Dynex™',
-        'Epson',
-        'Frigidaire',
-        'GE',
-        'HP',
-        'Hamilton Beach',
-        'Incipio',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-RefinementList-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Apple',
+          'Canon',
+          'Dell',
+          'Dynex™',
+          'Epson',
+          'Frigidaire',
+          'GE',
+          'HP',
+          'Hamilton Beach',
+          'Incipio',
+        ]);
+      });
     });
 
     test('sorts the items by descending name', async () => {
@@ -637,24 +641,24 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-RefinementList-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'Whirlpool',
-        'Speck',
-        'Sony',
-        'Samsung',
-        'Platinum',
-        'OtterBox',
-        'Metra',
-        'LG',
-        'KitchenAid',
-        'Insignia™',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-RefinementList-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Whirlpool',
+          'Speck',
+          'Sony',
+          'Samsung',
+          'Platinum',
+          'OtterBox',
+          'Metra',
+          'LG',
+          'KitchenAid',
+          'Insignia™',
+        ]);
+      });
     });
 
     test('sorts the items by count', async () => {
@@ -665,24 +669,24 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(container.querySelectorAll('.ais-RefinementList-count')).map(
-          (item) => item.textContent
-        )
-      ).toEqual([
-        '746',
-        '633',
-        '591',
-        '530',
-        '442',
-        '394',
-        '350',
-        '320',
-        '318',
-        '298',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-RefinementList-count')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          '746',
+          '633',
+          '591',
+          '530',
+          '442',
+          '394',
+          '350',
+          '320',
+          '318',
+          '298',
+        ]);
+      });
     });
 
     test('sorts the items by refinement state', async () => {
@@ -693,24 +697,24 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-RefinementList-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'Insignia™',
-        'Samsung',
-        'Metra',
-        'HP',
-        'Apple',
-        'GE',
-        'Sony',
-        'Incipio',
-        'KitchenAid',
-        'Whirlpool',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-RefinementList-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Insignia™',
+          'Samsung',
+          'Metra',
+          'HP',
+          'Apple',
+          'GE',
+          'Sony',
+          'Incipio',
+          'KitchenAid',
+          'Whirlpool',
+        ]);
+      });
 
       const [checkbox1, checkbox2] = Array.from(
         container.querySelectorAll(
@@ -721,24 +725,24 @@ describe('RefinementList', () => {
       userEvent.click(checkbox1);
       userEvent.click(checkbox2);
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-RefinementList-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'KitchenAid',
-        'Whirlpool',
-        'Insignia™',
-        'Samsung',
-        'Metra',
-        'HP',
-        'Apple',
-        'GE',
-        'Sony',
-        'Incipio',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-RefinementList-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'KitchenAid',
+          'Whirlpool',
+          'Insignia™',
+          'Samsung',
+          'Metra',
+          'HP',
+          'Apple',
+          'GE',
+          'Sony',
+          'Incipio',
+        ]);
+      });
     });
 
     test('sorts the items using a sorting function', async () => {
@@ -752,24 +756,24 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-RefinementList-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'HP',
-        'GE',
-        'LG',
-        'Sony',
-        'Dell',
-        'Metra',
-        'Apple',
-        'Canon',
-        'Speck',
-        'Epson',
-      ]);
+      await waitFor(() => {
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-RefinementList-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'HP',
+          'GE',
+          'LG',
+          'Sony',
+          'Dell',
+          'Metra',
+          'Apple',
+          'Canon',
+          'Speck',
+          'Epson',
+        ]);
+      });
     });
   });
 
@@ -786,75 +790,77 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
-
       const searchInput = container.querySelector(
         '.ais-SearchBox-input'
       ) as HTMLInputElement;
 
-      expect(
-        container.querySelector('.ais-RefinementList-searchBox')
-      ).toBeInTheDocument();
-      expect(searchInput).toHaveAttribute('placeholder', 'Search brands');
-      expect(
-        container.querySelector('.ais-Highlight-nonHighlighted')
-      ).toBeNull();
-      expect(container.querySelector('.ais-Highlight-highlighted')).toBeNull();
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-RefinementList-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'Insignia™',
-        'Samsung',
-        'Metra',
-        'HP',
-        'Apple',
-        'GE',
-        'Sony',
-        'Incipio',
-        'KitchenAid',
-        'Whirlpool',
-      ]);
+      await waitFor(() => {
+        expect(
+          container.querySelector('.ais-RefinementList-searchBox')
+        ).toBeInTheDocument();
+        expect(searchInput).toHaveAttribute('placeholder', 'Search brands');
+        expect(
+          container.querySelector('.ais-Highlight-nonHighlighted')
+        ).toBeNull();
+        expect(
+          container.querySelector('.ais-Highlight-highlighted')
+        ).toBeNull();
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-RefinementList-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Insignia™',
+          'Samsung',
+          'Metra',
+          'HP',
+          'Apple',
+          'GE',
+          'Sony',
+          'Incipio',
+          'KitchenAid',
+          'Whirlpool',
+        ]);
+      });
 
       userEvent.type(searchInput, 'app');
 
-      await wait(0);
-
-      // One call per keystroke
-      expect(client.searchForFacetValues).toHaveBeenCalledTimes(3);
-      expect(client.searchForFacetValues).toHaveBeenLastCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({
-            params: expect.objectContaining({
-              facetName: 'brand',
-              facetQuery: 'app',
+      await waitFor(() => {
+        // One call per keystroke
+        expect(client.searchForFacetValues).toHaveBeenCalledTimes(3);
+        expect(client.searchForFacetValues).toHaveBeenLastCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              params: expect.objectContaining({
+                facetName: 'brand',
+                facetQuery: 'app',
+              }),
             }),
-          }),
-        ])
-      );
-      expect(
-        container.querySelector('.ais-Highlight-nonHighlighted')
-      ).not.toBeNull();
-      expect(
-        container.querySelector('.ais-Highlight-highlighted')
-      ).not.toBeNull();
-      expect(
-        Array.from(
-          container.querySelectorAll('.ais-RefinementList-labelText')
-        ).map((item) => item.textContent)
-      ).toEqual([
-        'Apple',
-        'Alpine',
-        'APC',
-        'Amped Wireless',
-        "Applebee's",
-        'Amplicom',
-        'Apollo Enclosures',
-        'Apple®',
-        'Applica',
-        'Apricorn',
-      ]);
+          ])
+        );
+        expect(
+          container.querySelector('.ais-Highlight-nonHighlighted')
+        ).not.toBeNull();
+        expect(
+          container.querySelector('.ais-Highlight-highlighted')
+        ).not.toBeNull();
+        expect(
+          Array.from(
+            container.querySelectorAll('.ais-RefinementList-labelText')
+          ).map((item) => item.textContent)
+        ).toEqual([
+          'Apple',
+          'Alpine',
+          'APC',
+          'Amped Wireless',
+          "Applebee's",
+          'Amplicom',
+          'Apollo Enclosures',
+          'Apple®',
+          'Applica',
+          'Apricorn',
+        ]);
+      });
     });
 
     test('displays a fallback when there are no results', async () => {
@@ -1010,16 +1016,18 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
+      await waitFor(() =>
+        expect(
+          container.querySelectorAll('.ais-RefinementList-item')
+        ).toHaveLength(10)
+      );
 
       const showMoreButton = container.querySelector(
         '.ais-RefinementList-showMore'
       ) as HTMLButtonElement;
 
       expect(showMoreButton).toHaveTextContent('Show more');
-      expect(
-        container.querySelectorAll('.ais-RefinementList-item')
-      ).toHaveLength(10);
+
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
@@ -1290,11 +1298,12 @@ describe('RefinementList', () => {
         </InstantSearchHooksTestWrapper>
       );
 
-      await wait(0);
+      await waitFor(() =>
+        expect(
+          container.querySelectorAll('.ais-RefinementList-item')
+        ).toHaveLength(10)
+      );
 
-      expect(
-        container.querySelectorAll('.ais-RefinementList-item')
-      ).toHaveLength(10);
       expect(
         container.querySelector('.ais-RefinementList-showMore')
       ).toBeInTheDocument();

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/RefinementList.test.tsx
@@ -11,7 +11,7 @@ import {
 import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { RefinementList } from '../RefinementList';
 
-function getNewSearchClient(parameters: Record<string, any> = {}) {
+function createMockedSearchClient(parameters: Record<string, any> = {}) {
   return createSearchClient({
     search: jest.fn((requests) => {
       return Promise.resolve(
@@ -112,7 +112,7 @@ function getNewSearchClient(parameters: Record<string, any> = {}) {
 
 describe('RefinementList', () => {
   test('renders with props', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList attribute="brand" />
@@ -396,7 +396,7 @@ describe('RefinementList', () => {
   });
 
   test('enables conjunctive faceting', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList attribute="brand" operator="and" />
@@ -432,7 +432,7 @@ describe('RefinementList', () => {
   });
 
   test('limits the number of items to display', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList attribute="brand" limit={5} />
@@ -575,7 +575,7 @@ describe('RefinementList', () => {
   });
 
   test('transforms the items', async () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList
@@ -612,7 +612,7 @@ describe('RefinementList', () => {
 
   describe('sorting', () => {
     test('sorts the items by ascending name', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['name:asc']} />
@@ -640,7 +640,7 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items by descending name', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['name:desc']} />
@@ -668,7 +668,7 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items by count', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['count']} />
@@ -696,7 +696,7 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items by refinement state', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" sortBy={['isRefined']} />
@@ -752,7 +752,7 @@ describe('RefinementList', () => {
     });
 
     test('sorts the items using a sorting function', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
@@ -785,7 +785,7 @@ describe('RefinementList', () => {
 
   describe('searching', () => {
     test('displays a search box', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
@@ -870,7 +870,7 @@ describe('RefinementList', () => {
     });
 
     test('displays a fallback when there are no results', async () => {
-      const searchClient = getNewSearchClient({
+      const searchClient = createMockedSearchClient({
         searchForFacetValues: jest.fn(() =>
           Promise.resolve([createSFFVResponse({ facetHits: [] })])
         ),
@@ -1017,7 +1017,7 @@ describe('RefinementList', () => {
 
   describe('Show more / less', () => {
     test('displays a "Show more" button', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList attribute="brand" showMore={true} />
@@ -1295,7 +1295,7 @@ describe('RefinementList', () => {
     });
 
     test('limits the number of items to reveal', async () => {
-      const searchClient = getNewSearchClient();
+      const searchClient = createMockedSearchClient();
       const { container } = render(
         <InstantSearchHooksTestWrapper searchClient={searchClient}>
           <RefinementList
@@ -1334,7 +1334,7 @@ describe('RefinementList', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const searchClient = getNewSearchClient();
+    const searchClient = createMockedSearchClient();
     const { container } = render(
       <InstantSearchHooksTestWrapper searchClient={searchClient}>
         <RefinementList

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SortBy.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SortBy.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -128,29 +128,29 @@ describe('SortBy', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(client.search).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ indexName: 'instant_search' }),
-      ])
-    );
+    await waitFor(() => {
+      expect(client.search).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ indexName: 'instant_search' }),
+        ])
+      );
+    });
 
     userEvent.selectOptions(
       document.querySelector('.ais-SortBy-select') as HTMLSelectElement,
       getByRole('option', { name: 'Price (asc)' })
     );
 
-    await wait(0);
-
-    expect(document.querySelector('.ais-SortBy-select')).toHaveValue(
-      'instant_search_price_asc'
-    );
-    expect(client.search).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ indexName: 'instant_search_price_asc' }),
-      ])
-    );
+    await waitFor(() => {
+      expect(document.querySelector('.ais-SortBy-select')).toHaveValue(
+        'instant_search_price_asc'
+      );
+      expect(client.search).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ indexName: 'instant_search_price_asc' }),
+        ])
+      );
+    });
   });
 
   test('forwards custom class names and `div` props to the root element', () => {

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SortBy.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SortBy.test.tsx
@@ -3,11 +3,11 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { createSearchClient } from '../../../../../test/mock';
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { SortBy } from '../SortBy';
 
 describe('SortBy', () => {
-  test('renders with props', async () => {
+  test('renders with props', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <SortBy
@@ -20,11 +20,6 @@ describe('SortBy', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(document.querySelector('.ais-SortBy-select')).toHaveValue(
-      'instant_search'
-    );
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
@@ -57,7 +52,7 @@ describe('SortBy', () => {
     `);
   });
 
-  test('transform the passed items', async () => {
+  test('transform the passed items', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <SortBy
@@ -75,8 +70,6 @@ describe('SortBy', () => {
         />
       </InstantSearchHooksTestWrapper>
     );
-
-    await wait(0);
 
     expect(container).toMatchInlineSnapshot(`
       <div>

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SortBy.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SortBy.test.tsx
@@ -20,6 +20,10 @@ describe('SortBy', () => {
       </InstantSearchHooksTestWrapper>
     );
 
+    expect(document.querySelector('.ais-SortBy-select')).toHaveValue(
+      'instant_search'
+    );
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ToggleRefinement.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ToggleRefinement.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -86,9 +86,9 @@ describe('ToggleRefinement', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(client.search).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(client.search).toHaveBeenCalledTimes(1);
+    });
 
     const checkbox = container.querySelector<HTMLInputElement>(
       '.ais-ToggleRefinement-checkbox'
@@ -98,38 +98,38 @@ describe('ToggleRefinement', () => {
 
     userEvent.click(checkbox);
 
-    await wait(0);
-
-    expect(client.search).toHaveBeenCalledTimes(2);
-    expect(client.search).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          params: {
-            facetFilters: [['free_shipping:true']],
-            facets: ['free_shipping'],
-            tagFilters: '',
-          },
-        }),
-      ])
-    );
-    expect(checkbox.checked).toBe(true);
+    await waitFor(() => {
+      expect(client.search).toHaveBeenCalledTimes(2);
+      expect(client.search).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            params: {
+              facetFilters: [['free_shipping:true']],
+              facets: ['free_shipping'],
+              tagFilters: '',
+            },
+          }),
+        ])
+      );
+      expect(checkbox.checked).toBe(true);
+    });
 
     userEvent.click(checkbox);
 
-    await wait(0);
-
-    expect(client.search).toHaveBeenCalledTimes(3);
-    expect(client.search).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          params: expect.objectContaining({
-            facets: ['free_shipping'],
-            tagFilters: '',
+    await waitFor(() => {
+      expect(client.search).toHaveBeenCalledTimes(3);
+      expect(client.search).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            params: expect.objectContaining({
+              facets: ['free_shipping'],
+              tagFilters: '',
+            }),
           }),
-        }),
-      ])
-    );
-    expect(checkbox.checked).toBe(false);
+        ])
+      );
+      expect(checkbox.checked).toBe(false);
+    });
   });
 
   test('changes the value to filter on and off', async () => {
@@ -141,9 +141,9 @@ describe('ToggleRefinement', () => {
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
-    expect(client.search).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(client.search).toHaveBeenCalledTimes(1);
+    });
 
     const checkbox = container.querySelector<HTMLInputElement>(
       '.ais-ToggleRefinement-checkbox'
@@ -151,35 +151,37 @@ describe('ToggleRefinement', () => {
 
     userEvent.click(checkbox);
 
-    await wait(0);
-
-    expect(client.search).toHaveBeenCalledTimes(2);
-    expect(client.search).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          params: {
-            facetFilters: [['free_shipping:yes']],
-            facets: ['free_shipping'],
-            tagFilters: '',
-          },
-        }),
-      ])
-    );
+    await waitFor(() => {
+      expect(checkbox).toBeChecked();
+      expect(client.search).toHaveBeenCalledTimes(2);
+      expect(client.search).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            params: {
+              facetFilters: [['free_shipping:yes']],
+              facets: ['free_shipping'],
+              tagFilters: '',
+            },
+          }),
+        ])
+      );
+    });
 
     userEvent.click(checkbox);
 
-    await wait(0);
-
-    expect(client.search).toHaveBeenCalledTimes(3);
-    expect(client.search).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          params: expect.objectContaining({
-            facetFilters: [['free_shipping:no']],
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+      expect(client.search).toHaveBeenCalledTimes(3);
+      expect(client.search).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            params: expect.objectContaining({
+              facetFilters: [['free_shipping:no']],
+            }),
           }),
-        }),
-      ])
-    );
+        ])
+      );
+    });
   });
 
   test('forwards custom class names and `div` props to the root element', () => {

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ToggleRefinement.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/ToggleRefinement.test.tsx
@@ -3,18 +3,16 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { createSearchClient } from '../../../../../test/mock';
-import { InstantSearchHooksTestWrapper, wait } from '../../../../../test/utils';
+import { InstantSearchHooksTestWrapper } from '../../../../../test/utils';
 import { ToggleRefinement } from '../ToggleRefinement';
 
 describe('ToggleRefinement', () => {
-  test('renders with props', async () => {
+  test('renders with props', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <ToggleRefinement attribute="free_shipping" />
       </InstantSearchHooksTestWrapper>
     );
-
-    await wait(0);
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -39,21 +37,19 @@ describe('ToggleRefinement', () => {
     `);
   });
 
-  test('customizes the label', async () => {
+  test('customizes the label', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>
         <ToggleRefinement attribute="free_shipping" label="Free shipping" />
       </InstantSearchHooksTestWrapper>
     );
 
-    await wait(0);
-
     expect(
       container.querySelector('.ais-ToggleRefinement-labelText')
     ).toHaveTextContent('Free shipping');
   });
 
-  test('renders checked when the attribute is refined', async () => {
+  test('renders checked when the attribute is refined', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper
         initialUiState={{
@@ -67,8 +63,6 @@ describe('ToggleRefinement', () => {
         <ToggleRefinement attribute="free_shipping" />
       </InstantSearchHooksTestWrapper>
     );
-
-    await wait(0);
 
     expect(
       container.querySelector<HTMLInputElement>(

--- a/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
@@ -2,7 +2,6 @@ import { act, render, waitFor } from '@testing-library/react';
 import React, { createRef } from 'react';
 
 import { createSearchClient } from '../../../../../test/mock';
-import { wait } from '../../../../../test/utils';
 import { useHierarchicalMenu } from '../../connectors/useHierarchicalMenu';
 import { useMenu } from '../../connectors/useMenu';
 import { usePagination } from '../../connectors/usePagination';
@@ -405,7 +404,6 @@ describe('DynamicWidgets', () => {
 
     const { container, rerender } = render(<App attributes={['brand']} />);
 
-    await wait(0);
     await waitFor(() => {
       expect(container).toMatchInlineSnapshot(`
 <div>
@@ -423,8 +421,8 @@ describe('DynamicWidgets', () => {
       rerender(<App attributes={['brand', 'categories']} />);
     });
 
-    await wait(0);
     await waitFor(() => {
+      expect(searchClient.search).toHaveBeenCalledTimes(3);
       expect(container).toMatchInlineSnapshot(`
 <div>
   RefinementList(brand)
@@ -443,8 +441,8 @@ describe('DynamicWidgets', () => {
       rerender(<App attributes={['brand']} />);
     });
 
-    await wait(0);
     await waitFor(() => {
+      expect(searchClient.search).toHaveBeenCalledTimes(5);
       expect(container).toMatchInlineSnapshot(`
 <div>
   RefinementList(brand)

--- a/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
@@ -126,12 +126,14 @@ describe('DynamicWidgets', () => {
     );
 
     await waitFor(() => {
-      expect(container).toMatchInlineSnapshot(`
-<div>
-  RefinementList(brand)
-</div>
-`);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        RefinementList(brand)
+      </div>
+    `);
 
     expect(indexContextRef.current!.getWidgets()).toEqual([
       expect.objectContaining({ $$type: 'ais.refinementList' }),
@@ -156,20 +158,22 @@ describe('DynamicWidgets', () => {
     );
 
     await waitFor(() => {
-      expect(container).toMatchInlineSnapshot(`
-<div>
-  <div
-    class="ais-Panel"
-  >
-    <div
-      class="ais-Panel-body"
-    >
-      RefinementList(brand)
-    </div>
-  </div>
-</div>
-`);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Panel"
+        >
+          <div
+            class="ais-Panel-body"
+          >
+            RefinementList(brand)
+          </div>
+        </div>
+      </div>
+    `);
 
     expect(indexContextRef.current!.getWidgets()).toEqual([
       expect.objectContaining({ $$type: 'ais.refinementList' }),
@@ -267,12 +271,14 @@ describe('DynamicWidgets', () => {
     );
 
     await waitFor(() => {
-      expect(container).toMatchInlineSnapshot(`
-<div>
-  RefinementList(brand)
-</div>
-`);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        RefinementList(brand)
+      </div>
+    `);
 
     expect(indexContextRef.current!.getWidgets()).toEqual([
       expect.objectContaining({ $$type: 'ais.refinementList' }),
@@ -300,14 +306,16 @@ describe('DynamicWidgets', () => {
     );
 
     await waitFor(() => {
-      expect(container).toMatchInlineSnapshot(`
-<div>
-  RefinementList(brand)
-  Menu(categories)
-  Menu(hierarchicalCategories.lvl0)
-</div>
-`);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        RefinementList(brand)
+        Menu(categories)
+        Menu(hierarchicalCategories.lvl0)
+      </div>
+    `);
 
     expect(indexContextRef.current!.getWidgets()).toEqual([
       expect.objectContaining({ $$type: 'ais.refinementList' }),
@@ -336,14 +344,16 @@ describe('DynamicWidgets', () => {
     );
 
     await waitFor(() => {
-      expect(container).toMatchInlineSnapshot(`
-<div>
-  RefinementList(brand)
-  Menu(categories)
-  Menu(hierarchicalCategories.lvl0)
-</div>
-`);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        RefinementList(brand)
+        Menu(categories)
+        Menu(hierarchicalCategories.lvl0)
+      </div>
+    `);
   });
 
   test('renders dynamic widgets in an Index', async () => {
@@ -361,12 +371,14 @@ describe('DynamicWidgets', () => {
     );
 
     await waitFor(() => {
-      expect(container).toMatchInlineSnapshot(`
-<div>
-  RefinementList(brand)
-</div>
-`);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        RefinementList(brand)
+      </div>
+    `);
 
     const index = indexContextRef
       .current!.getWidgets()
@@ -405,12 +417,14 @@ describe('DynamicWidgets', () => {
     const { container, rerender } = render(<App attributes={['brand']} />);
 
     await waitFor(() => {
-      expect(container).toMatchInlineSnapshot(`
-<div>
-  RefinementList(brand)
-</div>
-`);
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
     });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        RefinementList(brand)
+      </div>
+    `);
 
     expect(indexContextRef.current!.getWidgets()).toEqual([
       expect.objectContaining({ $$type: 'ais.refinementList' }),
@@ -423,13 +437,14 @@ describe('DynamicWidgets', () => {
 
     await waitFor(() => {
       expect(searchClient.search).toHaveBeenCalledTimes(3);
-      expect(container).toMatchInlineSnapshot(`
-<div>
-  RefinementList(brand)
-  Menu(categories)
-</div>
-`);
     });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        RefinementList(brand)
+        Menu(categories)
+      </div>
+    `);
 
     expect(indexContextRef.current!.getWidgets()).toEqual([
       expect.objectContaining({ $$type: 'ais.refinementList' }),
@@ -443,12 +458,13 @@ describe('DynamicWidgets', () => {
 
     await waitFor(() => {
       expect(searchClient.search).toHaveBeenCalledTimes(5);
-      expect(container).toMatchInlineSnapshot(`
-<div>
-  RefinementList(brand)
-</div>
-`);
     });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        RefinementList(brand)
+      </div>
+    `);
 
     expect(indexContextRef.current!.getWidgets()).toEqual([
       expect.objectContaining({ $$type: 'ais.refinementList' }),

--- a/test/mock/createSearchClient.ts
+++ b/test/mock/createSearchClient.ts
@@ -20,8 +20,10 @@ type OverrideKeys<TTarget, TOptions> = TOptions extends Record<string, never>
   ? TTarget
   : Omit<TTarget, keyof TOptions> & TOptions;
 
-type SearchClient = OverrideKeys<
-  ReturnType<typeof algoliasearch>,
+type SearchClient = ReturnType<typeof algoliasearch>;
+
+type MockSearchClient = OverrideKeys<
+  SearchClient,
   {
     search: jest.Mock<any, any>;
     searchForFacetValues: jest.Mock<any, any>;
@@ -30,7 +32,7 @@ type SearchClient = OverrideKeys<
 
 export function createSearchClient<TOptions extends Partial<SearchClient>>(
   options: TOptions
-): OverrideKeys<SearchClient, TOptions> {
+): OverrideKeys<MockSearchClient, TOptions> {
   const appId = (options as Record<string, unknown>).appId || 'appId';
 
   // check if algoliasearch is v4 (has transporter)
@@ -92,5 +94,5 @@ export function createSearchClient<TOptions extends Partial<SearchClient>>(
       Promise.resolve([createSFFVResponse()])
     ),
     ...options,
-  } as SearchClient as OverrideKeys<SearchClient, TOptions>;
+  } as SearchClient as OverrideKeys<MockSearchClient, TOptions>;
 }

--- a/test/mock/createSearchClient.ts
+++ b/test/mock/createSearchClient.ts
@@ -20,7 +20,13 @@ type OverrideKeys<TTarget, TOptions> = TOptions extends Record<string, never>
   ? TTarget
   : Omit<TTarget, keyof TOptions> & TOptions;
 
-type SearchClient = ReturnType<typeof algoliasearch>;
+type SearchClient = OverrideKeys<
+  ReturnType<typeof algoliasearch>,
+  {
+    search: jest.Mock<any, any>;
+    searchForFacetValues: jest.Mock<any, any>;
+  }
+>;
 
 export function createSearchClient<TOptions extends Partial<SearchClient>>(
   options: TOptions


### PR DESCRIPTION
**Summary**

PR in support of `feat/react-18` that makes our tests pass with React 18.

Ticket: [FX-1450](https://algolia.atlassian.net/browse/FX-1450)

**TODO**

- [x] rely more on `waitFor` ~~or find a way to force rerender instead of waiting for an arbitrary duration~~
- [ ] ~~address issue with React 18 Strict Mode in dev environment and `<InstantSearch>` ([doc](https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state))~~ (to be done in a subsequent PR)

> **Note**
> CI is not expected to pass as the Strict Mode in React 18 performs more operations which make the relevant tests in our codebase fail. All the other tests should perform correctly.