### PR TITLE
fix(hooks-web): fix duplicated key in <CurrentRefinements>

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/ui/CurrentRefinements.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/CurrentRefinements.tsx
@@ -91,7 +91,7 @@ export function CurrentRefinements({
       >
         {items.map((item) => (
           <li
-            key={item.label}
+            key={[item.indexName, item.label].join('/')}
             className={cx('ais-CurrentRefinements-item', classNames.item)}
           >
             <span


### PR DESCRIPTION
When you use multiple `<Index>` widgets with widgets with the same attribute, and then refine both these widgets, the `<CurrentRefinements>` displays a React key warning because the keys are identical.

This adds the index name to the label key to have unique keys.