### PR TITLE
fix(hooks-web): reset with searchAsYouType=false should search

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/SearchBox.tsx
@@ -52,6 +52,10 @@ export function SearchBox({
 
   function onReset() {
     setQuery('');
+
+    if (!searchAsYouType) {
+      refine('');
+    }
   }
 
   function onChange(event: React.ChangeEvent<HTMLInputElement>) {

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/SearchBox.test.tsx
@@ -317,4 +317,31 @@ describe('SearchBox', () => {
     expect(lastUiState.indexName.query).toBe('iPhone');
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
+
+  test('refines on reset when searchAsYouType is set', () => {
+    let lastUiState: UiState = {};
+
+    const { container } = render(
+      <InstantSearchHooksTestWrapper
+        onStateChange={({ uiState }) => {
+          lastUiState = uiState;
+        }}
+      >
+        <SearchBox searchAsYouType={false} />
+      </InstantSearchHooksTestWrapper>
+    );
+
+    const input = container.querySelector<HTMLInputElement>(
+      '.ais-SearchBox-input'
+    )!;
+    input.focus();
+    userEvent.type(input, 'iPhone{Enter}');
+    expect(lastUiState.indexName.query).toBe('iPhone');
+
+    const resetButton = container.querySelector<HTMLButtonElement>(
+      '.ais-SearchBox-reset'
+    )!;
+    userEvent.click(resetButton);
+    expect(lastUiState.indexName.query).toBe(undefined);
+  });
 });


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Similarly as #802, when reset is triggered and searchAsYouType is false, a search should still happen.

**Result**

fixes #3641

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
