### PR TITLE
ci(shipjs): release package in dependent order

### DIFF
--- a/packages/react-instantsearch-dom-maps/package.json
+++ b/packages/react-instantsearch-dom-maps/package.json
@@ -48,5 +48,8 @@
     "react": ">= 16.3.0 < 19",
     "react-dom": ">= 16.3.0 < 19",
     "react-instantsearch-dom": "6.36.0"
+  },
+  "devDependencies": {
+    "react-instantsearch-dom": "6.36.0"
   }
 }

--- a/ship.config.js
+++ b/ship.config.js
@@ -1,21 +1,22 @@
 const fs = require('fs');
 const path = require('path');
+const shell = require('shelljs');
+
+const packages = JSON.parse(
+  shell.exec('yarn run --silent lerna list --toposort --json', {
+    silent: true,
+  })
+);
+const cwd = process.cwd();
 
 module.exports = {
   monorepo: {
     mainVersionFile: 'lerna.json',
     // We rely on Lerna to bump our dependencies.
     packagesToBump: [],
-    packagesToPublish: [
-      'packages/react-instantsearch-core',
-      'packages/react-instantsearch-dom-maps',
-      'packages/react-instantsearch-dom',
-      'packages/react-instantsearch-hooks',
-      'packages/react-instantsearch-hooks-web',
-      'packages/react-instantsearch-hooks-server',
-      'packages/react-instantsearch-native',
-      'packages/react-instantsearch',
-    ],
+    packagesToPublish: packages.map(({ location }) =>
+      location.replace(`${cwd}/`, '')
+    ),
   },
   versionUpdated: ({ version, exec, dir }) => {
     // Update version in `react-instantsearch-core`


### PR DESCRIPTION
If we'd use `lerna publish` instead of a publish command per package, this may not be needed, but I couldn't find how to make that work correctly with shipjs just yet.

The order is now (note dom-maps is published later):

```
  'packages/react-instantsearch-core',
  'packages/react-instantsearch-hooks',
  'packages/react-instantsearch-dom',
  'packages/react-instantsearch-hooks-server',
  'packages/react-instantsearch-hooks-web',
  'packages/react-instantsearch-native',
  'packages/react-instantsearch-dom-maps',
  'packages/react-instantsearch'
  ```

  This is equivalent to https://github.com/algolia/ui-components/pull/23
