### PR TITLE
docs(ssr): pass renderToString to getServerState in examples

### DIFF
--- a/examples/hooks-next/pages/index.tsx
+++ b/examples/hooks-next/pages/index.tsx
@@ -89,7 +89,7 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> =
     const protocol = req.headers.referer?.split('://')[0] || 'https';
     const url = `${protocol}://${req.headers.host}${req.url}`;
     const serverState = await getServerState(<HomePage url={url} />, {
-      // renderToString,
+      renderToString,
     });
 
     return {

--- a/examples/hooks-next/pages/index.tsx
+++ b/examples/hooks-next/pages/index.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { GetServerSideProps } from 'next';
+import { renderToString } from 'react-dom/server';
 import algoliasearch from 'algoliasearch/lite';
 import { Hit as AlgoliaHit } from 'instantsearch.js';
 import {
@@ -87,7 +88,9 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> =
   async function getServerSideProps({ req }) {
     const protocol = req.headers.referer?.split('://')[0] || 'https';
     const url = `${protocol}://${req.headers.host}${req.url}`;
-    const serverState = await getServerState(<HomePage url={url} />);
+    const serverState = await getServerState(<HomePage url={url} />, {
+      // renderToString,
+    });
 
     return {
       props: {

--- a/examples/hooks-ssr/src/server.js
+++ b/examples/hooks-ssr/src/server.js
@@ -13,7 +13,9 @@ app.get('/', async (req, res) => {
   const location = new URL(
     `${req.protocol}://${req.get('host')}${req.originalUrl}`
   );
-  const serverState = await getServerState(<App location={location} />);
+  const serverState = await getServerState(<App location={location} />, {
+    renderToString,
+  });
   const html = renderToString(
     <App serverState={serverState} location={location} />
   );


### PR DESCRIPTION
Followup on #3658, to be merged close to the release

EDIT: actually this can be merged before the release already as previously the unused argument wasn't used