### PR TITLE
fix(rish): hide reset button when search is stalled in `SearchBox`

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/ui/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/SearchBox.tsx
@@ -207,7 +207,7 @@ export function SearchBox({
           className={cx('ais-SearchBox-reset', classNames.reset)}
           type="reset"
           title={translations.resetTitle}
-          hidden={value.length === 0 && !isSearchStalled}
+          hidden={value.length === 0 || isSearchStalled}
         >
           <ResetIcon classNames={classNames} />
         </button>

--- a/packages/react-instantsearch-hooks-web/src/ui/__tests__/SearchBox.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/__tests__/SearchBox.test.tsx
@@ -349,6 +349,14 @@ describe('SearchBox', () => {
     expect(container.querySelector('.ais-SearchBox-reset')).not.toBeVisible();
   });
 
+  test('with search stalled hides the reset indicator', () => {
+    const props = createProps({ value: 'query', isSearchStalled: true });
+
+    const { container } = render(<SearchBox {...props} />);
+
+    expect(container.querySelector('.ais-SearchBox-reset')).not.toBeVisible();
+  });
+
   test('with search stalled shows the loading indicator', () => {
     const props = createProps({ isSearchStalled: true });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

[FX-1646](https://algolia.atlassian.net/browse/FX-1646)

Here's a minor bug fix I had in my stash. There's a screenshot in the issue linked above.

**Result**

Added a test to ensure the reset button is hidden when search is stalled.
