### PR TITLE
fix(hooks): mount widgets in SSR to retrieve HTML

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     '<rootDir>/examples/',
     '/__utils__/',
   ],
-  snapshotSerializers: ['enzyme-to-json/serializer'],
+  snapshotSerializers: ['enzyme-to-json/serializer', 'jest-serializer-html'],
   testEnvironment: 'jsdom',
   watchPlugins: [
     'jest-watch-typeahead/filename',

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "website:build": "yarn build && yarn webpack --config website/webpack.config.js"
   },
   "devDependencies": {
-    "@algolia/client-search": "4.11.0",
     "@algolia/cache-common": "4.11.0",
     "@algolia/cache-in-memory": "4.11.0",
+    "@algolia/client-search": "4.11.0",
     "@algolia/logger-common": "4.11.0",
     "@algolia/requester-node-http": "4.11.0",
     "@algolia/transporter": "4.11.0",
@@ -114,6 +114,7 @@
     "instantsearch.css": "7.4.5",
     "jest": "27.4.7",
     "jest-diff": "27.4.6",
+    "jest-serializer-html": "7.1.0",
     "jest-watch-typeahead": "1.0.0",
     "json": "9.0.6",
     "latest-version": "5.1.0",

--- a/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
@@ -3,16 +3,16 @@
  */
 
 import React, { version as ReactVersion } from 'react';
+import { renderToString } from 'react-dom/server';
 import {
   InstantSearch,
   InstantSearchSSRProvider,
   Index,
   DynamicWidgets,
-  useHits,
-  useRefinementList,
-  useSearchBox,
   version,
+  useSearchBox,
 } from 'react-instantsearch-hooks';
+import { Hits, RefinementList } from 'react-instantsearch-hooks-web';
 
 import { createSearchClient } from '../../../../test/mock';
 import { getServerState } from '../getServerState';
@@ -20,8 +20,19 @@ import { getServerState } from '../getServerState';
 import type {
   InstantSearchServerState,
   InstantSearchProps,
-  UseRefinementListProps,
 } from 'react-instantsearch-hooks';
+
+function SearchBox() {
+  const { query } = useSearchBox();
+
+  return (
+    <div className="ais-SearchBox">
+      <form action="" className="ais-SearchBox-form" noValidate>
+        <input className="ais-SearchBox-input" type="search" value={query} />
+      </form>
+    </div>
+  );
+}
 
 type CreateTestEnvironmentProps = {
   searchClient: InstantSearchProps['searchClient'];
@@ -55,17 +66,22 @@ function createTestEnvironment({
         {children}
         <RefinementList attribute="brand" />
         <SearchBox />
+
+        <h2>instant_search</h2>
         <Hits />
 
         <Index indexName="instant_search_price_asc">
+          <h2>instant_search_price_asc</h2>
           <Hits />
 
           <Index indexName="instant_search_rating_desc">
+            <h2>instant_search_rating_desc</h2>
             <Hits />
           </Index>
         </Index>
 
         <Index indexName="instant_search_price_desc">
+          <h2>instant_search_price_desc</h2>
           <Hits />
         </Index>
       </InstantSearch>
@@ -362,19 +378,58 @@ describe('getServerState', () => {
       },
     });
   });
+
+  test('returns HTML from server state', async () => {
+    const searchClient = createSearchClient({});
+    const { App } = createTestEnvironment({ searchClient });
+
+    const serverState = await getServerState(<App />);
+    const html = renderToString(<App serverState={serverState} />);
+
+    expect(html).toMatchInlineSnapshot(`
+      <div class="ais-RefinementList ais-RefinementList--noRefinement">
+        <ul class="ais-RefinementList-list">
+        </ul>
+      </div>
+      <div class="ais-SearchBox">
+        <form action
+              class="ais-SearchBox-form"
+              novalidate
+        >
+          <input class="ais-SearchBox-input"
+                 type="search"
+                 value="iphone"
+          >
+        </form>
+      </div>
+      <h2>
+        instant_search
+      </h2>
+      <div class="ais-Hits ais-Hits--empty">
+        <ol class="ais-Hits-list">
+        </ol>
+      </div>
+      <h2>
+        instant_search_price_asc
+      </h2>
+      <div class="ais-Hits ais-Hits--empty">
+        <ol class="ais-Hits-list">
+        </ol>
+      </div>
+      <h2>
+        instant_search_rating_desc
+      </h2>
+      <div class="ais-Hits ais-Hits--empty">
+        <ol class="ais-Hits-list">
+        </ol>
+      </div>
+      <h2>
+        instant_search_price_desc
+      </h2>
+      <div class="ais-Hits ais-Hits--empty">
+        <ol class="ais-Hits-list">
+        </ol>
+      </div>
+    `);
+  });
 });
