### PR TITLE
fix(hooks): use single instance in <InstantSearch>

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     },
     {
       "path": "packages/react-instantsearch-hooks-web/dist/umd/ReactInstantSearchHooksDOM.min.js",
-      "maxSize": "48.75 kB"
+      "maxSize": "49 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",

--- a/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
@@ -542,8 +542,7 @@ describe('InstantSearch', () => {
 
     await waitFor(() => {
       expect(searchClient1.search).toHaveBeenCalledTimes(1);
-      // @TODO: can this call count go down to 1 in Strict Mode?
-      expect(searchClient2.search).toHaveBeenCalledTimes(2);
+      expect(searchClient2.search).toHaveBeenCalledTimes(1);
       expect(searchClient2.addAlgoliaAgent).toHaveBeenCalledWith(
         `react (${ReactVersion})`
       );
@@ -559,8 +558,8 @@ describe('InstantSearch', () => {
 
     await waitFor(() => {
       expect(searchClient1.search).toHaveBeenCalledTimes(1);
-      expect(searchClient2.search).toHaveBeenCalledTimes(2);
-      expect(searchClient3.search).toHaveBeenCalledTimes(2);
+      expect(searchClient2.search).toHaveBeenCalledTimes(1);
+      expect(searchClient3.search).toHaveBeenCalledTimes(1);
       expect(searchClient3.addAlgoliaAgent).toHaveBeenCalledWith(
         `react (${ReactVersion})`
       );
@@ -575,7 +574,7 @@ describe('InstantSearch', () => {
     userEvent.type(screen.getByRole('searchbox'), 'iphone');
 
     await waitFor(() => {
-      expect(searchClient3.search).toHaveBeenCalledTimes(8);
+      expect(searchClient3.search).toHaveBeenCalledTimes(7);
       expect(searchClient3.search).toHaveBeenLastCalledWith([
         {
           indexName: 'indexName',
@@ -611,11 +610,12 @@ describe('InstantSearch', () => {
       ]);
     });
 
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+
     rerender(<App indexName="indexName2" />);
 
     await waitFor(() => {
-      // @TODO: can this call count go down in Strict Mode?
-      expect(searchClient.search).toHaveBeenCalledTimes(3);
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
       expect(searchClient.search).toHaveBeenLastCalledWith([
         expect.objectContaining({
           indexName: 'indexName2',
@@ -626,8 +626,7 @@ describe('InstantSearch', () => {
     rerender(<App indexName="indexName3" />);
 
     await waitFor(() => {
-      // @TODO: can this call count go down in Strict Mode?
-      expect(searchClient.search).toHaveBeenCalledTimes(5);
+      expect(searchClient.search).toHaveBeenCalledTimes(3);
       expect(searchClient.search).toHaveBeenLastCalledWith([
         expect.objectContaining({
           indexName: 'indexName3',
@@ -638,7 +637,7 @@ describe('InstantSearch', () => {
     userEvent.type(screen.getByRole('searchbox'), 'iphone');
 
     await waitFor(() => {
-      expect(searchClient.search).toHaveBeenCalledTimes(11);
+      expect(searchClient.search).toHaveBeenCalledTimes(9);
       expect(searchClient.search).toHaveBeenLastCalledWith([
         {
           indexName: 'indexName3',

--- a/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
@@ -147,8 +147,11 @@ describe('InstantSearch', () => {
 
     unmount();
 
-    expect(searchContext.current!.dispose).toHaveBeenCalledTimes(1);
-    expect(searchContext.current!.started).toEqual(false);
+    await waitFor(() => {
+      expect(searchContext.current!.dispose).toHaveBeenCalledTimes(1);
+      expect(searchContext.current!.started).toEqual(false);
+      expect(searchContext.current!.mainIndex.getWidgets()).toEqual([]);
+    });
   });
 
   test('triggers a single network request on mount with widgets', async () => {
@@ -452,9 +455,10 @@ describe('InstantSearch', () => {
   });
 
   // This test shows that giving an unstable `onStateChange` reference (or any
-  // unstable prop) remounts the <InstantSearch> component and therefore resets
-  // the state after the remount.
-  // Users need to provide stable references for rerenders to keep the state.
+  // unstable prop) does not remount the <InstantSearch> component and therefore
+  // keeps the state.
+  // Prior to the current implementation, we created a new InstantSearch.js
+  // instance at each prop change, which made this test fail.
   test('recovers the state on rerender with an unstable onStateChange', async () => {
     const searchClient = createSearchClient({});
 
@@ -494,8 +498,6 @@ describe('InstantSearch', () => {
       ]);
     });
 
-    // After this rerender, the UI state is reset to the initial state because
-    // the `onStateChange` reference has changed.
     rerender(<App />);
 
     userEvent.type(screen.getByRole('searchbox'), ' case', {
@@ -508,11 +510,244 @@ describe('InstantSearch', () => {
         {
           indexName: 'indexName',
           params: expect.objectContaining({
-            // The query was reset because of the remount
-            query: ' case',
+            query: 'iphone case',
           }),
         },
       ]);
+    });
+  });
+
+  test('updates the client on client prop change', async () => {
+    const searchClient1 = createSearchClient({});
+    const searchClient2 = createSearchClient({});
+    const searchClient3 = createSearchClient({});
+
+    function App({ searchClient }) {
+      return (
+        <StrictMode>
+          <InstantSearch searchClient={searchClient} indexName="indexName">
+            <SearchBox />
+          </InstantSearch>
+        </StrictMode>
+      );
+    }
+
+    const { rerender } = render(<App searchClient={searchClient1} />);
+
+    await waitFor(() => {
+      expect(searchClient1.search).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<App searchClient={searchClient2} />);
+
+    await waitFor(() => {
+      expect(searchClient1.search).toHaveBeenCalledTimes(1);
+      // @TODO: can this call count go down to 1 in Strict Mode?
+      expect(searchClient2.search).toHaveBeenCalledTimes(2);
+      expect(searchClient2.addAlgoliaAgent).toHaveBeenCalledWith(
+        `react (${ReactVersion})`
+      );
+      expect(searchClient2.addAlgoliaAgent).toHaveBeenCalledWith(
+        `react-instantsearch (${version})`
+      );
+      expect(searchClient2.addAlgoliaAgent).toHaveBeenCalledWith(
+        `react-instantsearch-hooks (${version})`
+      );
+    });
+
+    rerender(<App searchClient={searchClient3} />);
+
+    await waitFor(() => {
+      expect(searchClient1.search).toHaveBeenCalledTimes(1);
+      expect(searchClient2.search).toHaveBeenCalledTimes(2);
+      expect(searchClient3.search).toHaveBeenCalledTimes(2);
+      expect(searchClient3.addAlgoliaAgent).toHaveBeenCalledWith(
+        `react (${ReactVersion})`
+      );
+      expect(searchClient3.addAlgoliaAgent).toHaveBeenCalledWith(
+        `react-instantsearch (${version})`
+      );
+      expect(searchClient3.addAlgoliaAgent).toHaveBeenCalledWith(
+        `react-instantsearch-hooks (${version})`
+      );
+    });
+
+    userEvent.type(screen.getByRole('searchbox'), 'iphone');
+
+    await waitFor(() => {
+      expect(searchClient3.search).toHaveBeenCalledTimes(8);
+      expect(searchClient3.search).toHaveBeenLastCalledWith([
+        {
+          indexName: 'indexName',
+          params: expect.objectContaining({
+            query: 'iphone',
+          }),
+        },
+      ]);
+    });
+  });
+
+  test('updates the index on index prop change', async () => {
+    const searchClient = createSearchClient({});
+
+    function App({ indexName }) {
+      return (
+        <StrictMode>
+          <InstantSearch searchClient={searchClient} indexName={indexName}>
+            <SearchBox />
+          </InstantSearch>
+        </StrictMode>
+      );
+    }
+
+    const { rerender } = render(<App indexName="indexName1" />);
+
+    await waitFor(() => {
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+      expect(searchClient.search).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          indexName: 'indexName1',
+        }),
+      ]);
+    });
+
+    rerender(<App indexName="indexName2" />);
+
+    await waitFor(() => {
+      // @TODO: can this call count go down in Strict Mode?
+      expect(searchClient.search).toHaveBeenCalledTimes(3);
+      expect(searchClient.search).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          indexName: 'indexName2',
+        }),
+      ]);
+    });
+
+    rerender(<App indexName="indexName3" />);
+
+    await waitFor(() => {
+      // @TODO: can this call count go down in Strict Mode?
+      expect(searchClient.search).toHaveBeenCalledTimes(5);
+      expect(searchClient.search).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          indexName: 'indexName3',
+        }),
+      ]);
+    });
+
+    userEvent.type(screen.getByRole('searchbox'), 'iphone');
+
+    await waitFor(() => {
+      expect(searchClient.search).toHaveBeenCalledTimes(11);
+      expect(searchClient.search).toHaveBeenLastCalledWith([
+        {
+          indexName: 'indexName3',
+          params: expect.objectContaining({
+            query: 'iphone',
+          }),
+        },
+      ]);
+    });
+  });
+
+  test('updates onStateChange on onStateChange prop change', async () => {
+    const searchClient = createSearchClient({});
+    const onStateChange1 = jest.fn(({ uiState, setUiState }) => {
+      setUiState(uiState);
+    });
+    const onStateChange2 = jest.fn(({ uiState, setUiState }) => {
+      setUiState(uiState);
+    });
+
+    function App({ onStateChange }) {
+      return (
+        <StrictMode>
+          <InstantSearch
+            searchClient={searchClient}
+            indexName="indexName"
+            onStateChange={onStateChange}
+          >
+            <SearchBox />
+          </InstantSearch>
+        </StrictMode>
+      );
+    }
+
+    const { rerender } = render(<App onStateChange={onStateChange1} />);
+
+    userEvent.type(screen.getByRole('searchbox'), 'iphone');
+
+    await waitFor(() => {
+      expect(onStateChange1).toHaveBeenCalledTimes(6);
+    });
+
+    rerender(<App onStateChange={onStateChange2} />);
+
+    userEvent.type(screen.getByRole('searchbox'), ' case', {
+      initialSelectionStart: 6,
+    });
+
+    await waitFor(() => {
+      expect(onStateChange1).toHaveBeenCalledTimes(6);
+      expect(onStateChange2).toHaveBeenCalledTimes(5);
+    });
+
+    rerender(<App onStateChange={undefined} />);
+
+    userEvent.type(screen.getByRole('searchbox'), ' red', {
+      initialSelectionStart: 11,
+    });
+
+    await waitFor(() => {
+      expect(onStateChange1).toHaveBeenCalledTimes(6);
+      expect(onStateChange2).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  test('updates searchFunction on searchFunction prop change', async () => {
+    const searchClient = createSearchClient({});
+    const searchFunction1 = jest.fn((helper) => {
+      helper.search();
+    });
+    const searchFunction2 = jest.fn((helper) => {
+      helper.search();
+    });
+
+    function App({ searchFunction }) {
+      return (
+        <StrictMode>
+          <InstantSearch
+            searchClient={searchClient}
+            indexName="indexName"
+            searchFunction={searchFunction}
+          >
+            <SearchBox />
+          </InstantSearch>
+        </StrictMode>
+      );
+    }
+
+    const { rerender } = render(<App searchFunction={searchFunction1} />);
+
+    await waitFor(() => {
+      expect(searchFunction1).toHaveBeenCalledTimes(1);
+    });
+
+    userEvent.type(screen.getByRole('searchbox'), 'iphone');
+
+    await waitFor(() => {
+      expect(searchFunction1).toHaveBeenCalledTimes(7);
+    });
+
+    rerender(<App searchFunction={searchFunction2} />);
+
+    userEvent.type(screen.getByRole('searchbox'), ' case', {
+      initialSelectionStart: 6,
+    });
+
+    await waitFor(() => {
+      expect(searchFunction1).toHaveBeenCalledTimes(7);
+      expect(searchFunction2).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/packages/react-instantsearch-hooks/src/components/__tests__/routing/dispose-start.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/routing/dispose-start.test.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import {
   InstantSearch,
   SearchBox,
-  useInstantSearch,
+  useSearchBox,
 } from 'react-instantsearch-hooks-web';
 
 import { createSearchClient } from '../../../../../../test/mock';
@@ -23,19 +23,12 @@ describe('routing back and forth to an InstantSearch instance', () => {
     const searchClient = createSearchClient({});
 
     let setQuery = (_query: string) => {};
-    function QueryMiddleware() {
-      const { use } = useInstantSearch();
+    function QueryController() {
+      const { refine } = useSearchBox();
 
       useEffect(() => {
-        return use(({ instantSearchInstance }) => {
-          return {
-            subscribe() {
-              setQuery =
-                instantSearchInstance.renderState.indexName.searchBox!.refine;
-            },
-          };
-        });
-      }, [use]);
+        setQuery = refine;
+      }, [refine]);
 
       return null;
     }
@@ -47,7 +40,7 @@ describe('routing back and forth to an InstantSearch instance', () => {
           indexName="indexName"
           routing={{ router: historyRouter({ writeDelay: 0 }) }}
         >
-          <QueryMiddleware />
+          <QueryController />
           <SearchBox />
         </InstantSearch>
       );

--- a/packages/react-instantsearch-hooks/src/components/__tests__/routing/dispose-start.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/routing/dispose-start.test.tsx
@@ -1,0 +1,108 @@
+import { render, waitFor } from '@testing-library/react';
+import historyRouter from 'instantsearch.js/es/lib/routers/history';
+import React, { useEffect } from 'react';
+import {
+  InstantSearch,
+  SearchBox,
+  useInstantSearch,
+} from 'react-instantsearch-hooks-web';
+
+import { createSearchClient } from '../../../../../../test/mock';
+
+describe('routing back and forth to an InstantSearch instance', () => {
+  test('updates the URL after the instance is disposed then restarted', async () => {
+    // -- Flow
+    // 1. Initial: '/'
+    // 2. Refine: '/?indexName[query]=Apple'
+    // 3. Dispose: '/'
+    // 4. Refine: '/'
+    // 5. Start: '/'
+    // 6. Refine: '/?indexName[query]=Apple'
+
+    const pushState = jest.spyOn(window.history, 'pushState');
+    const searchClient = createSearchClient({});
+
+    let setQuery = (_query: string) => {};
+    function QueryMiddleware() {
+      const { use } = useInstantSearch();
+
+      useEffect(() => {
+        return use(({ instantSearchInstance }) => {
+          return {
+            subscribe() {
+              setQuery =
+                instantSearchInstance.renderState.indexName.searchBox!.refine;
+            },
+          };
+        });
+      }, [use]);
+
+      return null;
+    }
+
+    function App() {
+      return (
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="indexName"
+          routing={{ router: historyRouter({ writeDelay: 0 }) }}
+        >
+          <QueryMiddleware />
+          <SearchBox />
+        </InstantSearch>
+      );
+    }
+
+    const { unmount } = render(<App />);
+
+    // 1. Initial: '/'
+    await waitFor(() => {
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(0);
+
+    // 2. Refine: '/?indexName[query]=Apple'
+    setQuery('Apple');
+
+    await waitFor(() => {
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    });
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    // 3. Dispose: '/'
+    unmount();
+
+    await waitFor(() => {
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(2);
+
+    // 4. Refine: '/'
+    setQuery('Apple');
+
+    await waitFor(() => {
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(2);
+
+    // 5. Start: '/'
+    render(<App />);
+
+    await waitFor(() => {
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(2);
+
+    // 6. Refine: '/?indexName[query]=Samsung'
+    setQuery('Samsung');
+
+    await waitFor(() => {
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Samsung')}`
+      );
+    });
+    expect(pushState).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/react-instantsearch-hooks/src/components/__tests__/routing/external-influence.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/routing/external-influence.test.tsx
@@ -1,0 +1,91 @@
+import { render, waitFor } from '@testing-library/react';
+import historyRouter from 'instantsearch.js/es/lib/routers/history';
+import React, { useEffect } from 'react';
+import {
+  InstantSearch,
+  SearchBox,
+  useInstantSearch,
+} from 'react-instantsearch-hooks-web';
+
+import { createSearchClient } from '../../../../../../test/mock';
+
+describe('routing with external influence', () => {
+  test('keeps on working when the URL is updated by another program', async () => {
+    // -- Flow
+    // 1. Initial: '/'
+    // 2. Refine: '/?indexName[query]=Apple'
+    // 3. External influence: '/about'
+    // 4. Refine: '/about?indexName[query]=Samsung'
+
+    const pushState = jest.spyOn(window.history, 'pushState');
+    const searchClient = createSearchClient({});
+
+    let setQuery = (_query: string) => {};
+    function QueryMiddleware() {
+      const { use } = useInstantSearch();
+
+      useEffect(() => {
+        return use(({ instantSearchInstance }) => {
+          return {
+            subscribe() {
+              setQuery =
+                instantSearchInstance.renderState.indexName.searchBox!.refine;
+            },
+          };
+        });
+      }, [use]);
+
+      return null;
+    }
+
+    function App() {
+      return (
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="indexName"
+          routing={{ router: historyRouter({ writeDelay: 0 }) }}
+        >
+          <QueryMiddleware />
+          <SearchBox />
+        </InstantSearch>
+      );
+    }
+
+    render(<App />);
+
+    // 1. Initial: '/'
+    await waitFor(() => {
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(0);
+
+    // 2. Refine: '/?indexName[query]=Apple'
+    setQuery('Apple');
+
+    await waitFor(() => {
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    });
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    // 3. External influence: '/about'
+    window.history.pushState({}, '', '/about');
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(2);
+
+    // 4. Refine: '/about?indexName[query]=Samsung'
+    setQuery('Samsung');
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Samsung')}`
+      );
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks/src/components/__tests__/routing/external-influence.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/routing/external-influence.test.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import {
   InstantSearch,
   SearchBox,
-  useInstantSearch,
+  useSearchBox,
 } from 'react-instantsearch-hooks-web';
 
 import { createSearchClient } from '../../../../../../test/mock';
@@ -21,19 +21,12 @@ describe('routing with external influence', () => {
     const searchClient = createSearchClient({});
 
     let setQuery = (_query: string) => {};
-    function QueryMiddleware() {
-      const { use } = useInstantSearch();
+    function QueryController() {
+      const { refine } = useSearchBox();
 
       useEffect(() => {
-        return use(({ instantSearchInstance }) => {
-          return {
-            subscribe() {
-              setQuery =
-                instantSearchInstance.renderState.indexName.searchBox!.refine;
-            },
-          };
-        });
-      }, [use]);
+        setQuery = refine;
+      }, [refine]);
 
       return null;
     }
@@ -45,7 +38,7 @@ describe('routing with external influence', () => {
           indexName="indexName"
           routing={{ router: historyRouter({ writeDelay: 0 }) }}
         >
-          <QueryMiddleware />
+          <QueryController />
           <SearchBox />
         </InstantSearch>
       );

--- a/packages/react-instantsearch-hooks/src/components/__tests__/routing/modal.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/routing/modal.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import historyRouter from 'instantsearch.js/es/lib/routers/history';
+import React from 'react';
+import { InstantSearch, SearchBox } from 'react-instantsearch-hooks-web';
+
+import { createSearchClient } from '../../../../../../test/mock';
+
+describe('routing with no navigation', () => {
+  test('cleans the URL when InstantSearch is disposed within the same page', async () => {
+    // -- Flow
+    // 1. Initial: '/'
+    // 2. Refine: '/?indexName[query]=Apple'
+    // 3. Dispose: '/'
+
+    const pushState = jest.spyOn(window.history, 'pushState');
+    const searchClient = createSearchClient({});
+
+    function App() {
+      return (
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="indexName"
+          routing={{ router: historyRouter({ writeDelay: 0 }) }}
+        >
+          <SearchBox />
+        </InstantSearch>
+      );
+    }
+
+    const { unmount } = render(<App />);
+
+    // 1. Initial: '/'
+    await waitFor(() => {
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(0);
+
+    // 2. Refine: '/?indexName[query]=Apple'
+    userEvent.type(screen.getByRole('searchbox'), 'Apple');
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    });
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    // 3. Dispose: '/'
+    unmount();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react-instantsearch-hooks/src/components/__tests__/routing/spa-debounced.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/routing/spa-debounced.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import historyRouter from 'instantsearch.js/es/lib/routers/history';
+import React from 'react';
+import { InstantSearch, SearchBox } from 'react-instantsearch-hooks-web';
+
+import { createSearchClient } from '../../../../../../test/mock';
+
+describe('routing with debounced third-party client-side router', () => {
+  test('does not clean the URL after navigating', async () => {
+    // -- Flow
+    // 1. Initial: '/'
+    // 2. Refine: '/?indexName[query]=Apple'
+    // 3. Dispose: '/'
+    // 4. Route change: '/about'
+    // 5. Back: '/'
+    // 6. Back: '/?indexName[query]=Apple'
+
+    const pushState = jest.spyOn(window.history, 'pushState');
+    const searchClient = createSearchClient({});
+
+    function App() {
+      return (
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="indexName"
+          routing={{ router: historyRouter({ writeDelay: 0 }) }}
+        >
+          <SearchBox />
+        </InstantSearch>
+      );
+    }
+
+    const { unmount } = render(<App />);
+
+    // 1. Initial: '/'
+    await waitFor(() => {
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(0);
+
+    // 2. Refine: '/?indexName[query]=Apple'
+    userEvent.type(screen.getByRole('searchbox'), 'Apple');
+
+    await waitFor(() => {
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    });
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    // 3. Dispose: '/'
+    unmount();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(2);
+
+    // 4. Route change: '/about'
+    window.history.pushState({}, '', '/about');
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(3);
+
+    // 5. Back: '/'
+    window.history.back();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual('');
+    });
+
+    // 6. Back: '/?indexName[query]=Apple'
+    window.history.back();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    });
+    expect(pushState).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/react-instantsearch-hooks/src/components/__tests__/routing/spa-replace-state.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/routing/spa-replace-state.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import historyRouter from 'instantsearch.js/es/lib/routers/history';
+import React from 'react';
+import { InstantSearch, SearchBox } from 'react-instantsearch-hooks-web';
+
+import { createSearchClient } from '../../../../../../test/mock';
+
+describe('routing using `replaceState`', () => {
+  // We can't assert whether another router did update the URL
+  // So there's no way to prevent `write` after `dispose`
+  test('cleans the URL after navigating', async () => {
+    // -- Flow
+    // 1. Initial: '/'
+    // 2. Refine: '/?indexName[query]=Apple'
+    // 3. Dispose: does not yet write
+    // 4. Route change (with `replaceState`): '/about?external=true', replaces state 2
+    // 5. Dispose: writes '/about' (this is a bug, and should be fixed when we have a way to prevent it)
+    // 6. Back: '/about?external=true'
+
+    const pushState = jest.spyOn(window.history, 'pushState');
+    const searchClient = createSearchClient({});
+
+    function App() {
+      return (
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="indexName"
+          routing={{ router: historyRouter({ writeDelay: 0 }) }}
+        >
+          <SearchBox />
+        </InstantSearch>
+      );
+    }
+
+    const { unmount } = render(<App />);
+
+    // 1. Initial: '/'
+    await waitFor(() => {
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(0);
+
+    // 2. Refine: '/?indexName[query]=Apple'
+    userEvent.type(screen.getByRole('searchbox'), 'Apple');
+
+    await waitFor(() => {
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    });
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    // 3. Dispose: '/about'
+    unmount();
+
+    // 4. Route change (with `replaceState`): '/about'
+    window.history.replaceState({}, '', '/about?external=true');
+
+    // Asserting `replaceState` call
+    expect(window.location.pathname).toEqual('/about');
+    expect(window.location.search).toEqual('?external=true');
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    // Asserting `dispose` calling `pushState`
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(2);
+
+    // 5. Back: '/about'
+    window.history.back();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.search).toEqual('?external=true');
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks/src/components/__tests__/routing/spa.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/routing/spa.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import historyRouter from 'instantsearch.js/es/lib/routers/history';
+import React from 'react';
+import { InstantSearch, SearchBox } from 'react-instantsearch-hooks-web';
+
+import { createSearchClient } from '../../../../../../test/mock';
+
+describe('routing with third-party client-side router', () => {
+  test('does not clean the URL after navigating', async () => {
+    // -- Flow
+    // 1. Initial: '/'
+    // 2. Refine: '/?indexName[query]=Apple'
+    // 3. Navigate: '/about'
+    // 4. Back: '/?indexName[query]=Apple'
+
+    const pushState = jest.spyOn(window.history, 'pushState');
+    const searchClient = createSearchClient({});
+
+    function App() {
+      return (
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="indexName"
+          routing={{ router: historyRouter({ writeDelay: 0 }) }}
+        >
+          <SearchBox />
+        </InstantSearch>
+      );
+    }
+
+    const { unmount } = render(<App />);
+
+    // 1. Initial: '/'
+    await waitFor(() => {
+      expect(window.location.search).toEqual('');
+    });
+
+    expect(pushState).toHaveBeenCalledTimes(0);
+
+    // 2. Refine: '/?indexName[query]=Apple'
+    userEvent.type(screen.getByRole('searchbox'), 'Apple');
+
+    await waitFor(() => {
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    });
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    // 3. Navigate: '/about'
+    unmount();
+    window.history.pushState({}, '', '/about');
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.search).toEqual('');
+    });
+    expect(pushState).toHaveBeenCalledTimes(2);
+
+    // 4. Back to previous page
+    window.history.back();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks/src/hooks/__tests__/useInstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/hooks/__tests__/useInstantSearch.test.tsx
@@ -216,12 +216,7 @@ describe('useInstantSearch', () => {
       expect(middleware).toHaveBeenCalledTimes(1);
       expect(subscribe).toHaveBeenCalledTimes(1);
       expect(onStateChange).toHaveBeenCalledTimes(1);
-      // unsubscribe is first called by the parent InstantSearch unmounting
-      // 🚨 dispose doesn't remove middleware (because otherwise routing would break)
-      // then unuse is called by this widget itself unmounting.
-      // if only the component with useInstantSearch is unmounted, unsubscribe is called once.
-      // This is a problem in InstantSearch.js and will be fixed there.
-      expect(unsubscribe).toHaveBeenCalledTimes(2);
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
 
     test('provides a stable reference', () => {

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -1,5 +1,5 @@
 import InstantSearch from 'instantsearch.js/es/lib/InstantSearch';
-import { useCallback, useMemo, version as ReactVersion } from 'react';
+import { useCallback, useRef, useState, version as ReactVersion } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 
 import { useInstantSearchServerContext } from '../lib/useInstantSearchServerContext';
@@ -7,7 +7,6 @@ import { useInstantSearchSSRContext } from '../lib/useInstantSearchSSRContext';
 import version from '../version';
 
 import { useForceUpdate } from './useForceUpdate';
-import { useStableValue } from './useStableValue';
 
 import type {
   InstantSearchOptions,
@@ -20,6 +19,7 @@ const defaultUserAgents = [
   `react-instantsearch (${version})`,
   `react-instantsearch-hooks (${version})`,
 ];
+const serverUserAgent = `react-instantsearch-server (${version})`;
 
 export type UseInstantSearchApiProps<
   TUiState extends UiState,
@@ -33,9 +33,11 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
   const serverContext = useInstantSearchServerContext<TUiState, TRouteState>();
   const serverState = useInstantSearchSSRContext();
   const initialResults = serverState?.initialResults;
-  const stableProps = useStableValue(props);
-  const search = useMemo(() => {
-    const instance = new InstantSearch(stableProps);
+  const searchRef = useRef<InstantSearch<TUiState, TRouteState> | null>(null);
+  const [prevProps, setPrevProps] = useState(props);
+
+  if (searchRef.current === null) {
+    const search = new InstantSearch(props);
 
     if (serverContext || initialResults) {
       // InstantSearch.js has a private Initial Results API that lets us inject
@@ -44,34 +46,14 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
       // InstantSearch.js doesn't schedule a search that isn't used, leading to
       // an additional network request. (This is equivalent to monkey-patching
       // `scheduleSearch` to a noop.)
-      instance._initialResults = initialResults || {};
+      search._initialResults = initialResults || {};
     }
 
     addAlgoliaAgents(props.searchClient, [
       ...defaultUserAgents,
-      serverContext && `react-instantsearch-server (${version})`,
+      serverContext && serverUserAgent,
     ]);
 
-    return instance;
-  }, [initialResults, props.searchClient, serverContext, stableProps]);
-
-  const store = useSyncExternalStore<InstantSearch<TUiState, TRouteState>>(
-    useCallback(() => {
-      // On SSR, the instance is already started so we don't start it again here.
-      if (!search.started) {
-        search.start();
-        forceUpdate();
-      }
-
-      return () => {
-        search.dispose();
-      };
-    }, [forceUpdate, search]),
-    () => search,
-    () => search
-  );
-
-  if (!search.started) {
     // On the server, we start the search early to compute the search parameters.
     // On SSR, we start the search early to directly catch up with the lifecycle
     // and render.
@@ -84,7 +66,101 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
       // the server state and pass it to the render on SSR.
       serverContext.notifyServer({ search });
     }
+
+    searchRef.current = search;
   }
+
+  {
+    const search = searchRef.current;
+
+    if (prevProps.indexName !== props.indexName) {
+      search.helper!.setIndex(props.indexName).search();
+      setPrevProps(props);
+    }
+
+    if (prevProps.searchClient !== props.searchClient) {
+      addAlgoliaAgents(props.searchClient, [
+        ...defaultUserAgents,
+        serverContext && serverUserAgent,
+      ]);
+      search.mainHelper!.setClient(props.searchClient).search();
+      setPrevProps(props);
+    }
+
+    if (prevProps.onStateChange !== props.onStateChange) {
+      search.onStateChange = props.onStateChange;
+      setPrevProps(props);
+    }
+
+    if (prevProps.searchFunction !== props.searchFunction) {
+      // Updating the `searchFunction` to `undefined` is not supported by
+      // InstantSearch.js, so it will throw an error.
+      // This is a fair behavior until we add an update API in InstantSearch.js.
+      search._searchFunction = props.searchFunction;
+      setPrevProps(props);
+    }
+
+    if (prevProps.stalledSearchDelay !== props.stalledSearchDelay) {
+      // The default `stalledSearchDelay` in InstantSearch.js is 200ms.
+      // We need to reset it when it's undefined to get back to the original value.
+      search._stalledSearchDelay = props.stalledSearchDelay ?? 200;
+      setPrevProps(props);
+    }
+
+    // Updating the `routing` prop is not supported because InstantSearch.js
+    // doesn't let us change it. This might not be a problem though, because `routing`
+    // shouldn't need to be dynamic.
+    // If we find scenarios where `routing` needs to change, we can always expose
+    // it privately on the InstantSearch instance. Another way would be to
+    // manually inject the routing middleware in this library, and not rely
+    // on the provided `routing` prop.
+  }
+
+  const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const store = useSyncExternalStore<InstantSearch<TUiState, TRouteState>>(
+    useCallback(() => {
+      const search = searchRef.current!;
+
+      // Scenario 1: the component mounts.
+      if (cleanupTimerRef.current === null) {
+        // On SSR, the instance is already started so we don't start it again.
+        if (!search.started) {
+          search.start();
+          forceUpdate();
+        }
+      }
+      // Scenario 2: the component updates.
+      else {
+        // We cancel the previous cleanup function because we don't want to
+        // dispose the search during an update.
+        clearTimeout(cleanupTimerRef.current);
+      }
+
+      return () => {
+        function cleanup() {
+          // When `dispose()` is called, InstantSearch.js also calls `removeWigets()`.
+          // This is not desired because React starts by unmounting each widget
+          // before unmounting <InstantSearch>, so their `dispose()` methods are
+          // already called.
+          // Calling `removeWidgets()` would remove each widget multiple times.
+          const originalRemoveWidgets = search.removeWidgets;
+          search.removeWidgets = () => search;
+          search.dispose();
+          search.removeWidgets = originalRemoveWidgets;
+        }
+
+        // We clean up only when the component that uses this subscription unmounts,
+        // but not when it updates, because it would dispose the instance, which
+        // would remove all the widgets and break routing.
+        // Executing the cleanup function in a `setTimeout()` lets us cancel it
+        // in the next effect.
+        // (There might be better ways to do this.)
+        cleanupTimerRef.current = setTimeout(cleanup, 0);
+      };
+    }, [forceUpdate]),
+    () => searchRef.current,
+    () => searchRef.current
+  );
 
   return store;
 }

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -1,5 +1,5 @@
 import InstantSearch from 'instantsearch.js/es/lib/InstantSearch';
-import { useCallback, useRef, useState, version as ReactVersion } from 'react';
+import { useCallback, useRef, version as ReactVersion } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 
 import { useInstantSearchServerContext } from '../lib/useInstantSearchServerContext';
@@ -34,7 +34,7 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
   const serverState = useInstantSearchSSRContext();
   const initialResults = serverState?.initialResults;
   const searchRef = useRef<InstantSearch<TUiState, TRouteState> | null>(null);
-  const [prevProps, setPrevProps] = useState(props);
+  const prevPropsRef = useRef(props);
 
   if (searchRef.current === null) {
     const search = new InstantSearch(props);
@@ -72,10 +72,11 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
 
   {
     const search = searchRef.current;
+    const prevProps = prevPropsRef.current;
 
     if (prevProps.indexName !== props.indexName) {
       search.helper!.setIndex(props.indexName).search();
-      setPrevProps(props);
+      prevPropsRef.current = props;
     }
 
     if (prevProps.searchClient !== props.searchClient) {
@@ -84,12 +85,12 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
         serverContext && serverUserAgent,
       ]);
       search.mainHelper!.setClient(props.searchClient).search();
-      setPrevProps(props);
+      prevPropsRef.current = props;
     }
 
     if (prevProps.onStateChange !== props.onStateChange) {
       search.onStateChange = props.onStateChange;
-      setPrevProps(props);
+      prevPropsRef.current = props;
     }
 
     if (prevProps.searchFunction !== props.searchFunction) {
@@ -97,14 +98,14 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
       // InstantSearch.js, so it will throw an error.
       // This is a fair behavior until we add an update API in InstantSearch.js.
       search._searchFunction = props.searchFunction;
-      setPrevProps(props);
+      prevPropsRef.current = props;
     }
 
     if (prevProps.stalledSearchDelay !== props.stalledSearchDelay) {
       // The default `stalledSearchDelay` in InstantSearch.js is 200ms.
       // We need to reset it when it's undefined to get back to the original value.
       search._stalledSearchDelay = props.stalledSearchDelay ?? 200;
-      setPrevProps(props);
+      prevPropsRef.current = props;
     }
 
     // Updating the `routing` prop is not supported because InstantSearch.js


### PR DESCRIPTION
This addresses a lot of issues related to the `<InstantSearch>` lifecycle that happened when remounting:

- Closes #3530
- Closes #3550
- Maybe #3537

### Updating `<InstantSearch>` props

Prior to this PR, any prop change would create a new instance of InstantSearch.js, in an Effect. Now, we track props changes during rendering, and update them with the underlying InstantSearch.js internals. That's similar to [how it's done in Vue InstantSearch](https://github.com/algolia/vue-instantsearch//blob/71c25d460e1b077b62ca41a59a5c4df7b713ec56/src/util/createInstantSearchComponent.js#L16-L36).

InstantSearch.js doesn't provide a way to override `routing`, so this prop cannot be changed. If we find cases where we need `routing` to be dynamic, we can provide an internal API in InstantSearch.js.

But long term, I think we should have an update API in InstantSearch.js. There are many corner cases right now, like you can't have a `searchFunction`, and then remove it. InstantSearch.js will throw because it still expects a `searchFunction` to exist (because it was attached in `start()`).

### Unmounting `<InstantSearch>`

The `dispose()` call now happens in a `setTimeout()`, as in `useConnector()`. This lets us prevent InstantSearch from being recreated, and therefore to manipulate a single instance in all the widgets.

### Supporting SSR in Strict Mode

The single InstantSearch.js instance created is now compatible with SSR in Strict Mode.

### Routing tests

I copied the [InstantSearch.js routing tests](https://github.com/algolia/instantsearch.js/tree/cf738b50d36c99c12995c79157920748094b4a7c/src/lib/__tests__/routing) to make sure that React InstantSearch Hooks behaves similarly to InstantSearch.js. This is useful because we skip the `removeWidgets()` call on `dispose()`, as I explained in the comments. This lets React unmount all the widgets and not rely on `<InstantSearch>` to remove them.
