### PR TITLE
refactor(hooks): remove `useEffect()` from `<RangeInput>`

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/ui/RangeInput.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/RangeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { cx } from './lib/cx';
 
@@ -88,15 +88,17 @@ export function RangeInput({
         ? maxValue
         : unsetNumberInputValue,
   };
+  const [prevValues, setPrevValues] = useState(values);
 
   const [{ from, to }, setRange] = useState({
     from: values.min,
     to: values.max,
   });
 
-  useEffect(() => {
+  if (values.min !== prevValues.min || values.max !== prevValues.max) {
     setRange({ from: values.min, to: values.max });
-  }, [values.min, values.max]);
+    setPrevValues(values);
+  }
 
   return (
     <div


### PR DESCRIPTION
## Description

This refactors the `<RangeInput>` component to remove the `useEffect()`.

You can learn more in [**You Might Not Need an Effect**](https://beta.reactjs.org/learn/you-might-not-need-an-effect), notably the section [Adjusting some state when a prop changes](https://beta.reactjs.org/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).

## Related

- #3551