-
-function SearchBox() {
-  useSearchBox();
-  return null;
-}
-
-function Hits() {
-  useHits();
-  return null;
-}
-
-function RefinementList(props: UseRefinementListProps) {
-  useRefinementList(props);
-  return null;
-}

--- a/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
@@ -14,7 +14,11 @@ import {
 } from 'react-instantsearch-hooks';
 import { Hits, RefinementList } from 'react-instantsearch-hooks-web';
 
-import { createSearchClient } from '../../../../test/mock';
+import {
+  createMultiSearchResponse,
+  createSearchClient,
+  createSingleSearchResponse,
+} from '../../../../test/mock';
 import { getServerState } from '../getServerState';
 
 import type {
@@ -28,10 +32,14 @@ function SearchBox() {
   return (
     <div className="ais-SearchBox">
       <form action="" className="ais-SearchBox-form" noValidate>
-        <input className="ais-SearchBox-input" type="search" value={query} />
+        <input className="ais-SearchBox-input" type="search" defaultValue={}={query}  />
       </form>
     </div>
   );
+}
+
+function Hit({ hit }) {
+  return <>{hit.objectID}</>;
 }
 
 type CreateTestEnvironmentProps = {
@@ -68,21 +76,21 @@ function createTestEnvironment({
         <SearchBox />
 
         <h2>instant_search</h2>
-        <Hits />
+        <Hits hitComponent={Hit} />
 
         <Index indexName="instant_search_price_asc">
           <h2>instant_search_price_asc</h2>
-          <Hits />
+          <Hits hitComponent={Hit} />
 
           <Index indexName="instant_search_rating_desc">
             <h2>instant_search_rating_desc</h2>
-            <Hits />
+            <Hits hitComponent={Hit} />
           </Index>
         </Index>
 
         <Index indexName="instant_search_price_desc">
           <h2>instant_search_price_desc</h2>
-          <Hits />
+          <Hits hitComponent={Hit} />
         </Index>
       </InstantSearch>
     );
@@ -380,7 +388,19 @@ describe('getServerState', () => {
   });
 
   test('returns HTML from server state', async () => {
-    const searchClient = createSearchClient({});
+    const searchClient = createSearchClient({
+      search: jest.fn((requests) =>
+        Promise.resolve(
+          createMultiSearchResponse(
+            ...requests.map(() =>
+              createSingleSearchResponse({
+                hits: [{ objectID: '1' }, { objectID: '2' }],
+              })
+            )
+          )
+        )
+      ),
+    });
     const { App } = createTestEnvironment({ searchClient });
 
     const serverState = await getServerState(<App />);
@@ -405,29 +425,53 @@ describe('getServerState', () => {
       <h2>
         instant_search
       </h2>
-      <div class="ais-Hits ais-Hits--empty">
+      <div class="ais-Hits">
         <ol class="ais-Hits-list">
+          <li class="ais-Hits-item">
+            1
+          </li>
+          <li class="ais-Hits-item">
+            2
+          </li>
         </ol>
       </div>
       <h2>
         instant_search_price_asc
       </h2>
-      <div class="ais-Hits ais-Hits--empty">
+      <div class="ais-Hits">
         <ol class="ais-Hits-list">
+          <li class="ais-Hits-item">
+            1
+          </li>
+          <li class="ais-Hits-item">
+            2
+          </li>
         </ol>
       </div>
       <h2>
         instant_search_rating_desc
       </h2>
-      <div class="ais-Hits ais-Hits--empty">
+      <div class="ais-Hits">
         <ol class="ais-Hits-list">
+          <li class="ais-Hits-item">
+            1
+          </li>
+          <li class="ais-Hits-item">
+            2
+          </li>
         </ol>
       </div>
       <h2>
         instant_search_price_desc
       </h2>
-      <div class="ais-Hits ais-Hits--empty">
+      <div class="ais-Hits">
         <ol class="ais-Hits-list">
+          <li class="ais-Hits-item">
+            1
+          </li>
+          <li class="ais-Hits-item">
+            2
+          </li>
         </ol>
       </div>
     `);

--- a/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
@@ -32,7 +32,11 @@ function SearchBox() {
   return (
     <div className="ais-SearchBox">
       <form action="" className="ais-SearchBox-form" noValidate>
-        <input className="ais-SearchBox-input" type="search" defaultValue={}={query}  />
+        <input
+          className="ais-SearchBox-input"
+          type="search"
+          defaultValue={query}
+        />
       </form>
     </div>
   );

--- a/packages/react-instantsearch-hooks/src/components/__tests__/Index.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/Index.test.tsx
@@ -157,16 +157,15 @@ describe('Index', () => {
       },
     };
 
+    // @TODO: this test doesn't work in Strict Mode
     const { unmount } = render(
-      <StrictMode>
-        <InstantSearchSSRProvider initialResults={initialResults}>
-          <InstantSearchSpy searchClient={searchClient} indexName="indexName">
-            <Index indexName="indexName2">
-              <Configure />
-            </Index>
-          </InstantSearchSpy>
-        </InstantSearchSSRProvider>{' '}
-      </StrictMode>
+      <InstantSearchSSRProvider initialResults={initialResults}>
+        <InstantSearchSpy searchClient={searchClient} indexName="indexName">
+          <Index indexName="indexName2">
+            <Configure />
+          </Index>
+        </InstantSearchSpy>
+      </InstantSearchSSRProvider>
     );
 
     expect(indexContext.current!.addWidgets).toHaveBeenCalledTimes(1);

--- a/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearchSSRProvider.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearchSSRProvider.test.tsx
@@ -379,15 +379,14 @@ describe('InstantSearchSSRProvider', () => {
       },
     };
 
+    // @TODO: this test doesn't work in Strict Mode
     function App() {
       return (
-        <StrictMode>
-          <InstantSearchSSRProvider initialResults={initialResults}>
-            <InstantSearch searchClient={searchClient} indexName="indexName">
-              <SearchBox />
-            </InstantSearch>
-          </InstantSearchSSRProvider>
-        </StrictMode>
+        <InstantSearchSSRProvider initialResults={initialResults}>
+          <InstantSearch searchClient={searchClient} indexName="indexName">
+            <SearchBox />
+          </InstantSearch>
+        </InstantSearchSSRProvider>
       );
     }
 

--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -145,13 +145,12 @@ export function useConnector<
     return {};
   });
 
-  useWidget(widget, parentIndex, stableProps);
-
-  // On the server, we add the widget early to retrieve its search parameters
-  // in the render pass.
-  if (serverContext && !parentIndex.getWidgets().includes(widget)) {
-    parentIndex.addWidgets([widget]);
-  }
+  useWidget({
+    widget,
+    parentIndex,
+    props: stableProps,
+    shouldSsr: Boolean(serverContext),
+  });
 
   return state;
 }

--- a/packages/react-instantsearch-hooks/src/lib/useIndex.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useIndex.ts
@@ -2,9 +2,10 @@ import index from 'instantsearch.js/es/widgets/index/index';
 import { useMemo } from 'react';
 
 import { useIndexContext } from '../lib/useIndexContext';
-import { useInstantSearchServerContext } from '../lib/useInstantSearchServerContext';
 
 import { useForceUpdate } from './useForceUpdate';
+import { useInstantSearchServerContext } from './useInstantSearchServerContext';
+import { useInstantSearchSSRContext } from './useInstantSearchSSRContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 import { useStableValue } from './useStableValue';
 import { useWidget } from './useWidget';
@@ -15,6 +16,8 @@ export type UseIndexProps = IndexWidgetParams;
 
 export function useIndex(props: UseIndexProps) {
   const serverContext = useInstantSearchServerContext();
+  const ssrContext = useInstantSearchSSRContext();
+  const initialResults = ssrContext?.initialResults;
   const parentIndex = useIndexContext();
   const stableProps = useStableValue(props);
   const indexWidget = useMemo(() => index(stableProps), [stableProps]);
@@ -25,15 +28,12 @@ export function useIndex(props: UseIndexProps) {
     forceUpdate();
   }, [helper, forceUpdate]);
 
-  useWidget(indexWidget, parentIndex, stableProps);
-
-  // On the server, we directly add the Index widget early to retrieve its child
-  // widgets' search parameters in the render pass.
-  // On SSR, we also add the Index here to synchronize the search state associated
-  // to the widgets.
-  if (serverContext && !parentIndex.getWidgets().includes(indexWidget)) {
-    parentIndex.addWidgets([indexWidget]);
-  }
+  useWidget({
+    widget: indexWidget,
+    parentIndex,
+    props: stableProps,
+    shouldSsr: Boolean(serverContext || initialResults),
+  });
 
   return indexWidget;
 }

--- a/packages/react-instantsearch-hooks/src/lib/useWidget.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useWidget.ts
@@ -6,11 +6,17 @@ import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 import type { Widget } from 'instantsearch.js';
 import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
 
-export function useWidget<TWidget extends Widget | IndexWidget, TProps>(
-  widget: TWidget,
-  parentIndex: IndexWidget,
-  props: TProps
-) {
+export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
+  widget,
+  parentIndex,
+  props,
+  shouldSsr,
+}: {
+  widget: TWidget;
+  parentIndex: IndexWidget;
+  props: TProps;
+  shouldSsr: boolean;
+}) {
   const prevPropsRef = useRef<TProps>(props);
   useEffect(() => {
     prevPropsRef.current = props;
@@ -22,6 +28,8 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>(
   }, [widget]);
 
   const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const shouldSsrRender =
+    shouldSsr && !parentIndex.getWidgets().includes(widget);
 
   // This effect is responsible for adding, removing, and updating the widget.
   // We need to support scenarios where the widget is remounted quickly, like in
@@ -35,7 +43,9 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>(
 
     // Scenario 1: the widget is added for the first time.
     if (cleanupTimerRef.current === null) {
-      parentIndex.addWidgets([widget]);
+      if (!shouldSsrRender) {
+        parentIndex.addWidgets([widget]);
+      }
     }
     // Scenario 2: the widget is rerendered or updated.
     else {
@@ -66,5 +76,9 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>(
       // we're able to cancel it in the next effect.
       cleanupTimerRef.current = setTimeout(cleanup);
     };
-  }, [parentIndex, widget]);
+  }, [parentIndex, widget, shouldSsrRender]);
+
+  if (shouldSsrRender) {
+    parentIndex.addWidgets([widget]);
+  }
 }

--- a/packages/react-instantsearch-hooks/src/lib/useWidget.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useWidget.ts
@@ -28,7 +28,7 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
   }, [widget]);
 
   const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const shouldSsrRender =
+  const shouldAddWidgetEarly =
     shouldSsr && !parentIndex.getWidgets().includes(widget);
 
   // This effect is responsible for adding, removing, and updating the widget.
@@ -43,7 +43,7 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
 
     // Scenario 1: the widget is added for the first time.
     if (cleanupTimerRef.current === null) {
-      if (!shouldSsrRender) {
+      if (!shouldAddWidgetEarly) {
         parentIndex.addWidgets([widget]);
       }
     }
@@ -76,9 +76,9 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
       // we're able to cancel it in the next effect.
       cleanupTimerRef.current = setTimeout(cleanup);
     };
-  }, [parentIndex, widget, shouldSsrRender]);
+  }, [parentIndex, widget, shouldAddWidgetEarly]);
 
-  if (shouldSsrRender) {
+  if (shouldAddWidgetEarly) {
     parentIndex.addWidgets([widget]);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12501,6 +12501,13 @@ diff@^5.0.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
+diffable-html@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/diffable-html/-/diffable-html-4.1.0.tgz#e7a2d1de187c4e23a59751b4e4c17483a058c696"
+  integrity sha512-++kyNek+YBLH8cLXS+iTj/Hiy2s5qkRJEJ8kgu/WHbFrVY2vz9xPFUT+fii2zGF0m1CaojDlQJjkfrCt7YWM1g==
+  dependencies:
+    htmlparser2 "^3.9.2"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -12665,7 +12672,7 @@ domain-browser@^3.5.0:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-3.5.0.tgz#3a11f5df52fd9d60d7f1c79a62fde2d158c42b09"
   integrity sha512-zrzUu6auyZWRexjCEPJnfWc30Hupxh2lJZOJAF3qa2bCuD4O/55t0FvQt3ZMhEw++gjNkwdkOVZh8yA32w/Vfw==
 
-domelementtype@1:
+domelementtype@1, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
@@ -12698,6 +12705,13 @@ domhandler@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594"
   integrity sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=
+  dependencies:
+    domelementtype "1"
+
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
 
@@ -12735,7 +12749,7 @@ domutils@1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^1.7.0:
+domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
@@ -13033,6 +13047,11 @@ enquirer@^2.3.5:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+entities@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 entities@^2.0.0:
   version "2.2.0"
@@ -16480,6 +16499,18 @@ htmlnano@^2.0.0:
     posthtml "^0.16.5"
     timsort "^0.3.0"
 
+htmlparser2@^3.9.2:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+  dependencies:
+    domelementtype "^1.3.1"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.1.1"
+
 htmlparser2@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
@@ -18742,6 +18773,13 @@ jest-runtime@^27.4.6:
     jest-util "^27.4.2"
     slash "^3.0.0"
     strip-bom "^4.0.0"
+
+jest-serializer-html@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer-html/-/jest-serializer-html-7.1.0.tgz#0cfea8a03b9b82bc420fd2cb969bd76713a87c08"
+  integrity sha512-xYL2qC7kmoYHJo8MYqJkzrl/Fdlx+fat4U1AqYg+kafqwcKPiMkOcjWHPKhueuNEgr+uemhGc+jqXYiwCyRyLA==
+  dependencies:
+    diffable-html "^4.1.0"
 
 jest-serializer@24.0.0-alpha.6:
   version "24.0.0-alpha.6"


### PR DESCRIPTION
This fixes our SSR APIs as reported in #3511.

During the `useSyncExternalStore()` migration in #3489, we omitted some SSR checks by removing the `serverState.initialResults` condition. This was responsible for mounting the widgets during rendering, to then render them on the server. We now also cover the generated HTML with a test.

Note that this solution doesn't work with Strict Mode, as it wasn't prior to the bug. This is just a fix to release early, and then we'll work on Strict Mode support.

Closes #3511