### PR TITLE
docs(github): add React version in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -32,9 +32,10 @@ https://codesandbox.io/s/github/algolia/create-instantsearch-app/tree/templates/
 
 ## Environment
 
+- React InstantSearch version: [e.g. 6.24.0]
+- React version: [e.g. 18.1.0]
+- Browser: [e.g. Chrome 102.0.5005.61, Safari 15.2]
 - OS: [e.g. Windows / Linux / macOS / iOS / Android]
-- Browser: [e.g. Chrome, Safari]
-- Version: [e.g. 22]
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/Bug_report_Hooks.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report_Hooks.md
@@ -32,9 +32,10 @@ https://codesandbox.io/s/github/algolia/react-instantsearch/tree/master/examples
 
 ## Environment
 
+- React InstantSearch Hooks version: [e.g. 6.24.0]
+- React version: [e.g. 18.1.0]
+- Browser: [e.g. Chrome 102.0.5005.61, Safari 15.2]
 - OS: [e.g. Windows / Linux / macOS / iOS / Android]
-- Browser: [e.g. Chrome, Safari]
-- Version: [e.g. 22]
 
 ## Additional context
 


### PR DESCRIPTION
This adds the React version in the GitHub issue template to better track on what React version the InstantSearch bug appears. (We're seeing more bugs happen on React 18 only.)