### PR TITLE
fix(hooks): avoid effect in useStableValue

### DIFF
--- a/packages/react-instantsearch-hooks/src/lib/useStableValue.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useStableValue.ts
@@ -1,16 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { dequal } from '../lib/dequal';
 
 export function useStableValue<TValue>(value: TValue) {
   const [stableValue, setStableValue] = useState<TValue>(() => value);
 
-  useEffect(() => {
-    if (!dequal(stableValue, value)) {
-      setStableValue(value);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
+  if (!dequal(stableValue, value)) {
+    setStableValue(value);
+  }
 
   return stableValue;
 }


### PR DESCRIPTION
There's no tests for this, so make sure that the timings we had are still the same.

specifically used in:
https://github.com/algolia/react-instantsearch/blob/f436d31184f3f75b33a1fdaa19c665e77948df28/packages/react-instantsearch-hooks/src/hooks/useConnector.ts#L26-L29 https://github.com/algolia/react-instantsearch/blob/aa5f9d84ddb6e97d05e6ad1baf2c6caa23891281/packages/react-instantsearch-hooks/src/lib/useIndex.ts#L22

same as https://github.com/algolia/predict/pull/45