### PR TITLE
fix(hooks): provide state and results APIs from "render" event

### DIFF
--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 
-import { createSearchResults } from '../lib/createSearchResults';
 import { dequal } from '../lib/dequal';
+import { getIndexSearchResults } from '../lib/getIndexSearchResults';
 import { useIndexContext } from '../lib/useIndexContext';
 import { useInstantSearchContext } from '../lib/useInstantSearchContext';
 import { useInstantSearchServerContext } from '../lib/useInstantSearchServerContext';
@@ -99,27 +99,7 @@ export function useConnector<
       helper.state =
         widget.getWidgetSearchParameters?.(helper.state, { uiState }) ||
         helper.state;
-      const results =
-        // On SSR, we get the results injected on the Index.
-        parentIndex.getResults() ||
-        // On the browser, we create fallback results based on the widget's
-        // `getWidgetSearchParameters()` method to inject the initial UI state,
-        // or fall back to the helper state.
-        createSearchResults(helper.state);
-      const scopedResults = parentIndex
-        .getScopedResults()
-        .map((scopedResult) => {
-          const fallbackResults =
-            scopedResult.indexId === parentIndex.getIndexId()
-              ? results
-              : createSearchResults(scopedResult.helper.state);
-
-          return {
-            ...scopedResult,
-            // We keep `results` from being `null`.
-            results: scopedResult.results || fallbackResults,
-          };
-        });
+      const { results, scopedResults } = getIndexSearchResults(parentIndex);
 
       // We get the widget render state by providing the same parameters as
       // InstantSearch provides to the widget's `render` method.

--- a/packages/react-instantsearch-hooks/src/hooks/useInstantSearch.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useInstantSearch.ts
@@ -4,16 +4,15 @@ import { useInstantSearchContext } from '../lib/useInstantSearchContext';
 import { useSearchResults } from '../lib/useSearchResults';
 import { useSearchState } from '../lib/useSearchState';
 
-import type { SearchResultsRenderState } from '../lib/useSearchResults';
-import type { SearchStateRenderState } from '../lib/useSearchState';
+import type { SearchResultsApi } from '../lib/useSearchResults';
+import type { SearchStateApi } from '../lib/useSearchState';
 import type { InstantSearch, Middleware, UiState } from 'instantsearch.js';
 
-type InstantSearchApi<TUiState extends UiState> =
-  SearchStateRenderState<TUiState> &
-    SearchResultsRenderState & {
-      use: (...middlewares: Middleware[]) => () => void;
-      refresh: InstantSearch['refresh'];
-    };
+type InstantSearchApi<TUiState extends UiState> = SearchStateApi<TUiState> &
+  SearchResultsApi & {
+    use: (...middlewares: Middleware[]) => () => void;
+    refresh: InstantSearch['refresh'];
+  };
 
 export function useInstantSearch<
   TUiState extends UiState = UiState

--- a/packages/react-instantsearch-hooks/src/lib/__tests__/useSearchResults.test.tsx
+++ b/packages/react-instantsearch-hooks/src/lib/__tests__/useSearchResults.test.tsx
@@ -1,5 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
+import React from 'react';
+import { SearchBox } from 'react-instantsearch-hooks-web';
 
 import { createInstantSearchTestWrapper } from '../../../../../test/utils';
 import { useSearchResults } from '../useSearchResults';
