### PR TITLE
feat(hooks): add `searchAsYouType` option to <SearchBox>

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -60,10 +60,12 @@ export function SearchBox({
   }
 
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    if (!searchAsYouType) {
+      refine(inputValue);
+    }
+
     if (props.onSubmit) {
       props.onSubmit(event);
-    } else if (!searchAsYouType) {
-      refine(inputValue);
     }
   }
 

--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -12,14 +12,30 @@ type UiProps = Pick<
   | 'isSearchStalled'
   | 'onChange'
   | 'onReset'
+  | 'onSubmit'
   | 'value'
   | 'translations'
 >;
 
-export type SearchBoxProps = Omit<SearchBoxUiComponentProps, keyof UiProps> &
-  UseSearchBoxProps;
+export type SearchBoxProps = Omit<
+  SearchBoxUiComponentProps,
+  Exclude<keyof UiProps, 'onSubmit'>
+> &
+  UseSearchBoxProps & {
+    /**
+     * If false, triggers the search only on submit.
+     * @type {boolean}
+     * @default true
+     * @optional
+     */
+    searchAsYouType?: boolean;
+  };
 
-export function SearchBox({ queryHook, ...props }: SearchBoxProps) {
+export function SearchBox({
+  queryHook,
+  searchAsYouType = true,
+  ...props
+}: SearchBoxProps) {
   const { query, refine, isSearchStalled } = useSearchBox(
     { queryHook },
     { $$widgetType: 'ais.searchBox' }
@@ -29,7 +45,10 @@ export function SearchBox({ queryHook, ...props }: SearchBoxProps) {
 
   function setQuery(newQuery: string) {
     setInputValue(newQuery);
-    refine(newQuery);
+
+    if (searchAsYouType) {
+      refine(newQuery);
+    }
   }
 
   function onReset() {
@@ -38,6 +57,14 @@ export function SearchBox({ queryHook, ...props }: SearchBoxProps) {
 
   function onChange(event: React.ChangeEvent<HTMLInputElement>) {
     setQuery(event.currentTarget.value);
+  }
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    if (props.onSubmit) {
+      props.onSubmit(event);
+    } else {
+      refine(inputValue);
+    }
   }
 
   // Track when the InstantSearch query changes to synchronize it with
@@ -53,6 +80,7 @@ export function SearchBox({ queryHook, ...props }: SearchBoxProps) {
     isSearchStalled,
     onChange,
     onReset,
+    onSubmit,
     value: inputValue,
     translations: {
       submitTitle: 'Submit the search query.',

--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -23,10 +23,8 @@ export type SearchBoxProps = Omit<
 > &
   UseSearchBoxProps & {
     /**
-     * If false, triggers the search only on submit.
-     * @type {boolean}
+     * Whether to trigger the search only on submit.
      * @default true
-     * @optional
      */
     searchAsYouType?: boolean;
   };

--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -62,7 +62,7 @@ export function SearchBox({
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     if (props.onSubmit) {
       props.onSubmit(event);
-    } else {
+    } else if (!searchAsYouType) {
       refine(inputValue);
     }
   }

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
@@ -279,7 +279,7 @@ describe('SearchBox', () => {
     expect(lastUiState.indexName?.query).toBe(undefined);
   });
 
-  test('refines on submit when no custom onSubmit is provided', () => {
+  test('refines on submit when searchAsYouType is false and no custom onSubmit is provided', () => {
     let lastUiState: UiState = {};
 
     const { container } = render(

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
@@ -279,7 +279,8 @@ describe('SearchBox', () => {
     expect(lastUiState.indexName?.query).toBe(undefined);
   });
 
-  test('refines on submit when searchAsYouType is false and no custom onSubmit is provided', () => {
+  test('refines on submit when searchAsYouType is false, even if custom onSubmit is provided', () => {
+    const onSubmit = jest.fn();
     let lastUiState: UiState = {};
 
     const { container } = render(
@@ -288,7 +289,7 @@ describe('SearchBox', () => {
           lastUiState = uiState;
         }}
       >
-        <SearchBox searchAsYouType={false} />
+        <SearchBox searchAsYouType={false} onSubmit={onSubmit} />
       </InstantSearchHooksTestWrapper>
     );
 
@@ -300,5 +301,6 @@ describe('SearchBox', () => {
     userEvent.type(input, 'iPhone{Enter}');
 
     expect(lastUiState.indexName.query).toBe('iPhone');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
@@ -254,4 +254,51 @@ describe('SearchBox', () => {
     expect(root).toHaveClass('MySearchBox', 'ROOT');
     expect(root).toHaveAttribute('title', 'Some custom title');
   });
+
+  test('does not refine query on type when searchAsYouType is false', () => {
+    let lastUiState: UiState = {};
+
+    const { container } = render(
+      <InstantSearchHooksTestWrapper
+        onStateChange={({ uiState }) => {
+          lastUiState = uiState;
+        }}
+      >
+        <SearchBox searchAsYouType={false} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    const input = container.querySelector<HTMLInputElement>(
+      '.ais-SearchBox-input'
+    )!;
+    input.focus();
+
+    userEvent.type(input, 'iPhone');
+
+    expect(input).toHaveValue('iPhone');
+    expect(lastUiState.indexName?.query).toBe(undefined);
+  });
+
+  test('refines on submit when no custom onSubmit is provided', () => {
+    let lastUiState: UiState = {};
+
+    const { container } = render(
+      <InstantSearchHooksTestWrapper
+        onStateChange={({ uiState }) => {
+          lastUiState = uiState;
+        }}
+      >
+        <SearchBox searchAsYouType={false} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    const input = container.querySelector<HTMLInputElement>(
+      '.ais-SearchBox-input'
+    )!;
+    input.focus();
+
+    userEvent.type(input, 'iPhone{Enter}');
+
+    expect(lastUiState.indexName.query).toBe('iPhone');
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

As mentioned in discussion #3523, the `searchAsYouType` prop is missing from `react-instantsearch-hooks-web`'s `SearchBox` component, while it is present in [the non-hooks version](https://www.algolia.com/doc/api-reference/widgets/search-box/react/#widget-param-searchAsYouType).

**Notes**:
- I think we can do better on the widget/ui components splitting, so we won't have to duplicate default search behaviour for each JSX UI library (Preact or Solid for example)
- I'm not sure whether it's fine or not that we now refine on submit by default even if `searchAsYouType` is true, my guess would be it's okay as we won't trigger a search if query does not change.

**Result**

As the tests show, when `searchAsYouType` is set to `false`, it does not change internal InstantSearch state. Pressing enter or pushing the submit button will however trigger a search.

Ticket: [FX-1571](https://algolia.atlassian.net/browse/FX-1571)