### PR TITLE
fix(hooks-web): don't pass widget props to ui components

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/widgets/Hits.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Hits.tsx
@@ -18,10 +18,15 @@ export type HitsProps<THit extends BaseHit> = Omit<
 > &
   UseHitsProps<THit>;
 
-export function Hits<THit extends BaseHit = BaseHit>(props: HitsProps<THit>) {
-  const { hits, sendEvent } = useHits<THit>(props, {
-    $$widgetType: 'ais.hits',
-  });
+export function Hits<THit extends BaseHit = BaseHit>({
+  escapeHTML,
+  transformItems,
+  ...props
+}: HitsProps<THit>) {
+  const { hits, sendEvent } = useHits<THit>(
+    { escapeHTML, transformItems },
+    { $$widgetType: 'ais.hits' }
+  );
 
   const uiProps: UiProps<THit> = {
     hits,

--- a/packages/react-instantsearch-hooks-web/src/widgets/HitsPerPage.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/HitsPerPage.tsx
@@ -15,12 +15,17 @@ export type HitsPerPageProps = Omit<
   HitsPerPageUiComponentProps,
   keyof UiProps
 > &
-  UseHitsPerPageProps;
+  UseHitsPerPageProps & { notASwag: true };
 
-export function HitsPerPage(props: HitsPerPageProps) {
-  const { items, refine } = useHitsPerPage(props, {
-    $$widgetType: 'ais.hitsPerPage',
-  });
+export function HitsPerPage({
+  items: userItems,
+  transformItems,
+  ...props
+}: HitsPerPageProps) {
+  const { items, refine } = useHitsPerPage(
+    { items: userItems, transformItems },
+    { $$widgetType: 'ais.hitsPerPage' }
+  );
   const { value: currentValue } =
     items.find(({ isRefined }) => isRefined)! || {};
 

--- a/packages/react-instantsearch-hooks-web/src/widgets/HitsPerPage.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/HitsPerPage.tsx
@@ -15,7 +15,7 @@ export type HitsPerPageProps = Omit<
   HitsPerPageUiComponentProps,
   keyof UiProps
 > &
-  UseHitsPerPageProps & { notASwag: true };
+  UseHitsPerPageProps;
 
 export function HitsPerPage({
   items: userItems,

--- a/packages/react-instantsearch-hooks-web/src/widgets/InfiniteHits.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/InfiniteHits.tsx
@@ -33,10 +33,17 @@ export type InfiniteHitsProps<THit extends BaseHit = BaseHit> = Omit<
 
 export function InfiniteHits<THit extends BaseHit = BaseHit>({
   showPrevious: shouldShowPrevious = true,
+  cache,
+  escapeHTML,
+  showPrevious: userShowPrevious,
+  transformItems,
   ...props
 }: InfiniteHitsProps<THit>) {
   const { hits, sendEvent, showPrevious, showMore, isFirstPage, isLastPage } =
-    useInfiniteHits<THit>(props, { $$widgetType: 'ais.infiniteHits' });
+    useInfiniteHits<THit>(
+      { cache, escapeHTML, showPrevious: userShowPrevious, transformItems },
+      { $$widgetType: 'ais.infiniteHits' }
+    );
 
   const uiProps: UiProps<THit> = {
     hits,


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Similar to #3499, but i did a search for other places props was used literally in -web

We'd get a typescript error for these if https://github.com/microsoft/TypeScript/issues/39998 was fixed, but that doesn't seem to be on their table yet

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

all connector props are correctly avoided to be passed to the ui component
