### PR TITLE
fix(hooks): use `label` CSS class in <HierarchicalMenu>

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/ui/HierarchicalMenu.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/HierarchicalMenu.tsx
@@ -108,7 +108,7 @@ function HierarchicalList({
             }}
           >
             <span
-              className={cx('ais-HierarchicalMenu-labelText', classNames.label)}
+              className={cx('ais-HierarchicalMenu-label', classNames.label)}
             >
               {item.label}
             </span>

--- a/packages/react-instantsearch-hooks-web/src/ui/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/__tests__/HierarchicalMenu.test.tsx
@@ -71,7 +71,7 @@ describe('HierarchicalMenu', () => {
                 href="#Apple"
               >
                 <span
-                  class="ais-HierarchicalMenu-labelText"
+                  class="ais-HierarchicalMenu-label"
                 >
                   Apple
                 </span>
@@ -92,7 +92,7 @@ describe('HierarchicalMenu', () => {
                     href="#iPhone"
                   >
                     <span
-                      class="ais-HierarchicalMenu-labelText"
+                      class="ais-HierarchicalMenu-label"
                     >
                       iPhone
                     </span>
@@ -111,7 +111,7 @@ describe('HierarchicalMenu', () => {
                     href="#iPad"
                   >
                     <span
-                      class="ais-HierarchicalMenu-labelText"
+                      class="ais-HierarchicalMenu-label"
                     >
                       iPad
                     </span>
@@ -132,7 +132,7 @@ describe('HierarchicalMenu', () => {
                 href="#Samsung"
               >
                 <span
-                  class="ais-HierarchicalMenu-labelText"
+                  class="ais-HierarchicalMenu-label"
                 >
                   Samsung
                 </span>
@@ -182,7 +182,7 @@ describe('HierarchicalMenu', () => {
                   href="#Apple"
                 >
                   <span
-                    class="ais-HierarchicalMenu-labelText"
+                    class="ais-HierarchicalMenu-label"
                   >
                     Apple
                   </span>
@@ -203,7 +203,7 @@ describe('HierarchicalMenu', () => {
                       href="#iPhone"
                     >
                       <span
-                        class="ais-HierarchicalMenu-labelText"
+                        class="ais-HierarchicalMenu-label"
                       >
                         iPhone
                       </span>
@@ -222,7 +222,7 @@ describe('HierarchicalMenu', () => {
                       href="#iPad"
                     >
                       <span
-                        class="ais-HierarchicalMenu-labelText"
+                        class="ais-HierarchicalMenu-label"
                       >
                         iPad
                       </span>
@@ -243,7 +243,7 @@ describe('HierarchicalMenu', () => {
                   href="#Samsung"
                 >
                   <span
-                    class="ais-HierarchicalMenu-labelText"
+                    class="ais-HierarchicalMenu-label"
                   >
                     Samsung
                   </span>
@@ -319,7 +319,7 @@ describe('HierarchicalMenu', () => {
                 href="#Apple"
               >
                 <span
-                  class="ais-HierarchicalMenu-labelText LABEL"
+                  class="ais-HierarchicalMenu-label LABEL"
                 >
                   Apple
                 </span>
@@ -340,7 +340,7 @@ describe('HierarchicalMenu', () => {
                     href="#iPhone"
                   >
                     <span
-                      class="ais-HierarchicalMenu-labelText LABEL"
+                      class="ais-HierarchicalMenu-label LABEL"
                     >
                       iPhone
                     </span>
@@ -359,7 +359,7 @@ describe('HierarchicalMenu', () => {
                     href="#iPad"
                   >
                     <span
-                      class="ais-HierarchicalMenu-labelText LABEL"
+                      class="ais-HierarchicalMenu-label LABEL"
                     >
                       iPad
                     </span>
@@ -380,7 +380,7 @@ describe('HierarchicalMenu', () => {
                 href="#Samsung"
               >
                 <span
-                  class="ais-HierarchicalMenu-labelText LABEL"
+                  class="ais-HierarchicalMenu-label LABEL"
                 >
                   Samsung
                 </span>

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/HierarchicalMenu.test.tsx
@@ -74,7 +74,7 @@ describe('HierarchicalMenu', () => {
                 href="#"
               >
                 <span
-                  class="ais-HierarchicalMenu-labelText"
+                  class="ais-HierarchicalMenu-label"
                 >
                   Cameras & Camcorders
                 </span>
@@ -93,7 +93,7 @@ describe('HierarchicalMenu', () => {
                 href="#"
               >
                 <span
-                  class="ais-HierarchicalMenu-labelText"
+                  class="ais-HierarchicalMenu-label"
                 >
                   Video Games
                 </span>
@@ -112,7 +112,7 @@ describe('HierarchicalMenu', () => {
                 href="#"
               >
                 <span
-                  class="ais-HierarchicalMenu-labelText"
+                  class="ais-HierarchicalMenu-label"
                 >
                   Wearable Technology
                 </span>
@@ -187,7 +187,7 @@ describe('HierarchicalMenu', () => {
                 href="#"
               >
                 <span
-                  class="ais-HierarchicalMenu-labelText"
+                  class="ais-HierarchicalMenu-label"
                 >
                   Cameras & Camcorders
                 </span>
@@ -242,7 +242,7 @@ describe('HierarchicalMenu', () => {
       await waitFor(() =>
         expect(
           Array.from(
-            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+            container.querySelectorAll('.ais-HierarchicalMenu-label')
           ).map((item) => item.textContent)
         ).toEqual([
           'Cameras & Camcorders',
@@ -263,7 +263,7 @@ describe('HierarchicalMenu', () => {
       await waitFor(() =>
         expect(
           Array.from(
-            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+            container.querySelectorAll('.ais-HierarchicalMenu-label')
           ).map((item) => item.textContent)
         ).toEqual([
           'Wearable Technology',
@@ -310,7 +310,7 @@ describe('HierarchicalMenu', () => {
       await waitFor(() =>
         expect(
           Array.from(
-            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+            container.querySelectorAll('.ais-HierarchicalMenu-label')
           ).map((item) => item.textContent)
         ).toEqual([
           'Cameras & Camcorders n',
@@ -324,7 +324,7 @@ describe('HierarchicalMenu', () => {
       await waitFor(() => {
         expect(
           Array.from(
-            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+            container.querySelectorAll('.ais-HierarchicalMenu-label')
           ).map((item) => item.textContent)
         ).toEqual([
           'Video Games y',
@@ -338,7 +338,7 @@ describe('HierarchicalMenu', () => {
       await waitFor(() => {
         expect(
           Array.from(
-            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+            container.querySelectorAll('.ais-HierarchicalMenu-label')
           ).map((item) => item.textContent)
         ).toEqual([
           'Wearable Technology y',
@@ -362,7 +362,7 @@ describe('HierarchicalMenu', () => {
       await waitFor(() =>
         expect(
           Array.from(
-            container.querySelectorAll('.ais-HierarchicalMenu-labelText')
+            container.querySelectorAll('.ais-HierarchicalMenu-label')
           ).map((item) => item.textContent)
         ).toEqual([
           'Wearable Technology',
@@ -409,7 +409,7 @@ describe('HierarchicalMenu', () => {
                   href="#"
                 >
                   <span
-                    class="ais-HierarchicalMenu-labelText"
+                    class="ais-HierarchicalMenu-label"
                   >
                     Cameras & Camcorders
                   </span>


### PR DESCRIPTION
**Summary**

This PR fixes the `label` CSS class (instead of `labelText`) used in the `HierarchicalMenu` widget of React InstantSearch Hooks.

According to the [InstantSearch specs](https://instantsearch-css.netlify.app/widgets/hierarchical-menu/), the correct CSS class is `.ais-HierarchicalMenu-label`.
For reference, here is the [implementation of the CSS class in InstantSearch.js](https://github.com/algolia/instantsearch.js/blob/master/src/widgets/hierarchical-menu/hierarchical-menu.tsx#L335).

**Note:** This fix may break current user implementations that depend on the `labelText` CSS class so we want to make sure the release note mentions it clearly.

**Results**

When a `HierarchicalMenu` item is selected, [the correct style](https://github.com/algolia/instantsearch-specs/blob/master/src/scss/themes/satellite.scss#L266-L273) is applied to it.