### PR TITLE
feat(getServerState): allow users to inject renderToString

### DIFF
--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
@@ -114,8 +114,19 @@ describe('ReactDOMServer imports', () => {
     await expect(
       getServerState(<App />)
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Could not import ReactDOMServer."`
+      `"Could not import ReactDOMServer. You can provide it as an argument: getServerState(<Search />, ReactDOMServer.renderToString)."`
     );
+  });
+
+  test('does not throw if user provides their own renderToString', async () => {
+    const searchClient = createSearchClient({});
+    const { App } = createTestEnvironment({ searchClient });
+
+    const serverState = await getServerState(<App />, (element) =>
+      jest.requireActual('react-dom/server').renderToString(element)
+    );
+
+    expect(serverState.initialResults).toEqual(expect.any(Object));
   });
 });
 

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
@@ -118,7 +118,7 @@ describe('ReactDOMServer imports', () => {
     );
   });
 
-  test('does not throw if user provides their own renderToString', async () => {
+  test('calls the provided renderToString function', async () => {
     const searchClient = createSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
 

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
@@ -122,9 +122,10 @@ describe('ReactDOMServer imports', () => {
     const searchClient = createSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
 
-    const serverState = await getServerState(<App />, (element) =>
-      jest.requireActual('react-dom/server').renderToString(element)
-    );
+    const serverState = await getServerState(<App />, {
+      renderToString: (element) =>
+        jest.requireActual('react-dom/server').renderToString(element),
+    });
 
     expect(serverState.initialResults).toEqual(expect.any(Object));
   });

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-none.test.tsx
@@ -114,7 +114,7 @@ describe('ReactDOMServer imports', () => {
     await expect(
       getServerState(<App />)
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Could not import ReactDOMServer. You can provide it as an argument: getServerState(<Search />, ReactDOMServer.renderToString)."`
+      `"Could not import ReactDOMServer. You can provide it as an argument: getServerState(<Search />, { renderToString })."`
     );
   });
 
@@ -122,11 +122,15 @@ describe('ReactDOMServer imports', () => {
     const searchClient = createSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
 
+    const renderToString = jest.fn(
+      jest.requireActual('react-dom/server').renderToString
+    );
+
     const serverState = await getServerState(<App />, {
-      renderToString: (element) =>
-        jest.requireActual('react-dom/server').renderToString(element),
+      renderToString,
     });
 
+    expect(renderToString).toHaveBeenCalledTimes(1);
     expect(serverState.initialResults).toEqual(expect.any(Object));
   });
 });

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-with-extension.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-with-extension.test.tsx
@@ -108,12 +108,17 @@ jest.mock(
 
 describe('ReactDOMServer imports', () => {
   test('works when the import with an extension exists', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const searchClient = createSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
 
     const serverState = await getServerState(<App />);
 
     expect(serverState.initialResults).toEqual(expect.any(Object));
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenLastCalledWith(
+      '[InstantSearch] `renderToString` should be passed to getServerState(<App/>, { renderToString })'
+    );
   });
 });
 

--- a/packages/react-instantsearch-hooks-server/src/__tests__/modules-without-extension.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/modules-without-extension.test.tsx
@@ -108,12 +108,17 @@ jest.mock(
 
 describe('ReactDOMServer imports', () => {
   test('works when the import with no extension exists', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const searchClient = createSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
 
     const serverState = await getServerState(<App />);
 
     expect(serverState.initialResults).toEqual(expect.any(Object));
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenLastCalledWith(
+      '[InstantSearch] `renderToString` should be passed to getServerState(<App/>, { renderToString })'
+    );
   });
 });
 

--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -194,6 +194,10 @@ function importRenderToString(
   if (renderToString) {
     return Promise.resolve(renderToString);
   }
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[InstantSearch] `renderToString` should be passed to getServerState(<App/>, { renderToString })'
+  );
 
   // React pre-18 doesn't use `exports` in package.json, requiring a fully resolved path
   // Thus, only one of these imports is correct


### PR DESCRIPTION
**Summary**

There are some cases where the combination of trying to make sure renderToString doesn't end up in a browser bundle, being runnable on esm + cjs, react 17 and 18, .js extension etc. blows up.

One of those is pnpm/vercel removing "unused" packages.




<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**


This PR introduces a new argument `renderToString` to `getServerState` so you can inject the dependency yourself, meaning the import is within your own code and won't be purged.

```js
import { renderToString } from 'react-dom/server';
await getServerState(<App/>, renderToString);
await getServerState(<App/>, import('react-dom/server').then(mod => mod.renderToString));
```

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

fixes #3633
closes #3618
see vercel/next.js#40067
FX-1869