### PR TITLE
fix: remove unnecessary `useEffect`

### DIFF
--- a/packages/react-instantsearch-hooks/src/lib/useStableValue.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useStableValue.ts
@@ -1,16 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { dequal } from '../lib/dequal';
 
 export function useStableValue<TValue>(value: TValue) {
   const [stableValue, setStableValue] = useState<TValue>(() => value);
 
-  useEffect(() => {
-    if (!dequal(stableValue, value)) {
-      setStableValue(value);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
+  if (!dequal(stableValue, value)) {
+    setStableValue(value);
+  }
 
   return stableValue;
 }


### PR DESCRIPTION
This removes an unnecessary `useEffect` in `useStableValue`.

See https://github.com/algolia/predict/pull/45