### PR TITLE
docs(readme): update Getting Started sandbox link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const App = () => (
 ```
 
 <p align="center">
-  <a href="https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/React InstantSearch/getting-started" title="Edit on CodeSandbox">
+  <a href="https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/getting-started" title="Edit on CodeSandbox">
     <img alt="Edit on CodeSandbox" src="https://codesandbox.io/static/img/play-codesandbox.svg">
   </a>
 </p>


### PR DESCRIPTION
**Summary**

Fixes the codesandbox link within the readme, currently if you follow the link codesandbox is unable to access the example

![image](https://user-images.githubusercontent.com/22569730/181398996-c70dce43-94c5-4e5b-8875-2ce2220bbc54.png)


**Result**

Click the link to successfully navigate to codesandbox