### PR TITLE
ci(shipjs): update peerDependency on version bump

### DIFF
--- a/packages/react-instantsearch-dom-maps/package.json
+++ b/packages/react-instantsearch-dom-maps/package.json
@@ -47,6 +47,6 @@
     "algoliasearch": ">= 3.1 < 5",
     "react": ">= 16.3.0 < 19",
     "react-dom": ">= 16.3.0 < 19",
-    "react-instantsearch-dom": "6.26.0"
+    "react-instantsearch-dom": "6.32.1"
   }
 }

--- a/ship.config.js
+++ b/ship.config.js
@@ -46,6 +46,17 @@ module.exports = {
     exec(
       `yarn lerna version ${version} --exact --no-git-tag-version --no-push --yes`
     );
+
+    // Update peerDependency in `react-instantsearch-dom-maps`
+    const file = path.resolve(
+      dir,
+      'packages',
+      'react-instantsearch-dom-maps',
+      'package.json'
+    );
+    const package = require(file);
+    package.peerDependencies['react-instantsearch-dom'] = `${version}`;
+    fs.writeFileSync(file, JSON.stringify(package, null, 2));
   },
   shouldPrepare: ({ releaseType, commitNumbersPerType }) => {
     const { fix = 0 } = commitNumbersPerType;


### PR DESCRIPTION
This was disappeared when we moved to lerna for bumping the packages.

discovered in #2897