### PR TITLE
refactor(hooks): remove `useEffect()` from `<SearchBox>`

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -33,7 +33,7 @@ export function SearchBox({ queryHook, ...props }: SearchBoxProps) {
   }
 
   function onChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const targetValue = event.target.value;
+    const targetValue = event.currentTarget.value;
     setValue(targetValue);
     refine(targetValue);
   }

--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -24,26 +24,28 @@ export function SearchBox({ queryHook, ...props }: SearchBoxProps) {
     { queryHook },
     { $$widgetType: 'ais.searchBox' }
   );
-  const [value, setValue] = useState(query);
+  const [inputValue, setInputValue] = useState(query);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  function setQuery(newQuery: string) {
+    setInputValue(newQuery);
+    refine(newQuery);
+  }
+
   function onReset() {
-    setValue('');
-    refine('');
+    setQuery('');
   }
 
   function onChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const targetValue = event.currentTarget.value;
-    setValue(targetValue);
-    refine(targetValue);
+    setQuery(event.currentTarget.value);
   }
 
   // Track when the InstantSearch query changes to synchronize it with
   // the React state.
   // We bypass the state update if the input is focused to avoid concurrent
   // updates when typing.
-  if (query !== value && document.activeElement !== inputRef.current) {
-    setValue(query);
+  if (query !== inputValue && document.activeElement !== inputRef.current) {
+    setInputValue(query);
   }
 
   const uiProps: UiProps = {
@@ -51,7 +53,7 @@ export function SearchBox({ queryHook, ...props }: SearchBoxProps) {
     isSearchStalled,
     onChange,
     onReset,
-    value,
+    value: inputValue,
     translations: {
       submitTitle: 'Submit the search query.',
       resetTitle: 'Clear the search query.',

--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useSearchBox } from 'react-instantsearch-hooks';
 
 import { SearchBox as SearchBoxUiComponent } from '../ui/SearchBox';
@@ -29,33 +29,22 @@ export function SearchBox({ queryHook, ...props }: SearchBoxProps) {
 
   function onReset() {
     setValue('');
+    refine('');
   }
 
   function onChange(event: React.ChangeEvent<HTMLInputElement>) {
-    setValue(event.currentTarget.value);
+    const targetValue = event.target.value;
+    setValue(targetValue);
+    refine(targetValue);
   }
-
-  // Track when the value coming from the React state changes to synchronize
-  // it with InstantSearch.
-  useEffect(() => {
-    if (query !== value) {
-      refine(value);
-    }
-    // We don't want to track when the InstantSearch query changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, refine]);
 
   // Track when the InstantSearch query changes to synchronize it with
   // the React state.
-  useEffect(() => {
-    // We bypass the state update if the input is focused to avoid concurrent
-    // updates when typing.
-    if (document.activeElement !== inputRef.current && query !== value) {
-      setValue(query);
-    }
-    // We don't want to track when the React state value changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+  // We bypass the state update if the input is focused to avoid concurrent
+  // updates when typing.
+  if (query !== value && document.activeElement !== inputRef.current) {
+    setValue(query);
+  }
 
   const uiProps: UiProps = {
     inputRef,


### PR DESCRIPTION
## Description

This refactors the `<SearchBox>` component to remove the `useEffect()`.

You can learn more in [**You Might Not Need an Effect**](https://beta.reactjs.org/learn/you-might-not-need-an-effect), notably these two sections:

- [Adjusting some state when a prop changes](https://beta.reactjs.org/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
- [Sharing logic between event handlers](https://beta.reactjs.org/learn/you-might-not-need-an-effect#sharing-logic-between-event-handlers)

## Related

- #3552
- #3553