### PR TITLE
fix(HierarchicalMenu): show full hierarchical parent values

### DIFF
--- a/examples/hooks-react-native/package.json
+++ b/examples/hooks-react-native/package.json
@@ -14,7 +14,7 @@
     "algoliasearch": "4.12.1",
     "expo": "~44.0.0",
     "expo-status-bar": "~1.2.0",
-    "instantsearch.js": "4.41.0",
+    "instantsearch.js": "4.41.2",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-instantsearch-hooks": "6.28.0",

--- a/examples/hooks/package.json
+++ b/examples/hooks/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "algoliasearch": "4.11.0",
-    "instantsearch.js": "4.41.0",
+    "instantsearch.js": "4.41.2",
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "react-instantsearch-hooks-web": "6.28.0"

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     },
     {
       "path": "packages/react-instantsearch-hooks-web/dist/umd/ReactInstantSearchHooksDOM.min.js",
-      "maxSize": "48.50 kB"
+      "maxSize": "48.75 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.8.2",
+    "algoliasearch-helper": "^3.8.3",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0"
   },

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.8.2",
+    "algoliasearch-helper": "^3.8.3",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0",

--- a/packages/react-instantsearch-hooks-server/package.json
+++ b/packages/react-instantsearch-hooks-server/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "instantsearch.js": "^4.41.0",
+    "instantsearch.js": "^4.41.2",
     "react-instantsearch-hooks": "6.28.0"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -5,7 +5,7 @@ import {
   InstantSearchSSRProvider,
 } from 'react-instantsearch-hooks';
 
-import type { InitialResults, InstantSearch } from 'instantsearch.js';
+import type { InitialResults, InstantSearch, UiState } from 'instantsearch.js';
 import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
 import type { ReactNode } from 'react';
 import type { renderToString as reactRenderToString } from 'react-dom/server';
@@ -26,9 +26,10 @@ export function getServerState(
     current: undefined,
   };
 
