### PR TITLE
fix(hooks): prevent widget cleanup on `<InstantSearch>` unmount

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,12 @@ const config = {
         paths: ['instantsearch.js/es'],
       },
     ],
+    'react-hooks/exhaustive-deps': [
+      'warn',
+      {
+        additionalHooks: '(useIsomorphicLayoutEffect)',
+      },
+    ],
   },
   overrides: [
     {

--- a/packages/react-instantsearch-hooks/global.d.ts
+++ b/packages/react-instantsearch-hooks/global.d.ts
@@ -1,1 +1,8 @@
 declare const __DEV__: boolean;
+
+import 'instantsearch.js';
+declare module 'instantsearch.js' {
+  declare class InstantSearch {
+    _preventWidgetCleanup?: boolean;
+  }
+}

--- a/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
@@ -750,7 +750,7 @@ describe('InstantSearch', () => {
     });
   });
 
-  test('triggers no more than one search on unmount', async () => {
+  test('triggers no search on unmount', async () => {
     const searchClient = createSearchClient({});
 
     function App() {

--- a/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
@@ -6,7 +6,7 @@ import React, { StrictMode, Suspense, version as ReactVersion } from 'react';
 import { SearchBox } from 'react-instantsearch-hooks-web';
 
 import { createSearchClient } from '../../../../../test/mock';
-import { createInstantSearchSpy } from '../../../../../test/utils';
+import { createInstantSearchSpy, wait } from '../../../../../test/utils';
 import { useRefinementList } from '../../connectors/useRefinementList';
 import version from '../../version';
 import { Index } from '../Index';
@@ -748,5 +748,56 @@ describe('InstantSearch', () => {
       expect(searchFunction1).toHaveBeenCalledTimes(7);
       expect(searchFunction2).toHaveBeenCalledTimes(5);
     });
+  });
+
+  test('triggers no more than one search on unmount', async () => {
+    const searchClient = createSearchClient({});
+
+    function App() {
+      return (
+        <StrictMode>
+          <InstantSearch searchClient={searchClient} indexName="indexName">
+            <SearchBox />
+            <RefinementList attribute="brand" />
+            <RefinementList attribute="price" />
+          </InstantSearch>
+        </StrictMode>
+      );
+    }
+
+    const { unmount } = render(<App />);
+
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
+
+    unmount();
+
+    // We need to wait for the `cleanup` functions of the instance and
+    // the widgets to get called since they are schedule with a `setTimeout`.
+    await wait(100);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+  });
+
+  test('triggers a search on widget unmount', async () => {
+    const searchClient = createSearchClient({});
+
+    function App({ isMounted }) {
+      return (
+        <StrictMode>
+          <InstantSearch searchClient={searchClient} indexName="indexName">
+            <SearchBox />
+            {isMounted && <RefinementList attribute="brand" />}
+          </InstantSearch>
+        </StrictMode>
+      );
+    }
+
+    const { rerender } = render(<App isMounted={true} />);
+
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
+
+    rerender(<App isMounted={false} />);
+
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(2));
   });
 });

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -153,6 +153,10 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
         // in the next effect.
         // (There might be better ways to do this.)
         cleanupTimerRef.current = setTimeout(cleanup);
+
+        // We need to prevent the `useWidget` cleanup function so that widgets
+        // are not removed before the instance is disposed, triggering
+        // an unwanted search request.
         search._preventWidgetCleanup = true;
       };
     }, [forceUpdate]),

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -143,15 +143,7 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
 
       return () => {
         function cleanup() {
-          // When `dispose()` is called, InstantSearch.js also calls `removeWigets()`.
-          // This is not desired because React starts by unmounting each widget
-          // before unmounting <InstantSearch>, so their `dispose()` methods are
-          // already called.
-          // Calling `removeWidgets()` would remove each widget multiple times.
-          const originalRemoveWidgets = search.removeWidgets;
-          search.removeWidgets = () => search;
           search.dispose();
-          search.removeWidgets = originalRemoveWidgets;
         }
 
         // We clean up only when the component that uses this subscription unmounts,

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -138,6 +138,7 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
         // We cancel the previous cleanup function because we don't want to
         // dispose the search during an update.
         clearTimeout(cleanupTimerRef.current);
+        search._preventWidgetCleanup = false;
       }
 
       return () => {
@@ -159,7 +160,8 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
         // Executing the cleanup function in a `setTimeout()` lets us cancel it
         // in the next effect.
         // (There might be better ways to do this.)
-        cleanupTimerRef.current = setTimeout(cleanup, 0);
+        cleanupTimerRef.current = setTimeout(cleanup);
+        search._preventWidgetCleanup = true;
       };
     }, [forceUpdate]),
     () => searchRef.current,

