### PR TITLE
docs(hooks): document why we use the InstantSearch constructor

### DIFF
--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -37,6 +37,9 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
   const prevPropsRef = useRef(props);
 
   if (searchRef.current === null) {
+    // We don't use the `instantsearch()` function because it comes with other
+    // top-level APIs that we don't need.
+    // See https://github.com/algolia/instantsearch.js/blob/5b529f43d8acc680f85837eaaa41f7fd03a3f833/src/index.es.ts#L63-L86
     const search = new InstantSearch(props);
 
     if (serverContext || initialResults) {


### PR DESCRIPTION
This adds a comment that explains why we use the InstantSearch constructor, and not the `instantsearch()` function.