@@ -8,10 +10,18 @@ describe('useSearchResults', () => {
   test('returns the connector render state', async () => {
     const wrapper = createInstantSearchTestWrapper();
     const { result, waitForNextUpdate } = renderHook(() => useSearchResults(), {
-      wrapper,
+      wrapper: ({ children }) =>
+        wrapper({
+          children: (
+            <>
+              <SearchBox />
+              {children}
+            </>
+          ),
+        }),
     });
 
-    // Initial render state from manual `getWidgetRenderState`
+    // Initial render
     expect(result.current).toEqual({
       results: expect.any(SearchResults),
       scopedResults: [
@@ -26,7 +36,7 @@ describe('useSearchResults', () => {
 
     await waitForNextUpdate();
 
-    // InstantSearch.js state from the `render` lifecycle step
+    // Update caused by <SearchBox>
     expect(result.current).toEqual({
       results: expect.any(SearchResults),
       scopedResults: [
@@ -37,7 +47,6 @@ describe('useSearchResults', () => {
         }),
       ],
     });
-
     expect(result.current.results.__isArtificial).toBeUndefined();
   });
 });

--- a/packages/react-instantsearch-hooks/src/lib/__tests__/useSearchState.test.tsx
+++ b/packages/react-instantsearch-hooks/src/lib/__tests__/useSearchState.test.tsx
@@ -16,13 +16,12 @@ function SearchBox() {
 }
 
 describe('useSearchState', () => {
-  test('returns the ui state', async () => {
+  test('returns the ui state', () => {
     const wrapper = createInstantSearchTestWrapper();
-    const { result, waitForNextUpdate } = renderHook(() => useSearchState(), {
+    const { result, rerender } = renderHook(() => useSearchState(), {
       wrapper,
     });
 
-    // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
       uiState: {
         indexName: {},
@@ -35,9 +34,8 @@ describe('useSearchState', () => {
     const setUiState = result.current.setUiState;
     const setIndexUiState = result.current.setIndexUiState;
 
-    await waitForNextUpdate();
+    rerender();
 
-    // InstantSearch.js state from the `render` lifecycle step
     expect(result.current).toEqual({
       uiState: {
         indexName: {},
@@ -48,7 +46,7 @@ describe('useSearchState', () => {
     });
   });
 
-  test('returns the ui state with initial state', async () => {
+  test('returns the ui state with initial state', () => {
     const wrapper = createInstantSearchTestWrapper({
       initialUiState: {
         indexName: {
@@ -56,23 +54,8 @@ describe('useSearchState', () => {
         },
       },
     });
-    const { result, waitForNextUpdate } = renderHook(() => useSearchState(), {
-      wrapper,
-    });
+    const { result } = renderHook(() => useSearchState(), { wrapper });
 
-    // Initial render state from manual `getWidgetRenderState`
-    expect(result.current).toEqual({
-      uiState: {
-        indexName: { query: 'iphone' },
-      },
-      indexUiState: { query: 'iphone' },
-      setUiState: expect.any(Function),
-      setIndexUiState: expect.any(Function),
-    });
-
-    await waitForNextUpdate();
-
-    // InstantSearch.js state from the `render` lifecycle step
     expect(result.current).toEqual({
       uiState: {
         indexName: { query: 'iphone' },

--- a/packages/react-instantsearch-hooks/src/lib/getIndexSearchResults.ts
+++ b/packages/react-instantsearch-hooks/src/lib/getIndexSearchResults.ts
@@ -1,0 +1,29 @@
+import { createSearchResults } from './createSearchResults';
+
+import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
+
+export function getIndexSearchResults(indexWidget: IndexWidget) {
+  const helper = indexWidget.getHelper()!;
+  const results =
+    // On SSR, we get the results injected on the Index.
+    indexWidget.getResults() ||
+    // On the browser, we create fallback results based on the helper state.
+    createSearchResults(helper.state);
+  const scopedResults = indexWidget.getScopedResults().map((scopedResult) => {
+    const fallbackResults =
+      scopedResult.indexId === indexWidget.getIndexId()
+        ? results
+        : createSearchResults(scopedResult.helper.state);
+
+    return {
+      ...scopedResult,
+      // We keep `results` from being `null`.
+      results: scopedResult.results || fallbackResults,
+    };
+  });
+
+  return {
+    results,
+    scopedResults,
+  };
+}

--- a/packages/react-instantsearch-hooks/src/lib/useSearchState.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useSearchState.ts
@@ -1,83 +1,73 @@
-import { useConnector } from '../hooks/useConnector';
+import { useCallback, useEffect, useState } from 'react';
 
-import type { Connector, UiState } from 'instantsearch.js';
+import { useIndexContext } from './useIndexContext';
+import { useInstantSearchContext } from './useInstantSearchContext';
 
-export type SearchStateRenderState<TUiState extends UiState> = {
+import type { UiState } from 'instantsearch.js';
+
+export type SearchStateApi<TUiState extends UiState> = {
   uiState: TUiState;
-  indexUiState: TUiState[keyof TUiState];
-  setUiState(
+  setUiState: (
     uiState: TUiState | ((previousUiState: TUiState) => TUiState)
-  ): void;
-  setIndexUiState(
+  ) => void;
+  indexUiState: TUiState[keyof TUiState];
+  setIndexUiState: (
     indexUiState:
       | TUiState[keyof TUiState]
       | ((
-          previousIndexUiState: TUiState[keyof UiState]
-        ) => TUiState[keyof UiState])
-  ): void;
+          previousIndexUiState: TUiState[keyof TUiState]
+        ) => TUiState[keyof TUiState])
+  ) => void;
 };
 
-type SearchStateWidgetDescription<TUiState extends UiState = UiState> = {
-  $$type: 'ais.searchState';
-  renderState: SearchStateRenderState<TUiState>;
-};
+export function useSearchState<
+  TUiState extends UiState
+>(): SearchStateApi<TUiState> {
+  const search = useInstantSearchContext<TUiState>();
+  const searchIndex = useIndexContext();
+  const indexId = searchIndex.getIndexId();
+  const [uiState, setLocalUiState] = useState(() => search.getUiState());
+  const indexUiState = uiState[indexId] as TUiState[keyof TUiState];
 
-type SearchStateConnector<TUiState extends UiState = UiState> = Connector<
-  SearchStateWidgetDescription<TUiState>,
-  never
->;
-
-const connectSearchState: SearchStateConnector = (renderFn) => {
-  return (widgetParams) => {
-    let setUiState: SearchStateRenderState<UiState>['setUiState'];
-    let setIndexUiState: SearchStateRenderState<UiState>['setIndexUiState'];
-    return {
-      $$type: 'ais.searchState',
-      getWidgetRenderState({ instantSearchInstance, parent }) {
-        const indexId = parent!.getIndexId();
-        const uiState = instantSearchInstance.getUiState();
-        const indexUiState = uiState[indexId];
-        if (!setUiState) {
-          setUiState = instantSearchInstance.setUiState.bind(
-            instantSearchInstance
-          );
-        }
-        if (!setIndexUiState) {
-          setIndexUiState = (nextUiState) => {
-            setUiState((prevUiState) => ({
-              ...prevUiState,
-              [indexId]:
-                typeof nextUiState === 'function'
-                  ? nextUiState(prevUiState[indexId])
-                  : nextUiState,
-            }));
-          };
-        }
-
-        return {
-          uiState,
-          indexUiState,
-          setUiState,
-          setIndexUiState,
-          widgetParams,
-        };
-      },
-      render(renderOptions) {
-        renderFn(
-          {
-            ...this.getWidgetRenderState!(renderOptions),
-            instantSearchInstance: renderOptions.instantSearchInstance,
-          },
-          false
-        );
-      },
-      dispose() {},
-    };
-  };
-};
-
-export function useSearchState<TUiState extends UiState = UiState>() {
-  return useConnector<never, SearchStateWidgetDescription<TUiState>>(
-    connectSearchState as unknown as SearchStateConnector<TUiState>
+  const setUiState = useCallback<SearchStateApi<TUiState>['setUiState']>(
+    (nextUiState) => {
+      search.setUiState(nextUiState);
+    },
+    [search]
   );
+  const setIndexUiState = useCallback<
+    SearchStateApi<TUiState>['setIndexUiState']
+  >(
+    (nextUiState) => {
+      setUiState((prevUiState) => ({
+        ...prevUiState,
+        [indexId]:
+          typeof nextUiState === 'function'
+            ? nextUiState(
+                prevUiState[indexId] as unknown as TUiState[keyof TUiState]
+              )
+            : nextUiState,
+      }));
+    },
+    [setUiState, indexId]
+  );
+
+  useEffect(() => {
+    function handleRender() {
+      setLocalUiState(search.getUiState());
+    }
+
+    search.addListener('render', handleRender);
+
+    return () => {
+      search.removeListener('render', handleRender);
+    };
+  }, [search, indexId]);
+
+  return {
+    uiState,
+    setUiState,
+    indexUiState,
+    setIndexUiState,
+  };
 }


### PR DESCRIPTION
This updates the [`useInstantSearch()`](https://www.algolia.com/doc/api-reference/widgets/use-instantsearch/react-hooks/) implementation for the search state and search results APIs (`uiState`, `setUiState()`, `indexUiState`, `setIndexUiState()`, `results`, `scopedResults`).

The **previous implementation relied on adding widgets** to the instance to retrieve the search state and the search results. This added footprint on the instance, and triggered unnecessary renders.

This **new implementation subscribes to the InstantSearch `render` event** to update the React state. Since we rely on this event, the React state will get updated at the same time as all the other widgets' render, resulting in a batch update.