### PR TITLE
feat(core): support react 18 strict mode

### DIFF
--- a/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
+++ b/packages/react-instantsearch-core/src/core/__tests__/createConnector.js
@@ -5,6 +5,7 @@ import createConnector, {
   createConnectorWithoutContext,
 } from '../createConnector';
 import { InstantSearchProvider } from '../context';
+import { wait } from '../../../../../test/utils';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -415,7 +416,7 @@ describe('createConnector', () => {
       expect(subscribe).toHaveBeenCalledTimes(1);
     });
 
-    it('unsubscribes from the store on unmount', () => {
+    it('unsubscribes from the store on unmount', async () => {
       const Connected = createConnectorWithoutContext({
         displayName: 'Connector',
         getProvidedProps: () => {},
@@ -434,6 +435,8 @@ describe('createConnector', () => {
       expect(unsubscribe).toHaveBeenCalledTimes(0);
 
       wrapper.unmount();
+
+      await wait(0);
 
       expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
@@ -787,7 +790,7 @@ describe('createConnector', () => {
       expect(onSearchStateChange).not.toHaveBeenCalled();
     });
 
-    it('unregisters itself on unmount', () => {
+    it('unregisters itself on unmount', async () => {
       const Connected = createConnectorWithoutContext({
         displayName: 'Connector',
         getProvidedProps: () => {},
@@ -808,10 +811,12 @@ describe('createConnector', () => {
 
       wrapper.unmount();
 
+      await wait(0);
+
       expect(unregisterWidget).toHaveBeenCalledTimes(1);
     });
 
-    it('calls onSearchStateChange with cleanUp on unmount', () => {
+    it('calls onSearchStateChange with cleanUp on unmount', async () => {
       const cleanUp = jest.fn(function (props, searchState) {
         return {
           instanceProps: this.props,
@@ -858,6 +863,8 @@ describe('createConnector', () => {
 
       wrapper.unmount();
 
+      await wait(0);
+
       expect(cleanUp).toHaveBeenCalledTimes(1);
       expect(onSearchStateChange).toHaveBeenCalledTimes(1);
       expect(onSearchStateChange).toHaveBeenCalledWith({
@@ -875,7 +882,7 @@ describe('createConnector', () => {
       });
     });
 
-    it('calls onSearchStateChange with cleanUp without empty keys on unmount', () => {
+    it('calls onSearchStateChange with cleanUp without empty keys on unmount', async () => {
       const cleanUp = jest.fn((_, searchState) => searchState);
 
       const Connected = createConnectorWithoutContext({
@@ -909,6 +916,8 @@ describe('createConnector', () => {
       const wrapper = shallow(<Connected contextValue={context} />);
 
       wrapper.unmount();
+
+      await wait(0);
 
       expect(onSearchStateChange).toHaveBeenCalledWith({
         query: 'hello',

--- a/packages/react-instantsearch-core/src/widgets/InstantSearch.tsx
+++ b/packages/react-instantsearch-core/src/widgets/InstantSearch.tsx
@@ -175,6 +175,7 @@ class InstantSearch extends Component<Props, State> {
     };
   }
 
+  cleanupTimerRef: ReturnType<typeof setTimeout> | null = null;
   isUnmounting: boolean = false;
 
   constructor(props: Props) {
@@ -235,6 +236,11 @@ class InstantSearch extends Component<Props, State> {
   }
 
   componentDidMount() {
+    if (this.cleanupTimerRef) {
+      clearTimeout(this.cleanupTimerRef);
+      this.cleanupTimerRef = null;
+    }
+
     if (isMetadataEnabled()) {
       injectMetadata(
         this.state.instantSearchManager.widgetsManager.getWidgets(),
@@ -244,8 +250,10 @@ class InstantSearch extends Component<Props, State> {
   }
 
   componentWillUnmount() {
-    this.isUnmounting = true;
-    this.state.instantSearchManager.skipSearch();
+    this.cleanupTimerRef = setTimeout(() => {
+      this.isUnmounting = true;
+      this.state.instantSearchManager.skipSearch();
+    });
   }
 
   createHrefForState(searchState: SearchState) {

--- a/packages/react-instantsearch-core/src/widgets/__tests__/InstantSearch.js
+++ b/packages/react-instantsearch-core/src/widgets/__tests__/InstantSearch.js
@@ -4,6 +4,7 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import createInstantSearchManager from '../../core/createInstantSearchManager';
 import InstantSearch from '../InstantSearch';
 import { InstantSearchConsumer } from '../../core/context';
+import { wait } from '../../../../../test/utils';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -330,7 +331,7 @@ describe('InstantSearch', () => {
     expect(childContext.widgetsManager).toBe(ism.widgetsManager);
   });
 
-  it('onSearchStateChange should not be called and search should be skipped if the widget is unmounted', () => {
+  it('onSearchStateChange should not be called and search should be skipped if the widget is unmounted', async () => {
     const ism = createFakeInstantSearchManager();
     let childContext;
     createInstantSearchManager.mockImplementation(() => ism);
@@ -350,6 +351,9 @@ describe('InstantSearch', () => {
     );
 
     wrapper.unmount();
+
+    await wait(0);
+
     childContext.onSearchStateChange({});
 
     expect(onSearchStateChangeMock).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
**Summary**

This PR makes React InstantSearch compatible with React 18's Strict Mode.

**Result**

Similar to what we did for React InstantSearch Hooks, cleanup logic is now scheduled instead of immediately executed on unmount, which makes them cancelable when React 18's Strict Mode remounts the components immediately.

[**Sandbox →**](https://codesandbox.io/s/react-instantsearch-app-forked-12ivo6?file=/package.json)