### PR TITLE
chore(hooks-web): track bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,10 @@
       "maxSize": "40 kB"
     },
     {
+      "path": "packages/react-instantsearch-hooks-web/dist/umd/ReactInstantSearchHooksDOM.min.js",
+      "maxSize": "48 kB"
+    },
+    {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",
       "maxSize": "44.75 kB"
     },


### PR DESCRIPTION
This tracks the `react-instantsearch-hooks-web` bundle size.

Notice that the UMD export is named `ReactInstantSearchHooksDOM` but I believe we wanted to go for `ReactInstantSearchHooksWeb`, like the package name.