### PR TITLE
Fix for webpack warning: Critical dependency: the request of a depend…

### DIFF
--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -183,23 +183,8 @@ function getInitialResults(rootIndex: IndexWidget): InitialResults {
 }
 
 function importRenderToString() {
-  // React pre-18 doesn't use `exports` in package.json, requiring a fully resolved path
-  // Thus, only one of these imports is correct
-  const modules = ['react-dom/server.js', 'react-dom/server'];
-
-  // import is an expression to make sure https://github.com/webpack/webpack/issues/13865 does not kick in
-  return Promise.all(modules.map((mod) => import(mod).catch(() => {}))).then(
-    (imports: unknown[]) => {
-      const ReactDOMServer = imports.find(
-        (mod): mod is { renderToString: typeof reactRenderToString } =>
-          mod !== undefined
-      );
-
-      if (!ReactDOMServer) {
-        throw new Error('Could not import ReactDOMServer.');
-      }
-
-      return ReactDOMServer.renderToString;
-    }
-  );
+  // React pre-18 doesn't use `exports` in package.json
+  const ReactDOMServer = (parseInt(React.version) >= 18) ? import('react-dom/server.browser') : import('react-dom/server');
+  
+  return ReactDOMServer.then((module) => module.renderToString);
 }


### PR DESCRIPTION
…ency is an expression

Use a static dependency import for react-dom using the same code as next.js:

https://github.com/vercel/next.js/blob/6108f10799b46bc0ef97373c913e23714e135942/packages/next/server/render.tsx#L92

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
