### PR TITLE
chore: explicitly set node version for codesandbox

### DIFF
--- a/examples/next/sandbox.config.json
+++ b/examples/next/sandbox.config.json
@@ -1,0 +1,8 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "container": {
+    "node": "12"
+  }
+}

--- a/examples/next/sandbox.config.json
+++ b/examples/next/sandbox.config.json
@@ -1,7 +1,4 @@
 {
-  "infiniteLoopProtection": true,
-  "hardReloadOnChange": false,
-  "view": "browser",
   "container": {
     "node": "12"
   }


### PR DESCRIPTION
This PR adds a CodeSandbox config file that explicitly sets node version to 12, to comply with some dependencies requirements.

This PR fixes https://github.com/algolia/react-instantsearch/issues/3601.

[**Sandbox →**](https://codesandbox.io/s/github/algolia/react-instantsearch/tree/fix/example-next-codesandbox/examples/next)