### PR TITLE
refactor(hooks): remove `useEffect()` from `<RefinementList>`

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/widgets/RefinementList.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/RefinementList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useRefinementList } from 'react-instantsearch-hooks';
 
 import { RefinementList as RefinementListUiComponent } from '../ui/RefinementList';
@@ -66,16 +66,13 @@ export function RefinementList({
       $$widgetType: 'ais.refinementList',
     }
   );
-  const [query, setQuery] = useState('');
-  const previousQueryRef = useRef(query);
+  const [inputValue, setInputValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (previousQueryRef.current !== query) {
-      previousQueryRef.current = query;
-      searchForItems(query);
-    }
-  }, [query, searchForItems]);
+  function setQuery(newQuery: string) {
+    setInputValue(newQuery);
+    searchForItems(newQuery);
+  }
 
   function onRefine(item: RefinementListItem) {
     refine(item.value);
@@ -101,13 +98,13 @@ export function RefinementList({
     items,
     canRefine,
     onRefine,
-    query,
+    query: inputValue,
     searchBox: searchable && (
       <SearchBoxUiComponent
         inputRef={inputRef}
         placeholder={searchablePlaceholder}
         isSearchStalled={false}
-        value={query}
+        value={inputValue}
         onChange={onChange}
         onReset={onReset}
         onSubmit={onSubmit}


### PR DESCRIPTION
## Description

This refactors the `<RefinementList>` component to remove the `useEffect()`.

You can learn more in [**You Might Not Need an Effect**](https://beta.reactjs.org/learn/you-might-not-need-an-effect), notably the section [Sharing logic between event handlers](https://beta.reactjs.org/learn/you-might-not-need-an-effect#sharing-logic-between-event-handlers).

## Related

- #3551
- #3552