### PR TITLE
fix(ci): fetch remote changes before pushing ref and tag with shipjs

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -57,6 +57,10 @@ module.exports = {
   pullRequestTeamReviewers: ['frontend-experiences-web'],
   buildCommand: ({ version }) =>
     `NODE_ENV=production VERSION=${version} yarn build`,
+  // Make sure the local branch is in sync with remote
+  // before pushing the ref and the tag on it
+  afterPublish: ({ exec }) =>
+    exec('git fetch && git rebase origin/master master'),
   slack: {
     // disable slack notification for `prepared` lifecycle.
     // Ship.js will send slack message only for `releaseSuccess`.


### PR DESCRIPTION
**Summary**

On rare occasions, the release process orchestrated by Ship.js cannot be completed if the local main branch and its remote counterpart are not in sync, when an unrelated PR is merged just after a release is started for instance.

This is not critical, but it can be a bother as the latest git tag won't be pushed to the remote, and the releases list on GitHub will not be updated too.

This PR addresses the issue by performing a rebase onto the main branch in order to sync them before performing the git tag operation.

**Result**

The release process should now be more resilient to this kind of issue.