### PR TITLE
chore(ci): run React 17 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,44 @@ jobs:
             # retry introduced in https://github.com/algolia/react-instantsearch/pull/3475
             retry yarn test --maxWorkers=4
 
+  test_unit_react_v17:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install_yarn_version
+      - restore_cache: *restore_yarn_cache
+      - run: *run_yarn_install
+      - save_cache: *save_yarn_cache
+      - run:
+          name: Install React v17 dependencies
+          command: |
+            yarn add --force -DW \
+              react@17.0.2 \
+              @types/react@17.0.47 \
+              react-dom@17.0.2 \
+              @types/react-dom@17.0.17 \
+              react-test-renderer@17.0.2 \
+              @types/react-test-renderer@17.0.2 \
+              @testing-library/react@12.1.4
+      - run:
+          name: Unit Tests
+          command: |
+            retry() {
+              MAX_RETRY=2
+              n=0
+              until [ $n -ge $MAX_RETRY ]
+              do
+                  "$@" && break
+                  n=$[$n+1]
+              done
+              if [ $n -ge $MAX_RETRY ]; then
+                exit 1
+              fi
+            }
+
+            # https://github.com/facebook/jest/issues/8987 - Jest fails to run tests on CI sporadically
+            # retry introduced in https://github.com/algolia/react-instantsearch/pull/3475
+            retry yarn test --maxWorkers=4
 
   test_unit_algoliasearch_v3:
     <<: *defaults
@@ -207,6 +245,7 @@ workflows:
     jobs:
       - test_build
       - test_unit
+      - test_unit_react_v17
       - test_unit_algoliasearch_v3
       - test_integration
       - test_e2e

--- a/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
@@ -32,11 +32,7 @@ function SearchBox() {
   return (
     <div className="ais-SearchBox">
       <form action="" className="ais-SearchBox-form" noValidate>
-        <input
-          className="ais-SearchBox-input"
-          type="search"
-          defaultValue={query}
-        />
+        <input className="ais-SearchBox-input" defaultValue={query} />
       </form>
     </div>
   );
@@ -421,7 +417,6 @@ describe('getServerState', () => {
               novalidate
         >
           <input class="ais-SearchBox-input"
-                 type="search"
                  value="iphone"
           >
         </form>


### PR DESCRIPTION
This runs our unit test suite with React 17 on the CI.

Since #3517, our codebase uses React 18, but we want to make sure that our libraries work on React 17 as well.