### PR TITLE
feat(SearchBox): introduce `autoFocus` prop

### DIFF
--- a/examples/hooks/App.tsx
+++ b/examples/hooks/App.tsx
@@ -107,7 +107,7 @@ export function App() {
             ]}
           />
 
-          <SearchBox placeholder="Search" />
+          <SearchBox placeholder="Search" autoFocus />
 
           <div className="Search-header">
             <PoweredBy />

--- a/packages/react-instantsearch-hooks-web/src/ui/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/SearchBox.tsx
@@ -62,7 +62,10 @@ export type SearchBoxProps = Omit<
 > &
   Pick<React.ComponentProps<'form'>, 'onSubmit'> &
   Required<Pick<React.ComponentProps<'form'>, 'onReset'>> &
-  Pick<React.ComponentProps<'input'>, 'placeholder' | 'onChange'> & {
+  Pick<
+    React.ComponentProps<'input'>,
+    'placeholder' | 'onChange' | 'autoFocus'
+  > & {
     inputRef: React.RefObject<HTMLInputElement>;
     isSearchStalled: boolean;
     value: string;
@@ -135,6 +138,7 @@ export function SearchBox({
   onSubmit,
   placeholder,
   value,
+  autoFocus,
   resetIconComponent: ResetIcon = DefaultResetIcon,
   submitIconComponent: SubmitIcon = DefaultSubmitIcon,
   loadingIconComponent: LoadingIcon = DefaultLoadingIcon,
@@ -190,6 +194,7 @@ export function SearchBox({
           type="search"
           value={value}
           onChange={onChange}
+          autoFocus={autoFocus}
         />
         <button
           className={cx('ais-SearchBox-submit', classNames.submit)}

--- a/packages/react-instantsearch-hooks-web/src/ui/__tests__/SearchBox.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/__tests__/SearchBox.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';
 
@@ -20,6 +20,7 @@ describe('SearchBox', () => {
       onSubmit,
       placeholder: '',
       value: '',
+      autoFocus: false,
       translations: {
         submitTitle: 'Submit the search query.',
         resetTitle: 'Clear the search query.',
@@ -132,6 +133,8 @@ describe('SearchBox', () => {
         </div>
       </div>
     `);
+
+    expect(within(container).getByRole('searchbox')).not.toHaveFocus();
   });
 
   test('renders with translations', () => {
@@ -320,6 +323,14 @@ describe('SearchBox', () => {
       'placeholder',
       'Search'
     );
+  });
+
+  test('forwards the `autoFocus` prop to the input', () => {
+    const props = createProps({ autoFocus: true });
+
+    const { container } = render(<SearchBox {...props} />);
+
+    expect(within(container).getByRole('searchbox')).toHaveFocus();
   });
 
   test('with input value shows the reset button', () => {

--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -14,12 +14,13 @@ type UiProps = Pick<
   | 'onReset'
   | 'onSubmit'
   | 'value'
+  | 'autoFocus'
   | 'translations'
 >;
 
 export type SearchBoxProps = Omit<
   SearchBoxUiComponentProps,
-  Exclude<keyof UiProps, 'onSubmit'>
+  Exclude<keyof UiProps, 'onSubmit' | 'autoFocus'>
 > &
   UseSearchBoxProps & {
     /**

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -113,6 +113,8 @@ describe('SearchBox', () => {
         </div>
       `);
     });
+
+    expect(within(container).getByRole('searchbox')).not.toHaveFocus();
   });
 
   test('forwards placeholder prop', async () => {
@@ -127,6 +129,18 @@ describe('SearchBox', () => {
         'placeholder',
         'Placeholder'
       );
+    });
+  });
+
+  test('forwards `autoFocus` prop', async () => {
+    const { container } = render(
+      <InstantSearchHooksTestWrapper>
+        <SearchBox autoFocus />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(within(container).getByRole('searchbox')).toHaveFocus();
     });
   });
 


### PR DESCRIPTION
## Summary

This PR introduces the `autoFocus` prop on the `<SearchBox>` widget in React InstantSearch Hooks.

This prop exists in all flavors but was missing in React InstantSearch Hooks.

The prop capitalization is different from other flavors (JS, Vue and Angular) because we're relying on React's custom `autoFocus` prop and not the native [`autofocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus). This is more natural for React developers who are used to this prop.

Ticket: [FX-1629](https://algolia.atlassian.net/browse/FX-1629)