-  const notifyServer: InstantSearchServerContextApi['notifyServer'] = ({
-    search,
-  }) => {
+  const notifyServer: InstantSearchServerContextApi<
+    UiState,
+    UiState
+  >['notifyServer'] = ({ search }) => {
     searchRef.current = search;
   };
 
@@ -74,7 +75,7 @@ export function getServerState(
 type ExecuteArgs = {
   children: ReactNode;
   renderToString: typeof reactRenderToString;
-  notifyServer: InstantSearchServerContextApi['notifyServer'];
+  notifyServer: InstantSearchServerContextApi<UiState, UiState>['notifyServer'];
   searchRef: SearchRef;
 };
 

--- a/packages/react-instantsearch-hooks-web/package.json
+++ b/packages/react-instantsearch-hooks-web/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "instantsearch.js": "^4.41.0",
+    "instantsearch.js": "^4.41.2",
     "react-instantsearch-hooks": "6.28.0"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -47,8 +47,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.8.2",
-    "instantsearch.js": "^4.41.0",
+    "algoliasearch-helper": "^3.8.3",
+    "instantsearch.js": "^4.41.2",
     "use-sync-external-store": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/react-instantsearch-hooks/src/components/InstantSearchServerContext.ts
+++ b/packages/react-instantsearch-hooks/src/components/InstantSearchServerContext.ts
@@ -1,17 +1,20 @@
 import { createContext } from 'react';
 
-import type { InstantSearch } from 'instantsearch.js';
+import type { InstantSearch, UiState } from 'instantsearch.js';
 
-export type InstantSearchServerContextApi = {
+export type InstantSearchServerContextApi<
+  TUiState extends UiState,
+  TRouteState = TUiState
+> = {
   /**
    * Fowards search internals to the server execution context to access them
    * in `getServerState()`.
    */
-  notifyServer(params: { search: InstantSearch }): void;
+  notifyServer(params: { search: InstantSearch<TUiState, TRouteState> }): void;
 };
 
 export const InstantSearchServerContext =
-  createContext<InstantSearchServerContextApi | null>(null);
+  createContext<InstantSearchServerContextApi<UiState, UiState> | null>(null);
 
 if (__DEV__) {
   InstantSearchServerContext.displayName = 'InstantSearchServer';

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -30,7 +30,7 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
   props: UseInstantSearchApiProps<TUiState, TRouteState>
 ) {
   const forceUpdate = useForceUpdate();
-  const serverContext = useInstantSearchServerContext();
+  const serverContext = useInstantSearchServerContext<TUiState, TRouteState>();
   const serverState = useInstantSearchSSRContext();
   const initialResults = serverState?.initialResults;
   const stableProps = useStableValue(props);

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
@@ -11,7 +11,7 @@ export function useInstantSearchContext<
   TUiState extends UiState,
   TRouteState = TUiState
 >() {
-  const search = useContext<InstantSearch<TUiState, TRouteState> | null>(
+  const search = useContext(
     InstantSearchContext as Context<InstantSearch<TUiState, TRouteState> | null>
   );
 

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
@@ -5,13 +5,14 @@ import { invariant } from '../lib/invariant';
 import { InstantSearchContext } from './InstantSearchContext';
 
 import type { InstantSearch, UiState } from 'instantsearch.js';
+import type { Context } from 'react';
 
 export function useInstantSearchContext<
   TUiState extends UiState,
   TRouteState = TUiState
 >() {
   const search = useContext<InstantSearch<TUiState, TRouteState> | null>(
-    InstantSearchContext
+    InstantSearchContext as Context<InstantSearch<TUiState, TRouteState> | null>
   );
 
   invariant(

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchServerContext.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchServerContext.ts
@@ -2,6 +2,18 @@ import { useContext } from 'react';
 
 import { InstantSearchServerContext } from '../components/InstantSearchServerContext';
 
-export function useInstantSearchServerContext() {
-  return useContext(InstantSearchServerContext);
+import type { InstantSearchServerContextApi } from '../components/InstantSearchServerContext';
+import type { UiState } from 'instantsearch.js';
+import type { Context } from 'react';
+
+export function useInstantSearchServerContext<
+  TUiState extends UiState,
+  TRouteState = TUiState
+>() {
+  return useContext(
+    InstantSearchServerContext as Context<InstantSearchServerContextApi<
+      TUiState,
+      TRouteState
+    > | null>
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7581,13 +7581,6 @@ algolia-aerial@^1.5.3:
   resolved "https://registry.yarnpkg.com/algolia-aerial/-/algolia-aerial-1.5.3.tgz#c8b8ca6bc484164ffc7b36717689a424ea6bfe6c"
   integrity sha512-LZTpVlYnhqNFd+ru/Spm73omhsagiRQLmjrosa5bJ6/I9OMRp4Sb9pYZkAxcx3RSr+ZNXZqthL7rpXqMFdrnPA==
 
-algoliasearch-helper@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.8.2.tgz#35726dc6d211f49dbab0bf6d37b4658165539523"
-  integrity sha512-AXxiF0zT9oYwl8ZBgU/eRXvfYhz7cBA5YrLPlw9inZHdaYF0QEya/f1Zp1mPYMXc1v6VkHwBq4pk6/vayBLICg==
-  dependencies:
-    "@algolia/events" "^4.0.1"
-
 algoliasearch-helper@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.8.3.tgz#74066a6aa56a6dfa7af1f3ab8c6a545d707d5d5e"
@@ -17129,23 +17122,7 @@ instantsearch.css@7.4.5:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.4.5.tgz#2a521aa634329bf1680f79adf87c79d67669ec8d"
   integrity sha512-iIGBYjCokU93DDB8kbeztKtlu4qVEyTg1xvS6iSO1YvqRwkIZgf0tmsl/GytsLdZhuw8j4wEaeYsCzNbeJ/zEQ==
 
-instantsearch.js@4.41.0, instantsearch.js@^4.41.0:
-  version "4.41.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.41.0.tgz#c879d7b892e3d9159a17a803e793e695aeb5431f"
-  integrity sha512-g9l+Cty0xxMT06L36gc6x6Nz6HsEbrqbNQOXAZDORb2g9ADjMQwR1YtOVqN28pTuwXnhWJ4UfEKlLfHTgTVKmg==
-  dependencies:
-    "@algolia/events" "^4.0.1"
-    "@types/google.maps" "^3.45.3"
-    "@types/hogan.js" "^3.0.0"
-    "@types/qs" "^6.5.3"
-    algoliasearch-helper "^3.8.2"
-    classnames "^2.2.5"
-    hogan.js "^3.0.2"
-    preact "^10.6.0"
-    qs "^6.5.1 < 6.10"
-    search-insights "^2.1.0"
-
-instantsearch.js@4.41.2:
+instantsearch.js@4.41.2, instantsearch.js@^4.41.2:
   version "4.41.2"
   resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.41.2.tgz#5f8aa367a00ce828db0b825dac77d4a36ec27336"
   integrity sha512-YsVd2tOxKPMZQSlqOgVzCYq9zIYqda1p8N6PDKgCdYoLbjngxAdIj7VHxWQEnJjGdAAkGqFPjr+RFx1l6WlwgA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7588,6 +7588,13 @@ algoliasearch-helper@^3.8.2:
   dependencies:
     "@algolia/events" "^4.0.1"
 
+algoliasearch-helper@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.8.3.tgz#74066a6aa56a6dfa7af1f3ab8c6a545d707d5d5e"
+  integrity sha512-J0H08fQoyhZ2qLi7Uy8EvUeN/NJ4Trtt7NWB8mF1CGLuYpdXPyjZu9+Uoya2eayxQ20RP+QGF9Om/LddPv49vw==
+  dependencies:
+    "@algolia/events" "^4.0.1"
+
 algoliasearch@4.11.0, "algoliasearch@>= 3.27.1 < 5":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.11.0.tgz#234befb3ac355c094077f0edf3777240b1ee013c"
@@ -17132,6 +17139,22 @@ instantsearch.js@4.41.0, instantsearch.js@^4.41.0:
     "@types/hogan.js" "^3.0.0"
     "@types/qs" "^6.5.3"
     algoliasearch-helper "^3.8.2"
+    classnames "^2.2.5"
+    hogan.js "^3.0.2"
+    preact "^10.6.0"
+    qs "^6.5.1 < 6.10"
+    search-insights "^2.1.0"
+
+instantsearch.js@4.41.2:
+  version "4.41.2"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.41.2.tgz#5f8aa367a00ce828db0b825dac77d4a36ec27336"
+  integrity sha512-YsVd2tOxKPMZQSlqOgVzCYq9zIYqda1p8N6PDKgCdYoLbjngxAdIj7VHxWQEnJjGdAAkGqFPjr+RFx1l6WlwgA==
+  dependencies:
+    "@algolia/events" "^4.0.1"
+    "@types/google.maps" "^3.45.3"
+    "@types/hogan.js" "^3.0.0"
+    "@types/qs" "^6.5.3"
+    algoliasearch-helper "^3.8.3"
     classnames "^2.2.5"
     hogan.js "^3.0.2"
     preact "^10.6.0"


### PR DESCRIPTION
**Summary**

This PR updates `algoliasearch-helper` in **React InstantSearch** and `instantsearch.js` in **React InstantSearch Hooks** to allow the `<HierarchicalMenu>` widget to retrieve and display the full list of a refined item's parents values.

I also had to take into account recent changes in InstantSearch JS types, so that's included here.