--- a/packages/react-instantsearch-hooks/src/lib/useWidget.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useWidget.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import { dequal } from './dequal';
+import { useInstantSearchContext } from './useInstantSearchContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 import type { Widget } from 'instantsearch.js';
@@ -31,6 +32,8 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
   const shouldAddWidgetEarly =
     shouldSsr && !parentIndex.getWidgets().includes(widget);
 
+  const search = useInstantSearchContext();
+
   // This effect is responsible for adding, removing, and updating the widget.
   // We need to support scenarios where the widget is remounted quickly, like in
   // Strict Mode, so that we don't lose its state, and therefore that we don't
@@ -38,6 +41,7 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
   useIsomorphicLayoutEffect(() => {
     const previousWidget = prevWidgetRef.current;
     function cleanup() {
+      if (search._preventWidgetCleanup) return;
       parentIndex.removeWidgets([previousWidget]);
     }
 

--- a/packages/react-instantsearch-hooks/src/lib/useWidget.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useWidget.ts
@@ -80,7 +80,7 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
       // we're able to cancel it in the next effect.
       cleanupTimerRef.current = setTimeout(cleanup);
     };
-  }, [parentIndex, widget, shouldAddWidgetEarly]);
+  }, [parentIndex, widget, shouldAddWidgetEarly, search, props]);
 
   if (shouldAddWidgetEarly) {
     parentIndex.addWidgets([widget]);


### PR DESCRIPTION
### Summary

#### Context

Starting from [v6.30.2](https://github.com/algolia/react-instantsearch/releases/tag/v6.30.2), when the `<InstantSearch>` component is unmounted, one search request per widget is triggered. The PR https://github.com/algolia/react-instantsearch/pull/3561 introduces this regression.

This issue was originally reported here: https://github.com/algolia/react-instantsearch/issues/3586.

#### Details

Currently, when the `<InstantSearch>` component is unmounted, a `cleanup` is scheduled using a `setTimeout`.

https://github.com/algolia/react-instantsearch/blob/affcbb58ee5c63345cc9424ad8ab566f3a01c9f9/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts#L156-L162

The widgets also rely on the same strategy when they unmount.

https://github.com/algolia/react-instantsearch/blob/affcbb58ee5c63345cc9424ad8ab566f3a01c9f9/packages/react-instantsearch-hooks/src/lib/useWidget.ts#L75-L77

And since the widgets are unmounted first, the `removeWidgets()` function is called and triggers a new search.

https://github.com/algolia/react-instantsearch/blob/affcbb58ee5c63345cc9424ad8ab566f3a01c9f9/packages/react-instantsearch-hooks/src/lib/useWidget.ts#L40-L42

#### Solution

This PR introduces a temporary fix that relies on a boolean flag `_preventWidgetCleanup` on the InstantSearch instance:

- This flag is set to `true` when the `<InstantSearch>` component is unmounted, thus preventing the widgets `cleanup` function to be executed.
- This flag is set to `false` when the `<InstantSearch>` component updates.

This solution works but should be considered temporary because in the future the InstantSearch.js update API should solve this issue.

#### Tests

This PR adds two tests, covering these use-cases:

- When the `<InstantSearch>` component is unmounted, no search request is made.
- When a widget is unmounted (we want to test this cause we introduce a new logic in the `useWidget` hook `cleanup` function), a new search request is made.

### Result

When the `<InstantSearch>` component is unmounted, no search request is made.